### PR TITLE
feat: Align frontmatter spec with Anthropic Agent Skills standard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,11 @@ Every skill follows this structure:
 
 ```text
 skill-name/
-├── SKILL.md              # YAML frontmatter + markdown instructions (<500 lines)
+├── SKILL.md              # YAML frontmatter + markdown instructions (≤5,000 words; warn at 500 lines)
 └── references/           # On-demand reference files (unlimited size)
 ```
 
-All SKILL.md files use the frontmatter convention defined in `skills/meta/skill-writer/references/frontmatter-spec.md`. Required fields: `name` (kebab-case), `version` (semver), `description` (trigger text). Agent roles also declare `owns`, `allowed_tools`, `composes_with`, `spawned_by`.
+All SKILL.md files use the frontmatter convention defined in `skills/meta/skill-writer/references/frontmatter-spec.md`. This spec aligns with Anthropic's official Agent Skills standard. Required fields: `name` (kebab-case, no `claude-`/`anthropic-` prefix), `version` (semver, top-level), `description` (trigger text, ≤1024 chars, no `<` or `>`). Optional Anthropic fields: `compatibility`, `license`, `allowed-tools` (hyphen canonical; `allowed_tools` accepted as alias), `metadata`. Agent roles also declare `owns`, `composes_with`, `spawned_by`.
 
 ## Skill Categories
 
@@ -55,7 +55,7 @@ All SKILL.md files use the frontmatter convention defined in `skills/meta/skill-
 
 When modifying a skill:
 
-- Keep SKILL.md body under 500 lines; move detail to `references/`
+- Keep SKILL.md body ≤5,000 words (Anthropic guideline); soft warning past 500 lines. Move detail to `references/`. Heavy skills may exceed when the length is load-bearing.
 - Description field is the primary trigger mechanism — include action verbs, specific contexts, and keyword variations
 - `owns.directories` must not overlap with other agent roles
 - Maintain the frontmatter convention (see `skills/meta/skill-writer/references/frontmatter-spec.md`)

--- a/IMPROVEMENT_PLAN.md
+++ b/IMPROVEMENT_PLAN.md
@@ -1,0 +1,167 @@
+# Skill Ecosystem Improvement Plan
+
+**Date:** 2026-05-19
+**Status:** Draft — under review
+**Owner:** @ivy00johns
+
+## Sources
+
+1. **`claude_notes.txt`** — Twitter post by @sairahul1, "20 Claude Skills Most Builders Don't Know Exist." Five categories: Content & Writing, Research & Analysis, Business & Ops, Coding & Dev, Strategy & Thinking. Each "skill" is a single-prompt template with frontmatter — no references, no scripts, no validation. Useful as a *pattern catalog*, not as importable skills.
+2. **Anthropic, "The Complete Guide to Building Skills for Claude"** — 32-page PDF, published with Agent Skills as an open standard. Six chapters: Introduction, Fundamentals, Planning & Design, Testing & Iteration, Distribution & Sharing, Patterns & Troubleshooting, Resources. This is the **canonical Anthropic spec** — the repo's `frontmatter-spec.md` should align with it where the divergence isn't deliberate.
+
+---
+
+## Part 1: Adopt 3 thinking-moves from `claude_notes.txt`
+
+### Rationale
+
+Most of the 20 skills in the Twitter post are either out of scope (content/writing, business ops) or under-engineered versions of skills we already have (PR Reviewer, Debug Partner, Code Explainer — we cover these 5-10x better with `code-review`, `superpowers:systematic-debugging`, `diagnose-loop`, `git-pr-feedback`, etc.).
+
+Three of their analysis skills name a *thinking discipline* this repo doesn't currently treat as a first-class move:
+
+| Their skill | Thinking move | Why we don't have it |
+|---|---|---|
+| **Contradiction Finder (07)** | "Where do my sources disagree?" | `wiki-research` and `repo-deep-dive` gather but don't reconcile conflicts. |
+| **Assumption Auditor (09)** | "Surface the invisible assumptions before launch." | `deployment-checklist` checks artifacts, not assumptions. `orchestrator` Phase 3 plans but doesn't audit. |
+| **Second-Order Thinker (19)** | "Map the consequences of the consequences." | `superpowers:brainstorming` explores intent; `plan-builder` sequences work. Neither forces second/third-order analysis. |
+
+These are not worth adding as standalone skills. They are worth adding as **named reference sections** inside existing skills so they can be invoked by name during the right phase.
+
+### Changes
+
+1. **`skills/workflows/wiki-research/references/`** — add `contradiction-finding.md`. Heuristics for surfacing disagreement across sources (surface consensus → 3 specific contradictions → weakest claim → real debate → confidence verdict). Reference it from the wiki-research SKILL.md body as a checklist step when synthesizing 3+ sources.
+
+2. **`skills/workflows/deployment-checklist/references/`** — add `assumption-audit.md`. Pre-launch check that surfaces explicit + implicit assumptions + the single most-dangerous-if-wrong assumption + how to test each. Wire it into the deployment-checklist body as a required step before sign-off. Also reference it from `skills/orchestrator/references/phase-guide.md` at Phase 3 (design).
+
+3. **`skills/workflows/plan-builder/references/`** — add `second-order-effects.md`. Maps 1st/2nd/3rd-order consequences + the unintended consequence + the feedback loop. Reference it from plan-builder's SKILL.md when the plan affects systems beyond 30 days. Also link from `superpowers:brainstorming` as an optional deepening move when the user is stuck on first-order framing.
+
+### Out of scope
+
+- **Content & writing (skills 01-05)** — Hook Forge, Voice Locker, Thread Architect, Repurpose Engine, Headline Lab. Wrong repo. This is a multi-agent dev toolkit, not a content-marketing toolkit. If wanted, they belong in a separate personal skill set.
+- **Business & ops (skills 11-15)** — SOP Writer, Decision Framer, Meeting Extractor, Pricing Stress Tester, Offer Sharpener. Wrong repo.
+- **Coding (skills 16-18)** — Code Explainer, PR Reviewer, Debug Partner. We have `code-review`, `review`, `git-pr-feedback`, `security-review`, `superpowers:systematic-debugging`, `diagnose-loop`, `simplify` and an entire `roles/code-review` agent. Our versions are richer.
+- **Strategy (skill 20)** — Mental Model Applier. Too generic; "apply three mental models" without naming which is just a vibe, not a discipline.
+
+---
+
+## Part 2: Adopt patterns from Anthropic's official guide
+
+The repo's `skills/meta/skill-writer/references/frontmatter-spec.md` is its own spec — opinionated and richer than Anthropic's in some places (ownership, runtime detection, plan-tier gating) but **divergent on field names and structure** in ways that may break cross-platform loading. `CLAUDE.md` explicitly states "skills should be platform-agnostic" — so divergence is a real cost, not a hypothetical one.
+
+### A. Compliance gaps (must-fix if we want cross-platform loading)
+
+These are places where Anthropic's spec differs and the divergence likely breaks Claude.ai / Agent SDK consumption of our skills.
+
+| # | Issue | Anthropic | This repo | Recommendation |
+|---|---|---|---|---|
+| A1 | **`allowed-tools` field name** | hyphen: `allowed-tools` (PDF p.31) | underscore: `allowed_tools` | Add `allowed-tools` as the canonical form; keep `allowed_tools` as a deprecated alias for one release cycle. |
+| A2 | **`metadata` nesting** | nested object with `author`, `version`, `mcp-server`, `category`, `tags` (p.11, p.31) | flat: `version` at top level, no `metadata` object | Move `version` (and any future author/category fields) under `metadata`. Top-level `version` stays valid for back-compat. |
+| A3 | **`compatibility` field** | 1-500 chars; declares environment/platform requirements (p.11, p.19) | not in spec | Add it. Use it to capture `requires_claude_code` + `requires_agent_teams` + `min_plan` in a human-readable string. Keep boolean flags for programmatic checks. |
+| A4 | **Forbidden frontmatter chars** | XML angle brackets `< >` forbidden; "claude" / "anthropic" name prefixes reserved (p.11, p.31) | not enforced | Add validation to `skill-review`: fail any skill with `<` or `>` in frontmatter, or `claude-*` / `anthropic-*` name. |
+| A5 | **Description max length** | 1024 chars (p.10) | target ≤200 chars | Keep 200 as our *target* (forces tight triggers), but document 1024 as the hard ceiling. Some pushy descriptions in this repo already exceed 200; that's fine if they trigger reliably. |
+| A6 | **SKILL.md body length** | "under 5,000 words" (p.27) | "<500 lines" in CLAUDE.md | Switch the rule to **5,000 words OR 500 lines, whichever comes first**. Word count is what actually drives context cost. |
+
+### B. Worth-adopting additions
+
+Net-new patterns from the Anthropic guide that would strengthen the repo without conflicting with existing structure.
+
+| # | Pattern | Source | Action |
+|---|---|---|---|
+| B1 | **Recommended SKILL.md body structure** — `## Instructions` → `### Step N` → `## Examples` → `## Troubleshooting (Error / Cause / Solution)` (p.12) | Anthropic | Add as the default template in `skill-writer`. Many existing skills already follow this loosely; make it explicit. |
+| B2 | **"Iterate on a single task before expanding"** (p.15) | Anthropic | Add to `skill-writer` and `skill-update` guidance: prototype against one real task, get it working, then extract to a skill. Prevents speculative skills. |
+| B3 | **Triggering test format** — explicit "Should trigger" + "Should NOT trigger" lists (p.15) | Anthropic | Add to `skill-review` as a required output: every skill review must produce a triggering test list with at least 3 positives and 2 negatives. |
+| B4 | **Performance comparison metric** — "with skill vs without skill" (token count, back-and-forth count, failed-call count) (p.16) | Anthropic | Add to `skill-review`'s deep-dive mode as an optional measurement. Hard to automate but valuable for high-traffic skills. |
+| B5 | **The 5 emergent patterns** (Ch.5, p.21-24) — Sequential workflow, Multi-MCP coordination, Iterative refinement, Context-aware tool selection, Domain-specific intelligence | Anthropic | Add `skills/meta/skill-writer/references/patterns.md` cataloging all 5 with one-line "use when" + a pointer to an in-repo example. |
+| B6 | **Quick Checklist (Reference A, p.30)** — before-start / during-development / before-upload / after-upload | Anthropic | Add as `skills/meta/skill-writer/references/quick-checklist.md`. Referenced from `skill-writer` body as the final step before declaring a skill done. |
+| B7 | **Troubleshooting taxonomy** — Skill won't upload / doesn't trigger / triggers too often / instructions not followed / large context (p.25-27) | Anthropic | Add as `skills/meta/skill-explorer/references/troubleshooting.md`. Lets `skill-explorer` answer "why isn't my skill firing?" with named symptoms. |
+| B8 | **"Add explicit encouragement" for model laziness** (p.26) — `## Performance Notes` block | Anthropic | Document as an optional pattern; add to `skill-writer` reference. Some of our long-running role agents could benefit. |
+| B9 | **Programmatic validation script pattern** (p.26 "Advanced technique") — bundle a deterministic check script instead of relying on prose validation | Anthropic | Already partially done (contract-auditor). Document as a first-class pattern: `scripts/validate.{sh,py}` is the right home for invariants you can compute. |
+| B10 | **Description anatomy: `[What] + [When] + [Key capabilities]`** (p.11) | Anthropic | Adopt explicitly in `frontmatter-spec.md`. The repo's current "pushy enumeration" advice doesn't name the three slots. |
+
+### C. Strengths the repo has that Anthropic doesn't cover — no action
+
+Context for the next reviewer: these are deliberate extensions, not omissions in the Anthropic guide we missed.
+
+- **File ownership (`owns.directories`, `owns.patterns`, `owns.shared_read`)** — core to zero-conflict parallel multi-agent builds. Anthropic's guide assumes single-skill execution.
+- **Two-runtime degradation** — Agent Teams → subagents → sequential. Orchestrator-specific.
+- **QE-gated builds** with `qa-report.json` schema and blocker thresholds.
+- **Symlink-based syncing** (`sync-skills`) — keeps repo and `~/.claude/skills/` in lockstep.
+- **Plugin namespacing** (e.g., `superpowers:writing-plans`) — handles cross-plugin collisions.
+- **Cross-platform tool mapping** (`references/copilot-tools.md`, `references/codex-tools.md`) — lets the same SKILL.md body work across hosts.
+- **`spawned_by` / `composes_with`** — explicit composition graph.
+- **`requires_agent_teams` / `requires_claude_code` / `min_plan`** booleans — programmatic gating Anthropic's `compatibility` string can't do.
+
+### D. Explicit non-adoptions — divergence on purpose
+
+- **No `version` field in `metadata` (we keep it top-level required)** — semver is too important to bury under `metadata`. We adopt B-A2 partially: `metadata.version` becomes valid, but top-level `version` stays the canonical form for this repo.
+- **No `license` field per-skill** — repo-level LICENSE applies. Per-skill license is noise for an OSS bundle that ships as one unit.
+- **Anthropic's "Single-prompt skill" pattern** — many of their examples are essentially fancy prompts (cf. claude_notes.txt). We deliberately set a higher bar: a skill earns its keep with references, scripts, or composition logic. Single-prompt skills should be slash commands or in-context prompts, not skills.
+
+---
+
+## Execution order
+
+Phased so that compliance work lands before additive work, and so each phase can be a clean PR.
+
+### Phase 1 — Spec alignment (1 PR)
+- A1: add `allowed-tools` alias
+- A2: nested `metadata` block accepted, top-level `version` retained
+- A3: add `compatibility` field
+- A4: add validation rules to `skill-review`
+- A5–A6: update `frontmatter-spec.md` length rules
+- B10: rewrite description guidance with the 3-slot anatomy
+
+**Deliverable:** updated `skills/meta/skill-writer/references/frontmatter-spec.md` + `skill-review` validation rules.
+
+### Phase 2 — Templates and references (1 PR)
+- B1: default body template in `skill-writer`
+- B5: `patterns.md` reference (5 patterns)
+- B6: `quick-checklist.md` reference
+- B7: `troubleshooting.md` reference in `skill-explorer`
+- B8: `## Performance Notes` pattern doc
+- B9: validation-script pattern doc
+
+**Deliverable:** new reference files under `skills/meta/skill-writer/references/` and `skills/meta/skill-explorer/references/`.
+
+### Phase 3 — Thinking moves (1 PR)
+- Part 1: add `contradiction-finding.md` to `wiki-research`, `assumption-audit.md` to `deployment-checklist`, `second-order-effects.md` to `plan-builder`. Wire references from each parent SKILL.md.
+
+**Deliverable:** 3 new reference files + 3 SKILL.md body edits.
+
+### Phase 4 — Process changes (1 PR or just memory)
+- B2: "iterate on one task first" — add to `skill-writer` body
+- B3: triggering test format — add to `skill-review` required output
+- B4: performance comparison — optional deep-dive output in `skill-review`
+
+**Deliverable:** updated `skill-writer` and `skill-review` SKILL.md bodies.
+
+### Phase 5 — Sweep (defer until phases 1-2 land)
+- Audit existing 46 skills for compliance with new spec
+- Fix any with `<` / `>` in frontmatter (A4)
+- Move any out-of-template body sections to match B1
+- Add missing Troubleshooting sections where applicable
+
+**Deliverable:** sweep PR with per-skill diffs.
+
+---
+
+## Decisions (resolved 2026-05-19)
+
+1. **`version` stays top-level, required.** Anthropic's nested `metadata.version` form is *accepted* as a valid alias by the spec, but our canonical form is top-level. Semver is too important to bury.
+2. **Publish/share is the target.** Repo is already public. Skills must load correctly on Claude.ai web app, Claude Desktop, and Agent SDK — not just Claude Code. **Phase 1 (spec alignment) is mandatory and ships first.**
+3. **Adopt both `compatibility` string AND `requires_*` booleans.** String for cross-platform spec parsers; booleans for the orchestrator's runtime checks.
+4. **Accept the 5,000-word divergence for heavy skills.** Skills like `orchestrator`, `ui-ux-pro-max`, `repo-deep-dive` earn the length. Rule becomes guidance, not gate: "aim for under 5,000 words; references for the rest." No forced splits.
+
+---
+
+## Not adopted from `claude_notes.txt`
+
+For the record, so future-us doesn't relitigate:
+
+- **All 5 content/writing skills** — out of repo scope.
+- **All 5 business/ops skills** — out of repo scope.
+- **3 coding skills** (Code Explainer, PR Reviewer, Debug Partner) — already covered more deeply.
+- **Source Ranker (10)** — `wiki-research` covers source quality; not worth a separate move.
+- **Signal Scanner (08)** — too domain-specific (industry-news triage).
+- **Brief Builder (06)** — overlaps with `plan-builder` and `superpowers:writing-plans`.
+- **Mental Model Applier (20)** — too generic to encode.

--- a/skills/meta/skill-review/SKILL.md
+++ b/skills/meta/skill-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-review
-version: 1.0.0
+version: 1.1.0
 argument-hint: skill-name or 'all'
 description: |
   Review skills for quality, consistency, triggering accuracy, and adherence to the 100-line rule. Two modes: 'all' (bulk ecosystem-wide scan for ownership conflicts, gaps, length outliers, weak triggers) or a single skill name (deep dive on description quality, body structure, anti-pattern naming, cross-references). Outputs a structured report consumable by skill-update. Trigger on: 'audit skills', 'review this skill', 'health check skills', 'skill ecosystem health', 'is this skill any good', 'scan all skills', 'check my skills', 'deep review', 'bulk review', 'what needs fixing'.
@@ -61,10 +61,12 @@ Optimize for speed. Score quickly, flag issues, move on. Use subagents to parall
 
 Run these check categories. Full checklist lives in `references/audit-checklist.md`.
 
-- **Frontmatter consistency** — required fields present, name matches directory, version is valid semver, description starts with action verb and is ≤200 chars
+- **Frontmatter consistency** — required fields present, name matches directory and does NOT start with `claude-` or `anthropic-`, version is valid semver, description starts with action verb and is ≤200 chars
+- **Spec compliance (FAIL)** — no `<` or `>` anywhere in frontmatter (security rule); no reserved-prefix name (`claude-*` / `anthropic-*`); description ≤1024 chars (hard ceiling)
+- **Tool field naming** — `allowed-tools` (hyphen) is canonical; `allowed_tools` (underscore) accepted as deprecated alias (warn but don't fail)
 - **Ownership conflict detection** — collect every `owns.directories` and `owns.patterns` across agent roles. Flag overlaps. Validate against the v1.1 resolved conflicts table in `frontmatter-spec.md`
 - **Description quality scoring** — has action verb, ≥3 trigger contexts, keyword variants, states exclusions if ambiguous, estimated "pushiness" (low/medium/high)
-- **Progressive disclosure** — SKILL.md body line count, references linked from body, body >500 lines flagged, references >300 lines without TOC flagged
+- **Progressive disclosure** — SKILL.md body line + word count, references linked from body, body >5,000 words OR >500 lines flagged (soft warning), references >300 lines without TOC flagged
 - **Cross-skill consistency** — `composes_with` and `spawned_by` point to real skills, no circular `composes_with` chains, no orphan reference files
 - **Coverage gaps** — compare inventory against `docs/architecture.md`, `CLAUDE.md`, and the orchestrator's File Ownership Map; flag roles or workflows referenced but not implemented
 
@@ -82,7 +84,7 @@ Read `SKILL.md` and every file in `references/`. Score these dimensions against 
 
 1. **Frontmatter compliance** — required fields, types, semver, optional fields used appropriately
 2. **Description quality** — action verb, trigger contexts, keyword variants, length, "pushiness"
-3. **Progressive disclosure** — body under 500 lines, references used appropriately, clear pointers
+3. **Progressive disclosure** — body ≤5,000 words (soft warning past 500 lines), references used appropriately, clear pointers
 4. **Instruction clarity** — imperative voice, logical flow, no ambiguity, explains "why" not just "what"
 5. **Coordination** — ownership declarations, `composes_with` accuracy, no overlaps
 6. **Completeness** — referenced files exist, no dead links, validation checklists where needed

--- a/skills/meta/skill-review/references/audit-checklist.md
+++ b/skills/meta/skill-review/references/audit-checklist.md
@@ -9,20 +9,27 @@ Run these for every skill in scope. In Mode A (bulk) they roll up to PASS / WARN
 ### Frontmatter
 
 - [ ] `name` field present, kebab-case, ≤64 chars
+- [ ] `name` does NOT start with `claude-` or `anthropic-` (reserved by Anthropic) — **FAIL**
 - [ ] `name` matches the directory name
-- [ ] `version` field present, valid semver
+- [ ] `version` field present (top-level), valid semver
 - [ ] `description` field present
+- [ ] No `<` or `>` anywhere in the frontmatter block — **FAIL** (security rule)
 - [ ] Description starts with an action verb
-- [ ] Description length ≤200 characters (target, not hard limit)
+- [ ] Description length ≤200 characters (target) and ≤1024 (hard ceiling — **FAIL** if exceeded)
+- [ ] Description follows the `[What] + [When] + [Capabilities]` anatomy
 - [ ] Agent role skills have an `owns` block with `directories`, `patterns`, `shared_read`
-- [ ] `allowed_tools` is appropriate for the skill's function
+- [ ] `allowed-tools` (hyphen, canonical) is appropriate for the skill's function. `allowed_tools` (underscore) still accepted as deprecated alias — flag as WARN
+- [ ] `compatibility` field is present for skills with host/tool requirements (recommended, not required)
+- [ ] `metadata` is a nested object if present (author, category, tags, mcp-server)
 - [ ] `composes_with` references existing skills
 - [ ] `spawned_by` references existing skills
 - [ ] `argument-hint` present if the skill takes an argument
 
 ### Body Structure
 
-- [ ] Body ≤500 lines (the 100-line rule: anything past ~200 should probably move to references)
+- [ ] Body ≤5,000 words (Anthropic guideline) — WARN past this
+- [ ] Body ≤500 lines (this repo's rule of thumb: anything past ~200 should probably move to references) — WARN past this
+- [ ] Heavy skills (`orchestrator`, `ui-ux-pro-max`, `repo-deep-dive`) may exceed both — note as accepted divergence rather than flag
 - [ ] Has a role/purpose statement
 - [ ] Has a process or steps section
 - [ ] Uses imperative voice ("Read the file" not "The file should be read")
@@ -78,7 +85,7 @@ Flag any of these in Mode B; aggregate counts in Mode A.
 - [ ] Instructions that fight against the LLM's natural behavior without justification
 - [ ] Style-over-substance rules (mandating comment formats, variable naming) without practical impact
 - [ ] "Kitchen sink" — trying to do too many things in one skill
-- [ ] Assuming tools or environment features that aren't declared in `allowed_tools` or `requires_*`
+- [ ] Assuming tools or environment features that aren't declared in `allowed-tools`, `compatibility`, or `requires_*`
 
 ## Bulk Scoring Quick Reference
 

--- a/skills/meta/skill-review/references/deep-review-rubric.md
+++ b/skills/meta/skill-review/references/deep-review-rubric.md
@@ -24,11 +24,14 @@ Scoring criteria for each dimension evaluated in Mode B (`--scope=<skill-name>`)
 
 Check:
 
-- `name`: kebab-case, ≤64 chars, unique across ecosystem
-- `version`: valid semver (X.Y.Z)
-- `description`: present, multiline YAML string
+- `name`: kebab-case, ≤64 chars, unique across ecosystem, no `claude-` / `anthropic-` prefix
+- No `<` or `>` anywhere in the frontmatter block
+- `version`: valid semver (X.Y.Z), top-level
+- `description`: present, multiline YAML string, ≤1024 chars
 - Agent roles: `owns.directories`, `owns.patterns`, `owns.shared_read` present
-- `allowed_tools`: appropriate for the skill's function
+- `allowed-tools` (hyphen): appropriate for the skill's function. `allowed_tools` (underscore) accepted as deprecated alias
+- `compatibility`: present if the skill has host/tool/env requirements
+- `metadata`: nested object form if used
 - `composes_with`: lists real skill names
 - `spawned_by`: accurate if declared
 - `argument-hint`: present if the skill takes an argument
@@ -56,11 +59,13 @@ Check against description-patterns:
 
 | Score | Criteria |
 |-------|----------|
-| 5 | Body <300 lines, references well-organized, clear pointers, table of contents for large refs |
-| 4 | Body <500 lines, references used, pointers present |
-| 3 | Body approaching 500 lines, some content could move to references |
-| 2 | Body >500 lines, or references exist but aren't linked |
+| 5 | Body <2,000 words and <300 lines, references well-organized, clear pointers, TOC for large refs |
+| 4 | Body ≤5,000 words and ≤500 lines, references used, pointers present |
+| 3 | Body approaching the 5,000-word / 500-line guideline, some content could move to references |
+| 2 | Body >5,000 words OR >500 lines without clear justification, or references exist but aren't linked |
 | 1 | Everything in one massive file, or references broken/missing |
+
+Note: heavy skills (`orchestrator`, `ui-ux-pro-max`, `repo-deep-dive`) earn length and should not be penalized below 3 for size alone — score them on whether the length is actually load-bearing.
 
 Check:
 

--- a/skills/meta/skill-update/SKILL.md
+++ b/skills/meta/skill-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-update
-version: 1.0.0
+version: 1.1.0
 description: |
   Plan and apply changes to an existing skill in one workflow. Reads a skill-deep-review or skill-audit report (or inline findings), drafts an edit list with the agent's recommended answer attached to each item, walks the user through the changes one at a time, applies them, and re-runs lint and frontmatter checks. Use after running skill-review or skill-audit and you are ready to ship changes. Trigger on: "apply the review", "update this skill", "fix the skill", "ship the recommendations", "edit this skill", "let's improve it", "apply the plan", "implement the changes", "make those edits".
 requires_agent_teams: false
@@ -97,7 +97,7 @@ For batches of 10+ independent edits across different skills, parallel-dispatch 
 After all edits in this pass:
 
 - Re-read every modified SKILL.md and validate frontmatter against `skills/meta/skill-writer/references/frontmatter-spec.md`
-- Confirm body line count is reasonable — hard limit 500 lines; warn over ~100 lines when content could move to references
+- Confirm body length is within spec guidance — ≤5,000 words and ≤500 lines (soft warnings); warn over ~100 lines when content could move to references
 - Resolve all reference links in modified files
 - If `owns` fields changed, re-check there are no overlaps with other agent roles
 - Run markdownlint if available — `.markdownlint.json` is at repo root

--- a/skills/meta/skill-update/references/validation-checklist.md
+++ b/skills/meta/skill-update/references/validation-checklist.md
@@ -9,15 +9,18 @@ For every SKILL.md modified in the pass:
 ### Frontmatter
 
 - [ ] YAML parses cleanly (no tab/space mix, no unclosed quotes)
-- [ ] Field order matches house style: `name`, `version`, `description`, `requires_agent_teams`, `requires_claude_code`, `min_plan`, `owns`, `allowed_tools`, `composes_with`, `spawned_by`
-- [ ] `name` is kebab-case, ≤64 chars, unique across the ecosystem
+- [ ] Field order matches house style: `name`, `version`, `description`, `compatibility`, `license`, `allowed-tools`, `metadata`, `requires_agent_teams`, `requires_claude_code`, `min_plan`, `owns`, `composes_with`, `spawned_by`
+- [ ] `name` is kebab-case, ≤64 chars, unique across the ecosystem, does NOT start with `claude-` or `anthropic-`
+- [ ] No `<` or `>` anywhere in the frontmatter block (security rule)
 - [ ] `version` is valid semver — bump MINOR for new behavior, PATCH for fixes, MAJOR for breaks
 - [ ] `description` includes at least one action verb and one trigger phrase
-- [ ] `description` target ≤200 chars per the spec — flag overflow but don't block
+- [ ] `description` target ≤200 chars per the spec — flag overflow but don't block. Hard ceiling 1024 chars — block if exceeded.
+- [ ] `compatibility` string (1-500 chars) present for skills with host/tool/env requirements
 - [ ] `requires_agent_teams` and `requires_claude_code` are booleans
 - [ ] `min_plan` is one of `starter | pro | team | enterprise`
 - [ ] `owns.directories` does not overlap with any other agent role (see resolved-conflicts table in `skills/meta/skill-writer/references/frontmatter-spec.md`)
-- [ ] `allowed_tools` only lists tools the skill actually uses
+- [ ] `allowed-tools` (hyphen, canonical) only lists tools the skill actually uses. `allowed_tools` (underscore) still accepted as deprecated alias — note and migrate when convenient.
+- [ ] `metadata` is a nested object if present (author, category, tags, mcp-server)
 - [ ] `composes_with` references real skill names (or planned skills explicitly noted)
 - [ ] `spawned_by` is empty unless the skill is genuinely spawned by another
 
@@ -25,7 +28,9 @@ Spec source: `skills/meta/skill-writer/references/frontmatter-spec.md`.
 
 ### Body
 
-- [ ] Body is under 500 lines (hard limit)
+- [ ] Body ≤5,000 words (Anthropic guideline) — soft warning past this
+- [ ] Body ≤500 lines (this repo's rule of thumb) — soft warning past this
+- [ ] Heavy skills (`orchestrator`, `ui-ux-pro-max`, `repo-deep-dive`) may exceed both — note as accepted divergence
 - [ ] Body under ~150 lines for SKILL.md files where references absorb the detail — the 100-line rule of thumb favors moving long tables and checklists out
 - [ ] Imperative voice — "Read the file", not "the agent reads the file"
 - [ ] No emojis (house style)

--- a/skills/meta/skill-writer/SKILL.md
+++ b/skills/meta/skill-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-writer
-version: 1.1.0
+version: 1.2.0
 description: |
   Generate new SKILL.md files conforming to the ecosystem's frontmatter spec and structure conventions. Use this skill when creating any new skill, agent role definition, or workflow skill. Trigger whenever someone says "create a skill", "new agent", "write a SKILL.md", or needs to add a role to the skill ecosystem. Also use when reviewing existing skills for spec compliance.
 requires_agent_teams: false
@@ -41,7 +41,7 @@ skill-name/
 Skills use three-level loading:
 
 1. **Metadata** (~100 tokens) — name + description, always in context
-2. **SKILL.md body** (<500 lines) — loaded when skill triggers
+2. **SKILL.md body** (≤5,000 words; soft warning at 500 lines) — loaded when skill triggers
 3. **References** (unlimited) — loaded on demand via explicit reads
 
 Keep SKILL.md bodies concise. Move detailed checklists, templates, and reference tables to `references/` with clear pointers.
@@ -64,11 +64,11 @@ Every SKILL.md starts with YAML frontmatter. See `references/frontmatter-spec.md
 
 Required fields:
 
-- `name` — kebab-case, max 64 chars
-- `version` — semver (start at 1.0.0)
-- `description` — action verb + what it does + trigger contexts (≤200 chars target)
+- `name` — kebab-case, max 64 chars, must NOT start with `claude-` or `anthropic-` (reserved)
+- `version` — semver (start at 1.0.0), top-level
+- `description` — `[What] + [When] + [Capabilities]` anatomy (≤200 chars target, 1024 hard ceiling)
 
-The description is the primary trigger mechanism. Write it "pushy" — enumerate contexts where the skill should activate. See `references/description-patterns.md` for templates.
+The description is the primary trigger mechanism. Write it "pushy" — enumerate contexts where the skill should activate. See `references/description-patterns.md` for templates and the 3-slot anatomy.
 
 ### Step 3: Write the Body
 
@@ -107,8 +107,10 @@ before reporting done.
 ### Step 5: Validate the Skill
 
 - [ ] Frontmatter has all required fields
-- [ ] Description is ≤200 characters and "pushy"
-- [ ] Body is under 500 lines
+- [ ] `name` is kebab-case and does NOT start with `claude-` or `anthropic-`
+- [ ] No `<` or `>` anywhere in frontmatter
+- [ ] Description is ≤200 chars (target) and "pushy"; never exceeds 1024 chars (ceiling)
+- [ ] Body is ≤5,000 words (soft warning past 500 lines)
 - [ ] File ownership doesn't overlap with existing agents (check v1.1 resolved conflicts)
 - [ ] Directory ownership takes precedence over pattern ownership
 - [ ] Reference files are linked from the body
@@ -117,7 +119,7 @@ before reporting done.
 ## Common Mistakes
 
 - **Vague descriptions** — "Helps with backend stuff" won't trigger. Be specific.
-- **Body too long** — Approaching 500 lines? Move content to references.
+- **Body too long** — Approaching 5,000 words or 500 lines? Move content to references.
 - **Missing ownership** — Agent roles must declare owned and off-limits files.
 - **Overlapping ownership** — Two agents can't own the same directory. Directory ownership takes precedence over pattern ownership (see `references/frontmatter-spec.md` §Ownership Resolution Rules).
 - **Ignoring resolved conflicts** — Check the v1.1 resolved conflicts table before declaring ownership of `contracts/`, `.claude/handoffs/`, `CLAUDE.md`, `README.md`, or `tests/performance/`.

--- a/skills/meta/skill-writer/references/description-patterns.md
+++ b/skills/meta/skill-writer/references/description-patterns.md
@@ -15,6 +15,28 @@ Write descriptions that:
 3. **Include keyword variants** — different ways users phrase the need
 4. **State exclusions** (if ambiguous) — what it's NOT for
 
+## Description Anatomy
+
+Anthropic's official spec recommends three slots:
+
+```text
+[What it does] + [When to use it] + [Key capabilities or keyword variants]
+```
+
+- **What it does** — start with an action verb in 3rd person. "Generate", "Audit", "Manage", "Verify".
+- **When to use it** — the trigger contexts. Phrase users would actually say. Multiple variants if the work has multiple natural entry points.
+- **Key capabilities or keyword variants** — domain keywords, file types, exclusions. The "pushy" surface that beats under-triggering.
+
+Length budget:
+
+- **Target:** ≤200 characters — keeps descriptions scannable and forces tight triggers
+- **Hard ceiling:** 1024 characters (Anthropic spec maximum)
+- Use a multiline YAML block (`description: |`) when you need more than one paragraph
+
+Forbidden characters:
+
+- **No XML angle brackets** (`<`, `>`) — frontmatter loads into Claude's system prompt and is security-stripped
+
 ## Template Patterns
 
 ### Agent Role Skills
@@ -52,9 +74,10 @@ spawning a [role] agent, [specific task 1], [specific task 2], or
 ## Quality Checklist
 
 - [ ] Starts with an action verb (Build, Generate, Verify, Audit, Manage, Run)
-- [ ] Under 200 characters (target)
+- [ ] Under 200 characters (target); under 1024 (hard ceiling)
 - [ ] Contains at least 3 specific trigger contexts
 - [ ] Includes keyword variants users might say
 - [ ] States exclusions if commonly confused with another skill
 - [ ] Written in 3rd person
+- [ ] Contains no `<` or `>` (forbidden by spec)
 - [ ] Would pass the "would Claude invoke this?" test

--- a/skills/meta/skill-writer/references/frontmatter-spec.md
+++ b/skills/meta/skill-writer/references/frontmatter-spec.md
@@ -2,35 +2,118 @@
 
 Canonical reference for all SKILL.md frontmatter fields in the skill ecosystem.
 
+This spec aligns with Anthropic's official Agent Skills frontmatter standard while adding fields specific to multi-agent orchestration (`owns`, `composes_with`, `spawned_by`, `requires_*`, `min_plan`). Skills written to this spec load correctly on Claude Code, Claude.ai, Claude Desktop, and the Agent SDK — the multi-agent extensions are ignored safely by parsers that don't understand them.
+
+## Quick Reference
+
+```yaml
+---
+name: my-skill                           # required, kebab-case
+version: 1.0.0                           # required, semver (top-level)
+description: |                           # required, ≤200 char target, 1024 char ceiling
+  [What it does]. Use this skill when [when to use].
+  [Key capabilities or keyword variants].
+
+# Optional — Anthropic spec
+compatibility: "Claude Code or Claude.ai; requires Bash + WebFetch"
+license: MIT
+allowed-tools: ["Read", "Edit", "Bash"]  # hyphen is canonical
+metadata:
+  author: your-name
+  category: workflows
+  tags: [planning, multi-agent]
+
+# Optional — this repo's multi-agent extensions
+requires_agent_teams: false
+requires_claude_code: false
+min_plan: starter
+owns:
+  directories: ["src/api/"]
+  patterns: ["Dockerfile*"]
+  shared_read: ["contracts/"]
+composes_with: ["contract-author"]
+spawned_by: ["orchestrator"]
+---
+```
+
 ## Required Fields
 
 ### name
 
 - **Type:** string
-- **Required:** yes
+- **Format:** kebab-case (lowercase, hyphens). No spaces, no capitals, no underscores.
 - **Max length:** 64 characters
-- **Format:** kebab-case (lowercase, hyphens)
-- **Example:** `backend-agent`, `contract-author`, `skill-writer`
-- **Validation:** Must be unique across the ecosystem
+- **Reserved prefixes:** must not start with `claude-` or `anthropic-` — reserved by Anthropic for first-party skills
+- **Must match** the skill folder name
+- **Must be unique** across the ecosystem
+- **Examples:** `backend-agent`, `contract-author`, `skill-writer`
 
 ### version
 
 - **Type:** string
-- **Required:** yes
-- **Format:** Semantic versioning (MAJOR.MINOR.PATCH)
-- **Example:** `1.0.0`, `1.2.3`
-- **Convention:** Start at 1.0.0. Bump MINOR for features, PATCH for fixes, MAJOR for breaking changes.
+- **Format:** Semantic versioning (`MAJOR.MINOR.PATCH`) — e.g., `1.0.0`, `1.2.3`
+- **Position:** top-level (this repo's canonical form). Anthropic's spec also allows `version` nested under `metadata`; both are accepted, but top-level is preferred here so the semver is visible at a glance.
+- **Convention:** Start at `1.0.0`. Bump MINOR for features, PATCH for fixes, MAJOR for breaking changes.
 
 ### description
 
-- **Type:** string (multiline YAML)
-- **Required:** yes
-- **Target length:** ≤200 characters
-- **Format:** `[Action verb] [what it does]. Use this skill when [trigger contexts].`
-- **Purpose:** Primary trigger mechanism — Claude reads this to decide whether to invoke the skill
-- **Style:** "Pushy" — enumerate specific trigger contexts, keywords, and use cases
+- **Type:** string (multiline YAML via `|` is fine)
+- **Target length:** ≤200 characters — forces tight, scannable triggers
+- **Hard ceiling:** 1024 characters (Anthropic spec maximum)
+- **Anatomy:** `[What it does] + [When to use it] + [Key capabilities or keyword variants]`
+- **Style:** "Pushy" — enumerate specific trigger contexts and keyword variants users might actually say
+- **Forbidden:** XML angle brackets (`<`, `>`) — frontmatter loads into Claude's system prompt and could be used for prompt injection
+- **Purpose:** Primary trigger mechanism. Claude reads this to decide whether to invoke the skill.
 
-## Optional Fields
+See `description-patterns.md` for templates and worked examples.
+
+## Optional Fields — Anthropic Spec
+
+### compatibility
+
+- **Type:** string
+- **Length:** 1–500 characters
+- **Purpose:** Human-readable declaration of environment requirements: intended host (Claude Code, Claude.ai, API), required system packages, network access, MCP servers, etc.
+- **Cross-platform parsers use this string.** For programmatic runtime gating, use the `requires_*` booleans below.
+- **Example:** `"Claude Code only; requires Bash + WebFetch tools and a clean git working tree"`
+
+### license
+
+- **Type:** string
+- **Purpose:** Per-skill license override. Usually unnecessary for skills shipped in this repo — the repo-level LICENSE applies.
+- **Examples:** `MIT`, `Apache-2.0`
+
+### allowed-tools
+
+- **Type:** string[]
+- **Canonical form:** `allowed-tools` (hyphen — matches Anthropic spec)
+- **Deprecated alias:** `allowed_tools` (underscore) is still accepted for back-compat; new skills should use the hyphenated form
+- **Purpose:** Whitelist of tools the skill may invoke. Cross-platform parsers respect this.
+- **Example:** `["Read", "Edit", "Bash", "WebFetch"]`
+
+### metadata
+
+- **Type:** object (free-form key/value)
+- **Purpose:** Attribution, cataloging, and integration metadata
+- **Common subfields:**
+  - `author` — skill author or team
+  - `category` — e.g., `workflows`, `roles`, `meta`, `git`, `contracts`
+  - `tags` — list of discovery keywords
+  - `mcp-server` — name of the MCP server this skill enhances, if any
+  - `documentation` — URL to extended docs
+  - `support` — contact for issues
+- **Example:**
+
+  ```yaml
+  metadata:
+    author: ivy00johns
+    category: workflows
+    tags: [planning, multi-agent]
+  ```
+
+## Optional Fields — Multi-Agent Extensions
+
+This repo's extensions for orchestrated builds. Not part of Anthropic's spec; parsers that don't understand them ignore them safely.
 
 ### requires_agent_teams
 
@@ -42,7 +125,7 @@ Canonical reference for all SKILL.md frontmatter fields in the skill ecosystem.
 
 - **Type:** boolean
 - **Default:** false
-- **Purpose:** Set true if skill requires Claude Code CLI (bash tool, file system access)
+- **Purpose:** Set true if skill requires Claude Code CLI (bash, filesystem access)
 
 ### min_plan
 
@@ -69,11 +152,6 @@ Canonical reference for all SKILL.md frontmatter fields in the skill ecosystem.
 - **Purpose:** Directories this agent reads but doesn't own
 - **Example:** `["contracts/", "shared/", "src/types/"]`
 
-### allowed_tools
-
-- **Type:** string[]
-- **Purpose:** Subset of tools this agent may use
-
 ### composes_with
 
 - **Type:** string[]
@@ -84,16 +162,34 @@ Canonical reference for all SKILL.md frontmatter fields in the skill ecosystem.
 - **Type:** string[]
 - **Purpose:** Which skills spawn this one
 
+## Forbidden in Frontmatter
+
+These rules come from Anthropic's spec. `skill-review` enforces them.
+
+- **XML angle brackets `<` and `>`** anywhere in the frontmatter — security risk, since frontmatter loads into Claude's system prompt
+- **Names starting with `claude-` or `anthropic-`** — reserved by Anthropic for first-party skills
+- **Code execution in YAML** — parsers use safe-YAML; tagged Python objects and similar constructs will fail to parse
+
+## Body Length Guidance
+
+- **Guideline:** SKILL.md body ≤ 5,000 words (Anthropic recommendation)
+- **Soft warning** at 500 lines OR 5,000 words — `skill-review` flags and suggests moving content to `references/`
+- **No hard gate.** Heavy skills (`orchestrator`, `ui-ux-pro-max`, `repo-deep-dive`) deliberately exceed the guideline because their body needs to load atomically. Trade-off accepted.
+- Content moved to `references/` is loaded on demand — the third level of progressive disclosure.
+
 ## Field Decisions
 
 | Field | Decision | Rationale |
 |-------|----------|-----------|
-| `version` | Required, semver | Community convention; enables changelog tracking |
-| `requires_agent_teams` | Explicit flag | Native teams need env var; skills must declare this |
-| `requires_claude_code` | Explicit flag | Some skills are CLI-only; users need to know |
+| `version` (top-level) | Required | Semver visibility; Anthropic also allows `metadata.version` but top-level is canonical here |
+| `description` ≤200 char target | Soft guidance | Forces concise triggers; 1024 is the hard ceiling per Anthropic spec |
+| `allowed-tools` (hyphen) | Canonical from this version | Aligns with Anthropic spec; `allowed_tools` accepted as deprecated alias |
+| `compatibility` | Added | Cross-platform parsers use this string; `requires_*` booleans complement for programmatic gating |
+| `metadata` | Adopted (optional) | Free-form attribution; nested form matches Anthropic spec |
+| `requires_agent_teams` | Explicit boolean | Native teams need env var; skills must declare this for runtime gating |
+| `requires_claude_code` | Explicit boolean | Some skills are CLI-only; users need to know |
 | `owns.directories` | Enforced by orchestrator | Core to zero-conflict parallel builds |
 | `owns.patterns` | Glob-based | Handles files not in a single directory |
-| `allowed_tools` | Per-agent whitelist | Prevents agents reaching outside their domain |
 | `composes_with` | Informational | Helps skill-writer and future auto-composition |
 
 ## Ownership Resolution Rules (v1.1)
@@ -117,9 +213,32 @@ When declaring `owns`, follow these precedence rules:
 
 ## Validation Rules
 
-1. `name` must be unique — no two skills share a name
-2. `owns.directories` must not overlap between agent roles
-3. Directory ownership takes precedence over pattern ownership (see resolution rules above)
-4. `description` should contain at least one action verb and one trigger context
-5. `version` must be valid semver
-6. `requires_agent_teams: true` skills must degrade gracefully when teams unavailable
+`skill-review` enforces these.
+
+1. `name` is kebab-case, ≤64 chars, unique, and does NOT start with `claude-` or `anthropic-`
+2. `version` is valid semver (top-level or under `metadata`)
+3. `description` is present, ≤1024 chars, contains no `<` or `>`
+4. No `<` or `>` anywhere in frontmatter
+5. `owns.directories` does not overlap with any other agent role
+6. Directory ownership takes precedence over pattern ownership (see resolution rules above)
+7. `description` contains at least one action verb and one trigger context
+8. `requires_agent_teams: true` skills degrade gracefully when teams unavailable
+9. Body ≤ 5,000 words OR ≤ 500 lines (guideline — warn, don't fail)
+
+## Spec Alignment Notes
+
+This spec aligns with Anthropic's open Agent Skills standard while preserving multi-agent extensions:
+
+| Anthropic field | This repo | Notes |
+|---|---|---|
+| `name` | `name` | Identical rules + reserved-prefix enforcement |
+| `description` | `description` | Same; we add a tighter 200-char *target* on top of the 1024 ceiling |
+| `allowed-tools` | `allowed-tools` (with `allowed_tools` alias) | Aligned this version |
+| `metadata` | `metadata` | Adopted as optional nested object |
+| `compatibility` | `compatibility` | Adopted |
+| `license` | `license` | Adopted |
+| — | `version` (top-level, required) | Extension: visible at a glance |
+| — | `requires_agent_teams`, `requires_claude_code`, `min_plan` | Extensions: runtime gating |
+| — | `owns`, `composes_with`, `spawned_by` | Extensions: multi-agent coordination |
+
+A skill written to this spec uploads to Claude.ai, runs on Claude Code, and works with the Agent SDK.


### PR DESCRIPTION
## Summary

- Repo skills now load cleanly on Claude.ai, Claude Desktop, and the Agent SDK — not just Claude Code. Previously, fields like `allowed_tools` (underscore) and top-level `version` were silently ignored by Anthropic-spec parsers.
- Adds the Anthropic spec fields (`compatibility`, `metadata`, hyphenated `allowed-tools`) while preserving this repo's multi-agent extensions (`owns`, `composes_with`, `spawned_by`, `requires_*`).
- Enforces Anthropic's security and reserved-name rules in `skill-review` so violations get caught before publish.
- Relaxes the hard 500-line body limit to a soft 5,000-word guideline (Anthropic's recommendation), accepting that heavy skills like `orchestrator` and `ui-ux-pro-max` earn their length.

## Changes

**Spec (canonical):**
- `skills/meta/skill-writer/references/frontmatter-spec.md` — full rewrite. Adds `compatibility`, `metadata`, hyphenated `allowed-tools` (with `allowed_tools` accepted as deprecated alias), reserved-prefix rule (`claude-*` / `anthropic-*` forbidden), forbidden frontmatter chars (`<`, `>`), 1024-char description ceiling, 5,000-word body guideline. Spec-alignment table at the bottom maps every field to Anthropic's standard.
- `skills/meta/skill-writer/references/description-patterns.md` — adds the `[What] + [When] + [Capabilities]` anatomy section from Anthropic's guide; updates Quality Checklist with 1024 ceiling + forbidden chars.

**Validation gates:**
- `skills/meta/skill-review/SKILL.md` + `references/audit-checklist.md` + `references/deep-review-rubric.md` — new FAIL conditions for reserved-prefix names, forbidden frontmatter chars, and 1024-char ceiling overflow. WARN for underscore `allowed_tools` alias. Body length rubric now uses words OR lines.
- `skills/meta/skill-update/SKILL.md` + `references/validation-checklist.md` — field order updated to include `compatibility`, `metadata`, `license`; new checks mirror skill-review.

**Project doc:**
- `CLAUDE.md` — Skill Anatomy section and Editing Skills section now reflect the new spec.

**Plan-of-record:**
- `IMPROVEMENT_PLAN.md` (new) — phased plan documenting Phase 1 scope, the 4 resolved decisions, and Phases 2–5 still to land.

**Version bumps:**
- `skill-writer` 1.1.0 → 1.2.0
- `skill-review` 1.0.0 → 1.1.0
- `skill-update` 1.0.0 → 1.1.0

## Test plan

- [ ] Spot-read updated `frontmatter-spec.md` — confirm the new fields and validation rules are clear and the spec-alignment table accurately maps to Anthropic's standard
- [ ] Run \`/skill-review all\` (manual smoke test) — confirm it does NOT regression-fail existing skills that still use `allowed_tools` underscore alias (should WARN, not FAIL)
- [ ] Confirm no existing skill name starts with `claude-` or `anthropic-` — \`grep -rE "^name: (claude-|anthropic-)" skills/\` should return nothing
- [ ] Confirm no existing skill has `<` or `>` in its frontmatter — \`grep -lE "^[a-z_-]+:.*[<>]" skills/**/SKILL.md\` should return nothing
- [ ] Verify the linked plan (\`IMPROVEMENT_PLAN.md\`) explains the rationale for any reviewer who wants the "why"

## Notes

This is Phase 1 of 5. Phases 2 (templates/references), 3 (thinking-moves from claude_notes.txt), 4 (process changes), and 5 (sweep of existing 46 skills) will land as separate PRs per the plan. Phase 5 is where individual skills get audited against this new spec — this PR only changes the canonical docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)