### PR TITLE
feat: Add skill design references and thinking-move disciplines

### DIFF
--- a/skills/meta/skill-explorer/SKILL.md
+++ b/skills/meta/skill-explorer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-explorer
-version: 1.0.0
+version: 1.1.0
 description: |
   Help the user discover, recall, understand, and pick the right skill from the available toolkit.
   Use this skill whenever the user is trying to find a skill ("I forgot the name of the one that does X",
@@ -156,7 +156,12 @@ When orchestrator would be wrong, **say so explicitly**: "This isn't a multi-age
 | Inventing skill names                              | If you don't see a skill that fits, say "no skill covers this — closest is X" or "this might warrant a new skill via `skill-writer`" |
 
 
+## Troubleshooting Help
+
+When the user asks why a skill is misbehaving — won't fire, fires too often, ignores its instructions, MCP errors, or feels slow — match their description against the named symptoms in `references/troubleshooting.md` before guessing. Confirm the symptom by what the user observes (not what they think the cause is), then walk the fix sequence.
+
 ## References
 
 - `references/routing-table.md` — fuller table of common requests → recommended skill, used when the four rules of thumb above don't cover the case
+- `references/troubleshooting.md` — symptom taxonomy for skill issues (won't upload, won't trigger, triggers too often, instructions not followed, MCP issues, large context)
 

--- a/skills/meta/skill-explorer/references/troubleshooting.md
+++ b/skills/meta/skill-explorer/references/troubleshooting.md
@@ -1,0 +1,117 @@
+# Skill Troubleshooting Taxonomy
+
+Named symptoms for "why isn't my skill behaving correctly?", drawn from Anthropic's guide (Chapter 5, p.25-27). Use this reference when the user asks why a skill won't fire, fires too often, ignores its instructions, or seems slow. Each symptom below pairs a recognizable observation with its common causes and a concrete fix sequence.
+
+## How to Use This Reference
+
+When a user describes a skill problem, match it to one of the symptoms below by what they observe — not by what they think the cause is. Users frequently misdiagnose ("the description must be wrong") when the real cause is a different symptom ("the skill is actually firing, but its instructions are too vague to follow"). Confirm the symptom first, then walk the fix.
+
+## Symptom: Skill Won't Upload / Sync
+
+**What it looks like:** the skill never appears in the available-skills list. Sync, upload, or registration silently skips it, or errors with a parser complaint.
+
+**Common causes:**
+
+- The file is not named exactly `SKILL.md` (case-sensitive — `Skill.md`, `skill.md`, and `SKILL.MD` are all wrong)
+- YAML frontmatter is malformed: missing `---` delimiters at top or bottom, unclosed quotes, bad indentation
+- `name` field violates the spec: contains spaces, uppercase letters, or starts with the reserved prefix `claude-` or `anthropic-`
+- File is inside a folder whose name violates the same rules
+
+**Fix:**
+
+1. Verify the filename is exactly `SKILL.md`
+2. Open the file and confirm the frontmatter starts with `---` on its own line and ends with `---` on its own line
+3. Run a YAML linter (or paste into a YAML validator) to catch unclosed quotes or indentation errors
+4. Confirm the `name` field is kebab-case and not reserved
+5. Re-run the sync or upload
+
+## Symptom: Skill Doesn't Trigger
+
+**What it looks like:** the user describes a task the skill should handle, but the model handles it itself or picks a different skill. The skill exists, syncs cleanly, but never fires.
+
+**Common causes:**
+
+- Description is too vague: "Helps with projects", "Assists with development" — these give the model no anchor
+- Description is missing the trigger phrases users actually say (the description talks about "code review" but the user always says "review my PR")
+- Description omits file-type mentions when the skill is file-type-specific (a `.tsx`-focused skill should name `.tsx`)
+- Description leads with the mechanism instead of the outcome ("Uses Playwright to..." vs. "Test the UI in a real browser to...")
+
+**Fix:**
+
+1. Ask Claude: "When would you use the `[skill-name]` skill?" — the answer is essentially a paraphrase of the description, which makes the gap visible
+2. Compare the answer against the actual phrases the user types — note any missing keywords
+3. Rewrite the description leading with the outcome and the trigger phrases (see `../../skill-writer/references/description-patterns.md`)
+4. Re-test with the exact phrases the user uses
+
+## Symptom: Skill Triggers Too Often
+
+**What it looks like:** the skill fires on tasks it has no business handling — adjacent topics, unrelated requests that share a keyword.
+
+**Common causes:**
+
+- Description is too broad ("Handles anything related to files" matches everything)
+- No negative trigger ("Do NOT use for X") to bound the scope
+- Missing specificity — the description should pin down the file types, contexts, or stages where the skill applies
+
+**Fix:**
+
+1. List the false-positive cases — what tasks is it firing on that it shouldn't?
+2. Identify the keyword causing the over-match
+3. Either narrow the description (replace "files" with "TypeScript files in `src/`") or add an explicit negative trigger ("Do NOT use for plain-text docs or markdown")
+4. Re-test on both the true-positive and the false-positive cases
+
+## Symptom: Instructions Not Followed
+
+**What it looks like:** the skill triggers, but the model ignores parts of the body — skips steps, invents its own workflow, doesn't run the validation script.
+
+**Common causes:**
+
+- Instructions are too verbose — long prose buries the imperative
+- Critical instructions are buried in the middle or at the bottom (the model weighs the top of the body more heavily)
+- Language is ambiguous: "validate properly", "review carefully" — these don't name an action
+- No `## Important` / `## Critical` header to flag must-do items
+
+**Fix:**
+
+1. Move critical instructions to the top of the body, directly under the title
+2. Use `## Important` or `## Critical` headers to mark non-skippable steps
+3. Rewrite ambiguous prose as imperative bullets ("Run `npm test` and confirm zero failures")
+4. Trim verbose paragraphs — bullets and tables outperform prose for instructions
+5. If the skill is long-running and the model is cutting corners, add a `## Performance Notes` block (see `../../skill-writer/references/performance-notes-pattern.md`)
+
+## Symptom: MCP Connection Issues
+
+**What it looks like:** the skill references an MCP tool and fails with "tool not found", "unauthorized", or silent no-ops. Only applies to skills that integrate with an MCP server.
+
+**Common causes:**
+
+- The MCP server is not connected in the current session
+- Authentication has expired or never completed
+- The tool name in SKILL.md doesn't match the actual MCP tool name (case-sensitivity matters)
+- The MCP server is connected but the specific tool the skill calls is not exposed
+
+**Fix:**
+
+1. Confirm the MCP server is listed in the current session's available tools
+2. Test the MCP tool independently of the skill — call it directly to confirm auth and connectivity
+3. Compare the tool name in SKILL.md against the actual tool name byte-for-byte
+4. If auth expired, re-run the MCP authentication flow
+5. If the tool genuinely isn't exposed, either expose it on the server or document an alternate workflow in the skill
+
+## Symptom: Large Context Issues
+
+**What it looks like:** the skill is slow, responses feel degraded, or the model seems to be losing track of details mid-task.
+
+**Common causes:**
+
+- SKILL.md body is too large (well past the 500-line soft warning)
+- Too many skills are enabled simultaneously and all of their metadata is loading
+- Reference files are being inlined into the body instead of being read on demand
+- The skill is loading all of `references/` up front instead of pointing the model at specific files
+
+**Fix:**
+
+1. Move detailed content from the body into `references/` and link rather than inline
+2. Audit the body for content that's only needed in edge cases — push it to a reference
+3. Recommend the user disable skills they aren't actively using (selective enablement)
+4. In the body, name the specific reference file the model should read for each sub-task ("For the full validation procedure, read `references/validation-checklist.md`") instead of "see references"

--- a/skills/meta/skill-review/SKILL.md
+++ b/skills/meta/skill-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-review
-version: 1.1.0
+version: 1.2.0
 argument-hint: skill-name or 'all'
 description: |
   Review skills for quality, consistency, triggering accuracy, and adherence to the 100-line rule. Two modes: 'all' (bulk ecosystem-wide scan for ownership conflicts, gaps, length outliers, weak triggers) or a single skill name (deep dive on description quality, body structure, anti-pattern naming, cross-references). Outputs a structured report consumable by skill-update. Trigger on: 'audit skills', 'review this skill', 'health check skills', 'skill ecosystem health', 'is this skill any good', 'scan all skills', 'check my skills', 'deep review', 'bulk review', 'what needs fixing'.
@@ -92,14 +92,39 @@ Read `SKILL.md` and every file in `references/`. Score these dimensions against 
 
 #### B2. Live Trigger Testing
 
-If `/skill-creator` is available, use its eval infrastructure to test whether the skill actually triggers:
+Every deep-review report **must** include an explicit triggering test block in this exact format (matches Anthropic's recommended format for skill triggering tests):
 
-1. Generate 3–5 realistic prompts that **should** trigger this skill
-2. Generate 2–3 near-miss prompts that should **not** trigger it
-3. Run trigger evaluation via skill-creator's description optimization tooling
-4. Report should-trigger hit rate and false-positive rate. List any problem triggers.
+```text
+Should trigger:
+- "<paraphrase 1 — realistic phrasing a user would actually say>"
+- "<paraphrase 2 — different angle / different keyword cluster>"
+- "<paraphrase 3 — edge phrasing that should still match>"
 
-If `/skill-creator` is unavailable, skip this phase and note it in the report.
+Should NOT trigger:
+- "<near-miss 1 — adjacent task that belongs to a different skill>"
+- "<near-miss 2 — vague prompt that should NOT pull this skill in>"
+```
+
+Minimum 3 positives and 2 negatives. Generate from the skill's stated purpose, not from optimistic intent. If you can't write a plausible negative, the skill's scope is too broad — flag that.
+
+If `/skill-creator` or its eval infrastructure is available, run the block as an actual trigger evaluation:
+
+1. Feed the should-trigger prompts; record hit rate
+2. Feed the should-NOT-trigger prompts; record false-positive rate
+3. Report both rates with examples of any problem triggers
+
+If `/skill-creator` is unavailable, the triggering test block is still required — just unrun. Note "evaluation not executed" in the report.
+
+#### B3. Performance Comparison (optional)
+
+For high-traffic skills where it's worth proving the skill improves over no-skill baseline, run a small A/B:
+
+1. Pick 2 representative task prompts
+2. **Without skill enabled:** record total messages, tool calls, failed calls, total tokens
+3. **With skill enabled:** record the same metrics
+4. Report the deltas — fewer back-and-forths, fewer failed calls, and lower total tokens are the wins. A skill that doesn't move any of these is not earning its load cost.
+
+Skip this for niche or first-version skills where the comparison would be noise. Note "performance comparison skipped — low-traffic skill" in the report.
 
 #### B3. Output Quality Sampling
 

--- a/skills/meta/skill-writer/SKILL.md
+++ b/skills/meta/skill-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-writer
-version: 1.2.0
+version: 1.3.0
 description: |
   Generate new SKILL.md files conforming to the ecosystem's frontmatter spec and structure conventions. Use this skill when creating any new skill, agent role definition, or workflow skill. Trigger whenever someone says "create a skill", "new agent", "write a SKILL.md", or needs to add a role to the skill ecosystem. Also use when reviewing existing skills for spec compliance.
 requires_agent_teams: false
@@ -47,6 +47,8 @@ Skills use three-level loading:
 Keep SKILL.md bodies concise. Move detailed checklists, templates, and reference tables to `references/` with clear pointers.
 
 ## Creating a New Skill
+
+> **Iterate on a single task first.** Before you write the skill, prototype the workflow against one real task in a normal conversation. Get it working there. Then extract the winning approach into a skill — leverages Claude's in-context learning and produces faster signal than designing the skill blind. Once you have a working foundation, expand to multiple test cases for coverage.
 
 ### Step 1: Choose the Skill Type
 
@@ -129,3 +131,8 @@ before reporting done.
 
 - `references/frontmatter-spec.md` — Complete field reference with types, rules, and examples
 - `references/description-patterns.md` — Templates for writing effective trigger descriptions
+- `references/body-template.md` — Recommended SKILL.md body structure (title → instructions → examples → troubleshooting) and when to deviate
+- `references/patterns.md` — 5 emergent design patterns (sequential, multi-service, iterative, context-aware, domain-specific) with in-repo examples
+- `references/quick-checklist.md` — 4-section pre-sync checklist (before / during / before sync / after sync)
+- `references/performance-notes-pattern.md` — When to add `## Performance Notes` to combat model laziness, and when not to
+- `references/validation-script-pattern.md` — When to bundle a deterministic `scripts/validate.sh` instead of asking the model to validate in prose

--- a/skills/meta/skill-writer/references/body-template.md
+++ b/skills/meta/skill-writer/references/body-template.md
@@ -1,0 +1,90 @@
+# SKILL.md Body Template
+
+Anthropic's recommended body structure for a SKILL.md, with commentary on when to deviate.
+
+## When to Use This Template
+
+This is the default body structure for **any new skill**. Use it unchanged unless you have a specific reason to deviate (see "When to Deviate" below). The structure prioritizes the same things Claude does when loading a skill: critical instructions first, then patterns to imitate, then known failure modes.
+
+## The Template
+
+```markdown
+# Skill Title
+
+One-paragraph statement of what the skill does and the typical situation it's invoked in.
+
+## Instructions
+
+High-signal guidance the model needs every time. Lead with the must-do bullets, then the workflow.
+
+### Step 1: First Major Step
+
+Describe the first action concretely. Use imperative voice ("Read the file", "Run the command", "Write the result"). Include the exact tool or command name where it helps.
+
+### Step 2: Second Major Step
+
+Describe the next action. Each step should be self-contained enough that the model can execute it without re-reading earlier steps.
+
+### Step 3: Third Major Step
+
+Continue until the happy-path workflow is covered. Keep steps under 5 — split into a reference file if you need more.
+
+## Examples
+
+Examples teach by pattern matching. Show at least one realistic invocation end-to-end.
+
+### Example 1: [Short scenario name]
+
+**User says:** "[Trigger phrase the user would actually type]"
+
+**Actions:**
+
+1. [First concrete action the skill takes]
+2. [Second action]
+3. [Third action]
+
+**Result:** [What the user sees / what gets produced]
+
+### Example 2: [A different scenario]
+
+**User says:** "[A different trigger phrase]"
+
+**Actions:**
+
+1. [Actions for this variant]
+
+**Result:** [Output for this variant]
+
+## Troubleshooting
+
+Document known failure modes so the model self-corrects instead of pinging the user.
+
+### Error: [Common error message or symptom]
+
+**Cause:** [Why this happens]
+
+**Solution:** [Concrete fix the model can apply]
+
+### Error: [Another common failure]
+
+**Cause:** [Why]
+
+**Solution:** [Fix]
+```
+
+## Why This Structure
+
+- **Critical instructions surface to the top.** The model reads top-down; the `## Instructions` H2 sits right under the title where it has the most weight.
+- **Examples teach pattern matching.** Models reliably imitate concrete `User says → Actions → Result` triples. A skill with three good examples often outperforms a skill with three paragraphs of prose.
+- **Troubleshooting prevents support tickets.** Naming a symptom + cause + fix lets the model recover from a known failure without escalating to the user.
+
+## When to Deviate
+
+| Skill type | Deviation | Why |
+|---|---|---|
+| Agent role skills (`skills/roles/*`) | Use Role / Inputs / Process / Coordination / Validation instead | Roles are spawned by the orchestrator and need explicit I/O and coordination contracts, not user examples |
+| Meta skills (`skills/meta/*`) | Examples section is often omitted | The "user" is usually another skill author, not an end user; the meta-doc itself is the example |
+| Orchestrator (`skills/orchestrator/`) | Replace Steps with named Phases (Phase 1 → Phase 14) and link each phase to a reference file | A 14-phase workflow doesn't fit in 5 numbered steps |
+| Workflow skills with branching logic | Add a `## Decision Tree` H2 above `## Instructions` | When the first action depends on context, surface the routing decision before the steps |
+
+If you deviate, keep the spirit intact: critical instructions near the top, concrete examples where they help, named failure modes at the bottom.

--- a/skills/meta/skill-writer/references/patterns.md
+++ b/skills/meta/skill-writer/references/patterns.md
@@ -1,0 +1,141 @@
+# Skill Design Patterns
+
+Five emergent patterns Anthropic cataloged from skills observed in the wild (Chapter 5 of "The Complete Guide to Building Skills for Claude"). Most well-shaped skills fall into one of these; some compose two. Use this catalog as a sanity check when designing a new skill — if your skill doesn't resemble any of these, ask whether the shape is right.
+
+Each pattern below documents: **Use when**, an example structure, **Key techniques**, and a pointer to an in-repo example.
+
+## Pattern 1: Sequential Workflow Orchestration
+
+**Use when:** the task is a multi-step process that must happen in a specific order, and skipping or reordering steps produces wrong output.
+
+**Example structure:**
+
+```markdown
+## Workflow
+
+### Step 1: Validate inputs
+### Step 2: Transform
+### Step 3: Persist
+### Step 4: Notify
+```
+
+**Key techniques:**
+
+- Number the steps explicitly — models reorder unnumbered bullets
+- Make each step's exit condition observable ("file exists at X", "command exits 0")
+- State the failure mode for each step inline, not at the bottom
+- Keep the happy path linear; push branching to a `## Branching` subsection or a reference file
+
+**In-repo example:** `skills/workflows/sync-skills` (scan → classify → confirm → symlink → verify) and `skills/git/git-pr` (status → diff → branch → push → create PR).
+
+## Pattern 2: Multi-MCP / Multi-Service Coordination
+
+**Use when:** the workflow spans several external services (or, in this repo, several role agents), each owning a phase, with handoffs between them.
+
+**Example structure:**
+
+```markdown
+## Phases
+
+### Phase 1: Design Export (Figma MCP)
+### Phase 2: Asset Storage (S3 MCP)
+### Phase 3: Task Creation (Linear MCP)
+### Phase 4: Notification (Slack MCP)
+```
+
+**Key techniques:**
+
+- Name the service or agent that owns each phase
+- Define the artifact handed off between phases (file path, JSON shape, URL)
+- Document the rollback or skip-ahead behavior when a phase's service is unavailable
+- Don't bury the cross-service dependency graph — surface it near the top
+
+**In-repo example:** `skills/orchestrator` applies this pattern to agent roles instead of MCPs — its 14-phase playbook hands artifacts (contracts, qa-report.json, handoff docs) between backend, frontend, qe, etc.
+
+## Pattern 3: Iterative Refinement
+
+**Use when:** output quality measurably improves with iteration, and a single pass produces something noticeably worse than two or three passes.
+
+**Example structure:**
+
+```markdown
+## Workflow
+
+### Initial Draft
+### Quality Check
+### Refinement Loop (repeat until criteria met)
+### Finalization
+```
+
+**Key techniques:**
+
+- Define the quality bar concretely (a checklist, a score threshold, or "no remaining `TODO` markers")
+- Cap the loop ("repeat up to 3 times, then escalate")
+- Make the refinement criteria observable — "fixes flagged issues" is too vague; "addresses each item in the qa-report.json blockers array" is concrete
+- Output a diff or change log each iteration so the user can audit
+
+**In-repo example:** `skills/meta/skill-update` (review → identify gaps → patch → re-review) and `skills/workflows/diagnose-loop` (hypothesis → test → refine → repeat).
+
+## Pattern 4: Context-Aware Tool Selection
+
+**Use when:** the same outcome can be achieved by different tools, and the right tool depends on runtime context (host, plan, what's installed, what's available).
+
+**Example structure:**
+
+```markdown
+## Decision Tree
+
+1. Detect available runtime
+2. Select tool path:
+   - If [condition A] → use [Tool A]
+   - Elif [condition B] → use [Tool B]
+   - Else → fall back to [Tool C]
+3. Execute the selected path
+4. Tell the user which path was taken and why
+```
+
+**Key techniques:**
+
+- Make the detection step explicit and cheap (one command, not a battery)
+- Order branches from most-preferred to fallback
+- Always tell the user which branch ran — silent fallbacks make debugging miserable
+- Document each branch's tradeoffs (speed vs. fidelity vs. dependencies)
+
+**In-repo example:** `skills/orchestrator` runtime detection — Agent Teams (best) → subagents (good) → sequential (works everywhere). The skill picks based on the host's capabilities and tells the user which mode it chose.
+
+## Pattern 5: Domain-Specific Intelligence
+
+**Use when:** the skill adds specialized knowledge beyond tool access — compliance rules, security checklists, framework idioms, regulatory constraints — that a generic agent wouldn't know to apply.
+
+**Example structure:**
+
+```markdown
+## Workflow
+
+### Step 1: Compliance / domain check
+### Step 2: Conditional processing based on domain rules
+### Step 3: Audit trail / evidence collection
+### Step 4: Reporting
+```
+
+**Key techniques:**
+
+- Bundle the domain knowledge in `references/` (rule lists, checklists, templates by stack)
+- Make the check step refuse to skip — "do not proceed until each item in the checklist is verified"
+- Produce an audit artifact (JSON, markdown report) so the work is reviewable, not just executed
+- Cite the source of each rule so the model can explain its reasoning
+
+**In-repo example:** `skills/contracts/contract-author` (selects an OpenAPI / AsyncAPI / Pydantic / TypeScript / JSON Schema template based on the project stack and applies stack-specific conventions) and `skills/roles/security-agent` (applies OWASP-style checklists and produces an audit trail).
+
+## Composing Patterns
+
+Real skills often combine two patterns. A few common combos:
+
+| Combo | Where it shows up |
+|---|---|
+| Sequential + Domain-specific | Most agent roles — a fixed workflow that also enforces domain rules at each step |
+| Iterative + Domain-specific | Skill audits, security reviews, code review |
+| Context-aware + Sequential | Orchestrator (pick a runtime, then run the 14-phase sequence in that runtime) |
+| Multi-service + Iterative | UX review (Playwright → screenshot → identify issues → fix → re-run) |
+
+If you find your skill needs more than two patterns, it's probably two skills. Split it.

--- a/skills/meta/skill-writer/references/performance-notes-pattern.md
+++ b/skills/meta/skill-writer/references/performance-notes-pattern.md
@@ -1,0 +1,49 @@
+# Performance Notes Pattern
+
+Document for the `## Performance Notes` body section described in Anthropic's guide (p.26): an explicit-encouragement block that combats model laziness on long-running or validation-heavy skills.
+
+## What It Is
+
+A short body section, placed near the top of the SKILL.md instructions, that explicitly tells Claude to slow down, prioritize quality over speed, and not skip validation. It exists because the model's default optimization pressure is toward token efficiency — which sometimes manifests as cutting corners on the very tasks where corner-cutting is most costly.
+
+## When to Use It
+
+Use it on:
+
+- Long-running role agents (backend-agent, frontend-agent, qe-agent, security-agent) where the cost of a missed step is high
+- Validation-heavy skills (code-review, contract-auditor, security-review)
+- Skills where you've **observed** the model cutting corners in prior runs — taking shortcuts, skipping the validation checklist, marking work complete without running tests
+
+Do NOT use it on:
+
+- Fast-response utility skills (git-commit, skill-explorer recall mode) — the encouragement to slow down works against the intended fast response
+- Skills where there is no observable corner-cutting problem — paranoid prophylactic use dilutes the signal across the ecosystem
+
+## The Pattern
+
+```markdown
+## Performance Notes
+
+- Take your time to do this thoroughly
+- Quality is more important than speed
+- Do not skip validation steps
+- [Add one or two domain-specific encouragements — e.g., "Run the full test suite, not a subset", "Read every file you claim to have reviewed", "Verify each contract field individually"]
+```
+
+Place this section near the top of the body — directly under the role/intro paragraph and before `## Instructions` — so it loads with the highest weight.
+
+## Why It Works
+
+The body of a triggered skill loads into the model's working context with high prominence. Explicit, plainly-worded instructions in that context counterweight the default token-efficiency pressure. The bullets are intentionally simple — "Take your time", "Quality over speed" — because subtle instructions get pattern-matched into the noise.
+
+The domain-specific bullet is the load-bearing one. Generic "be careful" instructions plateau quickly; "run the full test suite, not a subset" or "verify each contract field individually" name the specific corner that was being cut.
+
+## Anti-Pattern: Paranoid Adoption
+
+Adding `## Performance Notes` to every skill regardless of need is the most common failure mode. Three reasons it backfires:
+
+1. **Signal dilution** — when every skill says "take your time", the model stops weighing the instruction. It becomes part of the boilerplate the model skims past.
+2. **Conflicts with fast-response skills** — telling `git-commit` or `skill-explorer` to "take its time" produces noticeably worse UX with no quality benefit.
+3. **Hides where the real problem is** — when every skill has the same prophylactic block, you can't tell which skills actually had a quality issue worth fixing.
+
+The right discipline: add this section when you have observed a specific corner-cutting failure, name the failure in the domain-specific bullet, and remove the section if a later version of the model stops exhibiting the problem.

--- a/skills/meta/skill-writer/references/quick-checklist.md
+++ b/skills/meta/skill-writer/references/quick-checklist.md
@@ -1,0 +1,45 @@
+# Quick Checklist
+
+Run this before declaring a skill done. Mirrors Anthropic's Reference A "Quick checklist" (page 30 of "The Complete Guide to Building Skills for Claude"). Terse on purpose — if you want the "why", see the other references.
+
+## Before You Start
+
+- [ ] Identified 2-3 concrete use cases the skill must handle
+- [ ] Identified the tools the skill needs (built-in: Read/Write/Edit/Bash/Grep/Glob; or MCP)
+- [ ] Reviewed the frontmatter spec (`references/frontmatter-spec.md`) and at least one example skill in the same category
+- [ ] Planned the folder structure (SKILL.md + which references / scripts you'll need)
+
+## During Development
+
+- [ ] Folder named in kebab-case
+- [ ] Folder name does NOT start with `claude-` or `anthropic-` (reserved prefixes)
+- [ ] `SKILL.md` file exists at the folder root, spelled exactly that way (case-sensitive)
+- [ ] YAML frontmatter is delimited by `---` on its own line at top and bottom
+- [ ] `name` field is kebab-case and ≤64 characters
+- [ ] `description` includes both WHAT the skill does and WHEN to trigger it
+- [ ] `description` is ≤200 characters (target) and never exceeds 1024 characters (ceiling)
+- [ ] No `<` or `>` characters anywhere in frontmatter
+- [ ] Body instructions are clear and actionable (imperative voice, numbered steps)
+- [ ] Error handling included (`## Troubleshooting` or equivalent)
+- [ ] At least one concrete example provided (User says / Actions / Result)
+- [ ] All reference files are linked from the body with guidance on when to read them
+
+## Before Sync (or Upload)
+
+- [ ] Tested triggering on an obvious task ("create a skill" should fire `skill-writer`)
+- [ ] Tested triggering on a paraphrased request ("I need a new agent role" should also fire `skill-writer`)
+- [ ] Verified the skill does NOT trigger on unrelated topics (false-positive check)
+- [ ] Functional checks pass — the skill actually produces the documented output when invoked
+- [ ] Tool integration works (any MCP or shell command referenced in the body actually runs)
+- [ ] No orphan reference files (every file in `references/` is linked from SKILL.md or another reference)
+- [ ] Body is ≤5,000 words (or has explicit justification at the top if longer)
+
+## After Sync
+
+- [ ] Tested in real conversations, not just synthetic prompts
+- [ ] Monitored for under-triggering (skill should have fired but didn't)
+- [ ] Monitored for over-triggering (skill fired when it shouldn't have)
+- [ ] Collected feedback from real use (your own or teammates')
+- [ ] Iterated on the description first when triggering is wrong (description is the primary signal)
+- [ ] Iterated on the body when behavior-once-triggered is wrong
+- [ ] Bumped the `version` in frontmatter when shipping any user-visible change

--- a/skills/meta/skill-writer/references/validation-script-pattern.md
+++ b/skills/meta/skill-writer/references/validation-script-pattern.md
@@ -1,0 +1,75 @@
+# Validation Script Pattern
+
+Document for the "bundle a deterministic check script" pattern from Anthropic's guide (p.26, "Advanced technique"): when a skill's invariants can be expressed deterministically, bundle a script that checks them instead of relying on the model to validate in prose.
+
+## What It Is
+
+A skill bundles a script — typically `scripts/validate.sh` or `scripts/validate.py` — inside its folder that programmatically verifies the skill's invariants. The body of SKILL.md instructs the model to run the script before declaring the work done; the script exits non-zero on failure with an actionable message.
+
+This shifts validation from "the model asserts the invariant holds" to "the script proves the invariant holds". The model is no longer the judge of its own work.
+
+## When to Use It
+
+Use a validation script when the invariant can be expressed deterministically:
+
+- A specific file must exist at a specific path
+- A JSON file must conform to a JSON Schema
+- All required frontmatter fields must be present
+- A forbidden pattern (e.g., `console.log`, hardcoded secrets, `TODO`) must not appear
+- A file count or naming convention must hold
+- A generated artifact must parse / compile / lint cleanly
+
+These checks are cheap to write once and run in milliseconds, and they catch the exact class of error where prose validation has been observed to be inconsistent.
+
+## When NOT to Use It
+
+Skip the script when the check is a judgment call:
+
+- "Is the description clear?"
+- "Is this instruction well-written?"
+- "Is this design good?"
+- "Does this code feel idiomatic?"
+
+Also skip it when the check changes faster than the skill's intent — a script that needs editing every other run is just friction with extra steps.
+
+## In-Repo Example
+
+`skills/contracts/contract-auditor` uses this pattern. It bundles validation logic that programmatically verifies a generated contract (OpenAPI, AsyncAPI, Pydantic, TypeScript, JSON Schema) parses, type-checks, and conforms to the spec — rather than asking the model to read the contract and "check it looks right". Review its layout when designing your own validation script.
+
+## Skeleton
+
+Folder layout:
+
+```text
+skill-name/
+├── SKILL.md
+└── scripts/
+    └── validate.sh
+```
+
+In the SKILL.md body, link the script from the workflow steps and from the validation section:
+
+```markdown
+## Validation
+
+Before declaring done, run:
+
+\`\`\`bash
+scripts/validate.sh
+\`\`\`
+
+The script exits 0 on success and non-zero with an actionable error on failure. If it fails, fix the underlying issue and re-run — do NOT suppress or work around the script.
+```
+
+Keep the script's output terse and actionable: one line per failure, formatted as `path:line: problem` so the model can jump straight to the fix.
+
+## Failure Handling
+
+The contract with the model is one-way:
+
+- Script exits 0 → skill may declare done
+- Script exits non-zero → skill must read the error, fix the underlying issue, and re-run the script
+
+Explicitly forbid the model from suppressing the script, commenting it out, or marking the work complete despite a failure. The whole point of the pattern is that the script is the source of truth — letting the model overrule it returns you to prose-based validation with extra ceremony.
+
+If a check genuinely is too strict for a legitimate edge case, the fix is to update the script (so future runs benefit), not to skip it.

--- a/skills/workflows/deployment-checklist/SKILL.md
+++ b/skills/workflows/deployment-checklist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deployment-checklist
-version: 1.1.0
+version: 1.2.0
 description: |
   Run pre-deployment verification checklists before pushing to staging or production. Use this skill when preparing for deployment, running pre-deploy checks, verifying environment configs, or validating build artifacts. Trigger on: "pre-deploy check", "deployment checklist", "ready to ship", "is this ready for prod", "deploy readiness", "release checklist", "can we deploy", "verify the build", "pre-flight check".
 requires_agent_teams: false
@@ -49,6 +49,15 @@ Run through `references/pre-deploy.md` in order. Each section must pass before m
 5. **Database** — migrations applied, rollback tested?
 6. **Infrastructure** — Docker builds, health checks pass?
 7. **Integration** — services connect, CORS works?
+
+### Required Step Before Sign-Off
+
+After all seven sections pass, run the assumption audit — see `references/assumption-audit.md` — and resolve the most-dangerous assumption before issuing the final `READY` verdict. A clean checklist with an unexamined load-bearing assumption is still a `NOT READY`.
+
+## Reference Documents
+
+- **`references/pre-deploy.md`** — the seven-section pre-deploy checklist with commands and acceptance criteria.
+- **`references/assumption-audit.md`** — required pre-sign-off discipline that surfaces explicit and implicit assumptions, names the most-dangerous one, and defines executable tests for each implicit assumption.
 
 ## Output
 

--- a/skills/workflows/deployment-checklist/references/assumption-audit.md
+++ b/skills/workflows/deployment-checklist/references/assumption-audit.md
@@ -1,0 +1,61 @@
+# Assumption Audit
+
+A pre-sign-off discipline that surfaces every assumption baked into a deploy plan — including the invisible ones nobody thought to question. Most outages live in the assumptions nobody wrote down.
+
+## When to Use
+
+Invoke before sign-off in `deployment-checklist` — after the per-section checks pass, before the final `READY / NOT READY` verdict. Also suitable for architecture review during design phases (e.g., before contract authoring in an orchestrated build).
+
+Skip only for hotfixes where the change set is a single line and the failure mode is already understood.
+
+## The 4-Step Process
+
+Walk through these in order. Steps 2 and 3 are where the value lives — spend most of the time there.
+
+### 1. Explicit assumptions (3 bullets)
+
+List the things the plan **openly states as true**. These are stated but not necessarily proven — surface them so they can be re-examined under deploy conditions. Things like declared dependency versions, advertised SLAs, claimed migration ordering.
+
+### 2. Implicit assumptions (3 bullets)
+
+List the things the plan assumes are true **without saying so**. These are the beliefs so obvious to the author they were never written down — and so are also invisible to reviewers. Spend more time here than on explicit. Useful prompts:
+
+- What is true today that, if it changed silently, would break this plan?
+- What does the plan assume about upstream services, traffic shape, data volume, identity, or trust boundaries?
+- What does the plan assume about the *human* side — who is on call, what they know, how fast they can respond?
+
+### 3. The most-dangerous assumption (1 sentence)
+
+Name the single assumption that, **if wrong, causes the entire plan to fail.** Not the most likely to be wrong — the **most catastrophic if wrong**. These are different questions and the discipline is to answer the second one.
+
+### 4. How to test each (3 bullets)
+
+For each implicit assumption from step 2, write **one concrete way to verify it before commit**. Must be executable: a named source to query, a specific experiment to run, a specific person to ask. "Do more research" or "review the design" does not count.
+
+## Worked Example
+
+Deploy plan: "Roll out the new search service to 100% of traffic on Friday."
+
+1. **Explicit assumptions:**
+   - The search service passes all integration tests in staging.
+   - The new index is backwards-compatible with the v1 query shape.
+   - Rollback is one Helm command.
+2. **Implicit assumptions:**
+   - The upstream auth service can handle 10x its current QPS, because each search now triggers a per-request token check.
+   - Friday traffic patterns match Wednesday's load test (no weekly batch jobs hit search).
+   - The on-call rotation knows what a degraded-but-up search response looks like and will not page out at 3am.
+3. **Most-dangerous assumption:** That the upstream auth service can absorb the new per-request load — if wrong, every search degrades, every login degrades, the blast radius is the whole product.
+4. **How to test each:**
+   - Auth capacity: pull the auth service's current p99 utilization from Grafana dashboard `auth-prod-load`; if above 60%, run a shadow-traffic test before rollout.
+   - Friday traffic shape: ask the data team's on-call (Slack #data-oncall) for the Friday vs Wednesday QPS delta over the last 4 weeks.
+   - On-call readiness: walk the current primary through the new degraded-response runbook in a 15-min sync before Friday.
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails |
+|---|---|
+| Listing assumptions that are obviously safe | Pure filler — "we assume the network exists" wastes the slot a real assumption could fill |
+| Confusing "most likely to fail" with "most catastrophic if fails" | These are different questions; the discipline is specifically about blast radius, not probability |
+| Tests that aren't actually executable | "Verify with the team" is not a test; name the person, the dashboard, or the experiment |
+| Only listing technical assumptions | Human and process assumptions (who's on call, who can approve a rollback) cause as many incidents as code does |
+| Treating the audit as paperwork | If you finish without changing anything in the plan, you almost certainly skipped step 2 |

--- a/skills/workflows/plan-builder/SKILL.md
+++ b/skills/workflows/plan-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-builder
-version: 1.3.0
+version: 1.4.0
 description: |
   Transform research documents, Compass artifacts, PRDs, reference materials, and conversational goals into structured project plans ready for the orchestrator to execute. Use this skill when the user has source material and wants to build something from it, when the user says "make a plan", "plan this out", "I want to build X from this research", or when a plan is needed before invoking the orchestrator. Also trigger when @-mentioned files or attached documents accompany a build request, when the user wants to turn research into a website/app/tool, or when orchestrator would be invoked but no plan exists yet. This skill produces the plan — orchestrator consumes it.
 requires_agent_teams: false
@@ -89,6 +89,10 @@ When the user has a clear goal but no source material:
 - **Flag scale.** If the plan would require more than 6 parallel agents, suggest phasing: build the core in phase 1, extend in phase 2. Large teams need proactive context management (handoffs, phased spawning) to maintain quality.
 - **Respect existing code.** When augmenting an existing project, follow its conventions. Don't propose a React rewrite of a Vue app just because you prefer React.
 
+## Before Handoff: Long-Horizon Plans
+
+For plans affecting systems beyond roughly 30 days — product launches, pricing changes, migrations, anything with time to ripple — run the second-order-effects discipline before declaring the plan finalized. See `references/second-order-effects.md`. Document the **unintended consequence** and **feedback loop** in the plan itself (a short subsection at the end of Architecture Reasoning is the right home), so the orchestrator and downstream agents inherit that context rather than rediscovering it the hard way.
+
 ## Handoff
 
 After the plan is saved:
@@ -113,6 +117,7 @@ Wait for the user's choice. Do not auto-invoke the orchestrator.
 
 - **`references/plan-format.md`** — the section-by-section structure of the plan document (Architecture Reasoning + Build Plan, with templates for each section).
 - **`references/research-extraction.md`** — how to pull a plan out of research docs (synthesize, map to architecture, check existing code, confirm with user).
+- **`references/second-order-effects.md`** — discipline for mapping first, second, and third-order consequences plus the unintended consequence and feedback loop, for any plan affecting systems beyond ~30 days.
 
 ## Output Location
 

--- a/skills/workflows/plan-builder/references/second-order-effects.md
+++ b/skills/workflows/plan-builder/references/second-order-effects.md
@@ -1,0 +1,61 @@
+# Second-Order Effects
+
+A discipline for mapping consequences beyond the obvious first move when planning. Most planning stops at first-order effects ("we ship X, X happens") and misses the dynamics that actually determine whether the plan works in month two.
+
+## When to Use
+
+Invoke in `plan-builder` for any plan affecting systems beyond roughly 30 days — product launches, pricing changes, architectural migrations, team restructures, anything that has time to ripple. Also useful in brainstorming when stuck on first-order framing ("we'll just ship it and see").
+
+Skip for plans where the change is fully reversible within a sprint and the blast radius is one team.
+
+## The 5-Step Process
+
+Work through these in order. Steps 2 and 3 are where the leverage lives — most teams over-invest in step 1 and never reach step 5.
+
+### 1. First-order effects (3 bullets)
+
+The immediate, obvious consequences. **What everyone sees coming.** The reason someone is proposing the plan in the first place.
+
+### 2. Second-order effects (3 bullets)
+
+The consequences of the first-order effects. **What happens after what happens.** Spend more time here than on first-order. Useful prompt: "Given the first-order effect lands as expected, how do users, competitors, employees, and adjacent systems then *respond*?"
+
+### 3. Third-order effects (2 bullets)
+
+The consequences of the second-order effects. **Where things get unpredictable** — but where the surprises that kill the plan tend to live. You can't enumerate everything, so name the two effects that feel most consequential, not most likely.
+
+### 4. The unintended consequence (1 sentence)
+
+The one outcome **nobody is planning for** that is most likely to emerge from this. Must be specific. "There could be unforeseen effects" doesn't count — name the specific thing.
+
+### 5. The feedback loop (1 sentence)
+
+The dynamic where an effect circles back and **amplifies or undermines the original decision**. This is the most strategically important output of the discipline — feedback loops are why plans that look good on a whiteboard go sideways in production.
+
+## Worked Example
+
+Plan: "Add a 1,000-message-per-month cap to the free tier of our chat product."
+
+1. **First-order effects:**
+   - Revenue protection — heavy free users now hit a wall.
+   - Reduced infra cost on free-tier abuse.
+   - Cleaner conversion funnel from free → paid.
+2. **Second-order effects:**
+   - Heavy users split into two streams: a minority upgrades; the majority churns to free competitors.
+   - Power users — the loudest voice in the community — feel "punished for using the product."
+   - Support load shifts from infra complaints to billing complaints.
+3. **Third-order effects:**
+   - Community sentiment turns: the product gets labeled "the one that nickels-and-dimes you," which raises CAC for paid acquisition.
+   - The newly-paid cohort starts demanding premium features ("I'm paying now, where's the value") that didn't exist in the roadmap.
+4. **Unintended consequence:** A small group of churned power users builds an open-source competitor specifically positioned against the cap, and it gains traction precisely because the cap created a narrative anchor.
+5. **Feedback loop:** Upgraded users demand features to justify their new spend → roadmap shifts toward paid-tier feature work → free tier stagnates → free → paid conversion drops because the free tier is no longer compelling → revenue pressure increases → the team is tempted to *tighten* the cap further, deepening the loop.
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails |
+|---|---|
+| Stopping at first-order | The bias the discipline is explicitly designed to break; if your output is just "ship it, revenue goes up" you skipped steps 2–5 |
+| Listing risks instead of consequences | A risk is "this might not work"; a consequence is "if this works, here is what then happens." Risks belong in a risk register, not here |
+| Generic feedback loops not specific to this decision | "Users might react negatively" applies to every plan ever written. Name the actual loop in this product, with this user base, this quarter |
+| Treating the unintended consequence as a disclaimer | "There may be unforeseen impacts" is the absence of the discipline, not the application of it. Name a specific outcome |
+| Over-claiming certainty on third-order | These are deliberately speculative — the value is in naming candidates worth watching, not predicting the future |

--- a/skills/workflows/wiki-research/SKILL.md
+++ b/skills/workflows/wiki-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wiki-research
-version: 2.1.0
+version: 2.2.0
 description: |
   Use this skill BEFORE any codebase exploration, repo-deep-dive, or raw source reading when
   the project has an Obsidian-style wiki (index.md + wiki/ directory). Always invoke when an
@@ -91,6 +91,10 @@ After reading targeted pages, one of three situations applies:
 **Topic isn't in the wiki at all**:
 - Check `CLAUDE.md` for a source map or directory pointer
 - Proceed with targeted exploration (grep/glob first, not broad reads)
+
+## Step 5 — Synthesize Without Flattening
+
+When the output of this protocol is a summary, comparison, or write-up drawn from **3+ sources** on the same topic, run the contradiction-finding discipline before drafting — see `references/contradiction-finding.md`. The default failure mode of multi-source synthesis is silently smoothing conflicts into false consensus; this discipline forces the disagreements to stay on the page where downstream readers can see them.
 
 ## Standard Lookup Cost
 

--- a/skills/workflows/wiki-research/references/contradiction-finding.md
+++ b/skills/workflows/wiki-research/references/contradiction-finding.md
@@ -1,0 +1,56 @@
+# Contradiction-Finding Discipline
+
+A heuristic for surfacing where sources actually disagree when synthesizing research from multiple sources. Most research synthesis flattens contradictions into consensus prose; this discipline forces the conflicts to stay visible.
+
+## When to Use
+
+Invoke during wiki-research synthesis whenever you have **3 or more sources on the same topic** and you are about to write a summary, an overview page, or a comparison entry.
+
+Skip for single-source notes, raw transcripts, or pages that simply restate one document — there is nothing to triangulate.
+
+## The 5-Step Process
+
+Work through these in order. Each step has a target output size — resist expanding them. The discipline is in the compression.
+
+### 1. Surface consensus (1 sentence)
+
+State the one thing most sources agree on. If you can't compress it to a sentence, you don't actually have consensus — you have a vague topic.
+
+### 2. Name contradictions (3 bullets)
+
+Identify the three sharpest places where sources, data points, or arguments conflict. For each, name **both sides** with a short quote or paraphrase attributed to its source. No generalities — show the disagreement on the page.
+
+### 3. The weakest claim (1 bullet)
+
+Pick the single statement in the material with the least support and the highest chance of being wrong. This is often a confident assertion repeated by one source and echoed by others without verification.
+
+### 4. The real debate (1 paragraph)
+
+Describe what experts actually disagree on — the unresolved question underneath the surface dispute. The surface dispute is usually "is X good or bad"; the real debate is usually "what should we measure to decide, and whose interests does each measure serve?"
+
+### 5. Confidence verdict (1 sentence)
+
+Given the contradictions you surfaced, how confident should the reader be in the overall summary? Pick one: *high confidence*, *medium confidence — load-bearing claims contested*, or *low confidence — the field is unsettled*.
+
+## Worked Example
+
+Synthesizing 4 sources on whether the Bun runtime is production-ready:
+
+1. **Consensus:** Bun is significantly faster than Node for startup and most I/O benchmarks.
+2. **Contradictions:**
+   - Source A (vendor benchmark) reports "3x faster than Node in production workloads"; Source C (independent benchmark on real apps) reports "1.2–1.6x faster, sometimes slower under memory pressure."
+   - Source B claims "full Node.js API compatibility"; Source D documents 14 native modules that still crash or silently misbehave.
+   - Sources A and B treat the test runner as ready; Source C calls it "missing the long tail of Jest features teams actually depend on."
+3. **Weakest claim:** "Full Node.js API compatibility" — repeated everywhere, contradicted by Source D's specific failure list.
+4. **Real debate:** Not "is Bun fast" (it is) but "is Bun's compatibility surface stable enough that adopting it does not become a permanent migration tax." Performance is settled; the operational risk of edge-case incompatibility is not.
+5. **Verdict:** Medium confidence — the speed claims hold up, the compatibility claims do not, and the gap matters for any non-trivial Node port.
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails |
+|---|---|
+| Smoothing over conflicts ("sources broadly agree…") | Erases the most useful signal in the research; the disagreements are where understanding lives |
+| Strawman contradictions | Manufacturing disagreement between sources that actually agree just to fill the bullets — readers detect this immediately |
+| "More research is needed" as the real debate | Cop-out. The real debate is a *specific unresolved question*, not a generic request for more sources |
+| Burying the weakest claim in a footnote | If a claim is load-bearing and shaky, it belongs in the body so downstream readers don't build on it |
+| Listing every minor difference as a contradiction | Three sharp conflicts beat ten trivial ones; the discipline is selection, not enumeration |


### PR DESCRIPTION
## Summary

- **Stacked on top of #3** (Phase 1 spec alignment). Merge #3 first; this PR's base will retarget to `main` automatically.
- Adopts Anthropic's "Patterns & Troubleshooting" guidance as concrete in-repo references the skill-writer and skill-explorer can hand readers.
- Wires the 3 named thinking-move disciplines (`contradiction-finding`, `assumption-audit`, `second-order-effects`) from `claude_notes.txt` into existing workflow skills as references — not standalone skills.
- Skill-review now requires an explicit Should/ShouldNot trigger test block in every deep-review report, plus an optional performance-comparison output.
- Skill-writer gets the "iterate on one task first" guideline at the top of its skill-creation flow.

## Changes

**Phase 2 — Reference docs (Anthropic Agent Skills guide):**
- `skills/meta/skill-writer/references/body-template.md` (new, 90 lines) — recommended SKILL.md body structure with when-to-deviate notes
- `skills/meta/skill-writer/references/patterns.md` (new, 141 lines) — 5 emergent design patterns (sequential, multi-MCP, iterative, context-aware, domain-specific) each with an in-repo example
- `skills/meta/skill-writer/references/quick-checklist.md` (new, 45 lines) — 4-section pre-sync checklist
- `skills/meta/skill-writer/references/performance-notes-pattern.md` (new, 49 lines) — when to use `## Performance Notes` for model laziness
- `skills/meta/skill-writer/references/validation-script-pattern.md` (new, 75 lines) — when to bundle a deterministic `scripts/validate.sh`
- `skills/meta/skill-explorer/references/troubleshooting.md` (new, 117 lines) — symptom taxonomy (won't trigger, triggers too often, instructions not followed, MCP issues, large context)
- `skills/meta/skill-writer/SKILL.md` — Reference Files section lists the 5 new docs
- `skills/meta/skill-explorer/SKILL.md` — new \`## Troubleshooting Help\` H2 plus reference entry

**Phase 3 — Thinking-move disciplines (from `claude_notes.txt`):**
- `skills/workflows/wiki-research/references/contradiction-finding.md` (new, 56 lines) — surface where 3+ sources disagree, with worked example
- `skills/workflows/deployment-checklist/references/assumption-audit.md` (new, 61 lines) — pre-sign-off audit of explicit + implicit + most-dangerous assumptions
- `skills/workflows/plan-builder/references/second-order-effects.md` (new, 61 lines) — map 1st/2nd/3rd order effects + unintended consequence + feedback loop
- Each parent SKILL.md wires the new reference at the natural step (synthesis / pre-sign-off / before-handoff)

**Phase 4 — Process additions:**
- `skill-writer/SKILL.md` — adds "iterate on one task first" guideline at the top of "Creating a New Skill"
- `skill-review/SKILL.md` — Mode B deep-review now requires the explicit Should/ShouldNot trigger test block format (matches Anthropic's recommendation); adds optional B3 performance-comparison sub-phase

**Version bumps:**
- skill-writer 1.2.0 → 1.3.0
- skill-review 1.1.0 → 1.2.0
- skill-explorer 1.0.0 → 1.1.0
- wiki-research 2.1.0 → 2.2.0
- deployment-checklist 1.1.0 → 1.2.0
- plan-builder 1.3.0 → 1.4.0

## Test plan

- [ ] Spot-read \`skill-writer/references/patterns.md\` — confirm each of the 5 patterns has a real in-repo example, not vague aspirations
- [ ] Spot-read the 3 thinking-move references — each has a worked example and an anti-patterns section
- [ ] Run \`/skill-review skill-writer\` (after both PRs merge) — confirm it picks up the new references and runs the Should/ShouldNot test block format
- [ ] Confirm no inside-skill README.md violations were introduced — \`find skills -mindepth 3 -maxdepth 3 -name README.md\` should return nothing

## Follow-ups (deferred to Phase 5 sweep)

- Wire `orchestrator/references/phase-guide.md` Phase 3 (design) to invoke `deployment-checklist/references/assumption-audit.md` — currently softened to "suitable for invocation" rather than a hard wire
- `superpowers:brainstorming` is plugin-namespaced and outside this repo; can't wire it directly. `second-order-effects.md` notes it as "useful in brainstorming" rather than wired
- Phase 5 sweep: audit existing 46 skills for new spec compliance (description ≤1024, no `<`/`>`, no reserved-prefix names, hyphenated `allowed-tools`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)