### PR TITLE
chore: Migrate allowed_tools to allowed-tools and soften reserved-prefix rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ skill-name/
 └── references/           # On-demand reference files (unlimited size)
 ```
 
-All SKILL.md files use the frontmatter convention defined in `skills/meta/skill-writer/references/frontmatter-spec.md`. This spec aligns with Anthropic's official Agent Skills standard. Required fields: `name` (kebab-case, no `claude-`/`anthropic-` prefix), `version` (semver, top-level), `description` (trigger text, ≤1024 chars, no `<` or `>`). Optional Anthropic fields: `compatibility`, `license`, `allowed-tools` (hyphen canonical; `allowed_tools` accepted as alias), `metadata`. Agent roles also declare `owns`, `composes_with`, `spawned_by`.
+All SKILL.md files use the frontmatter convention defined in `skills/meta/skill-writer/references/frontmatter-spec.md`. This spec aligns with Anthropic's official Agent Skills standard. Required fields: `name` (kebab-case; `claude-*`/`anthropic-*` prefixes discouraged but allowed as documented exceptions), `version` (semver, top-level), `description` (trigger text, ≤1024 chars, no `<` or `>` in field values). Optional Anthropic fields: `compatibility`, `license`, `allowed-tools` (hyphen canonical; `allowed_tools` accepted as alias), `metadata`. Agent roles also declare `owns`, `composes_with`, `spawned_by`.
 
 ## Skill Categories
 

--- a/skills/contracts/contract-auditor/SKILL.md
+++ b/skills/contracts/contract-auditor/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Grep", "Glob", "Bash"]
+allowed-tools: ["Read", "Write", "Grep", "Glob", "Bash"]
 composes_with: ["contract-author", "qe-agent", "backend-agent", "frontend-agent"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/contracts/contract-author/SKILL.md
+++ b/skills/contracts/contract-author/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: ["contracts/", "schemas/"]
   patterns: ["openapi.yaml", "asyncapi.yaml"]
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Glob", "Grep"]
 composes_with: ["backend-agent", "frontend-agent", "contract-auditor", "qe-agent"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/git/git-commit/SKILL.md
+++ b/skills/git/git-commit/SKILL.md
@@ -16,7 +16,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Bash"]
+allowed-tools: ["Read", "Bash"]
 composes_with: ["git-pr", "git-branch-cleanup"]
 spawned_by: []
 ---

--- a/skills/git/git-post-merge-cleanup/SKILL.md
+++ b/skills/git/git-post-merge-cleanup/SKILL.md
@@ -22,7 +22,7 @@ owns:
   directories: []
   patterns: []
   shared_read: []
-allowed_tools: ["Bash", "Read", "Write"]
+allowed-tools: ["Bash", "Read", "Write"]
 composes_with: ["git-commit", "git-pr"]
 spawned_by: []
 ---

--- a/skills/git/git-pr-feedback/SKILL.md
+++ b/skills/git/git-pr-feedback/SKILL.md
@@ -17,7 +17,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Grep"]
 composes_with: ["git-pr", "git-commit"]
 spawned_by: []
 ---

--- a/skills/git/git-pr/SKILL.md
+++ b/skills/git/git-pr/SKILL.md
@@ -17,7 +17,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Bash"]
+allowed-tools: ["Read", "Bash"]
 composes_with: ["git-commit", "git-pr-feedback"]
 spawned_by: []
 ---

--- a/skills/meta/skill-explorer/SKILL.md
+++ b/skills/meta/skill-explorer/SKILL.md
@@ -20,7 +20,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["skills/"]
-allowed_tools: ["Read", "Grep", "Glob", "Bash"]
+allowed-tools: ["Read", "Grep", "Glob", "Bash"]
 composes_with: ["skill-audit", "skill-deep-review", "skill-writer"]
 spawned_by: []
 ---

--- a/skills/meta/skill-review/SKILL.md
+++ b/skills/meta/skill-review/SKILL.md
@@ -11,7 +11,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["skills/"]
-allowed_tools: ["Read", "Glob", "Grep", "Bash", "Write"]
+allowed-tools: ["Read", "Glob", "Grep", "Bash", "Write"]
 composes_with: ["skill-update", "skill-writer"]
 spawned_by: []
 ---
@@ -61,8 +61,9 @@ Optimize for speed. Score quickly, flag issues, move on. Use subagents to parall
 
 Run these check categories. Full checklist lives in `references/audit-checklist.md`.
 
-- **Frontmatter consistency** — required fields present, name matches directory and does NOT start with `claude-` or `anthropic-`, version is valid semver, description starts with action verb and is ≤200 chars
-- **Spec compliance (FAIL)** — no `<` or `>` anywhere in frontmatter (security rule); no reserved-prefix name (`claude-*` / `anthropic-*`); description ≤1024 chars (hard ceiling)
+- **Frontmatter consistency** — required fields present, name matches directory, version is valid semver, description starts with action verb and is ≤200 chars
+- **Spec compliance (FAIL)** — no `<` or `>` in frontmatter field values (security rule); description ≤1024 chars (hard ceiling)
+- **Spec compliance (WARN)** — reserved-prefix name (`claude-*` / `anthropic-*`). Acceptable as a documented exception when the skill targets the corresponding Anthropic product. Verify the documented exception exists in the skill body.
 - **Tool field naming** — `allowed-tools` (hyphen) is canonical; `allowed_tools` (underscore) accepted as deprecated alias (warn but don't fail)
 - **Ownership conflict detection** — collect every `owns.directories` and `owns.patterns` across agent roles. Flag overlaps. Validate against the v1.1 resolved conflicts table in `frontmatter-spec.md`
 - **Description quality scoring** — has action verb, ≥3 trigger contexts, keyword variants, states exclusions if ambiguous, estimated "pushiness" (low/medium/high)

--- a/skills/meta/skill-review/references/audit-checklist.md
+++ b/skills/meta/skill-review/references/audit-checklist.md
@@ -9,7 +9,7 @@ Run these for every skill in scope. In Mode A (bulk) they roll up to PASS / WARN
 ### Frontmatter
 
 - [ ] `name` field present, kebab-case, ≤64 chars
-- [ ] `name` does NOT start with `claude-` or `anthropic-` (reserved by Anthropic) — **FAIL**
+- [ ] `name` starting with `claude-` or `anthropic-` (reserved by Anthropic) — **WARN**, not FAIL. Acceptable when the skill targets the corresponding Anthropic product and the exception is documented in the skill body (e.g., `claude-design-brief` for Claude Design). Confirm the documented exception exists before clearing the warning.
 - [ ] `name` matches the directory name
 - [ ] `version` field present (top-level), valid semver
 - [ ] `description` field present

--- a/skills/meta/skill-review/references/deep-review-rubric.md
+++ b/skills/meta/skill-review/references/deep-review-rubric.md
@@ -24,7 +24,7 @@ Scoring criteria for each dimension evaluated in Mode B (`--scope=<skill-name>`)
 
 Check:
 
-- `name`: kebab-case, ≤64 chars, unique across ecosystem, no `claude-` / `anthropic-` prefix
+- `name`: kebab-case, ≤64 chars, unique across ecosystem. `claude-` / `anthropic-` prefixes trigger a WARN (not FAIL); acceptable when the skill targets the corresponding Anthropic product and documents the exception.
 - No `<` or `>` anywhere in the frontmatter block
 - `version`: valid semver (X.Y.Z), top-level
 - `description`: present, multiline YAML string, ≤1024 chars

--- a/skills/meta/skill-update/SKILL.md
+++ b/skills/meta/skill-update/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: ["skills/"]
   patterns: []
   shared_read: []
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 composes_with: ["skill-review", "skill-writer", "sync-skills"]
 spawned_by: []
 ---

--- a/skills/meta/skill-update/references/validation-checklist.md
+++ b/skills/meta/skill-update/references/validation-checklist.md
@@ -10,7 +10,7 @@ For every SKILL.md modified in the pass:
 
 - [ ] YAML parses cleanly (no tab/space mix, no unclosed quotes)
 - [ ] Field order matches house style: `name`, `version`, `description`, `compatibility`, `license`, `allowed-tools`, `metadata`, `requires_agent_teams`, `requires_claude_code`, `min_plan`, `owns`, `composes_with`, `spawned_by`
-- [ ] `name` is kebab-case, ≤64 chars, unique across the ecosystem, does NOT start with `claude-` or `anthropic-`
+- [ ] `name` is kebab-case, ≤64 chars, unique across the ecosystem. `claude-*` / `anthropic-*` names are discouraged (reserved by Anthropic) but acceptable as a documented exception when the skill targets the corresponding Anthropic product.
 - [ ] No `<` or `>` anywhere in the frontmatter block (security rule)
 - [ ] `version` is valid semver — bump MINOR for new behavior, PATCH for fixes, MAJOR for breaks
 - [ ] `description` includes at least one action verb and one trigger phrase

--- a/skills/meta/skill-writer/SKILL.md
+++ b/skills/meta/skill-writer/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: []
   shared_read: []
-allowed_tools: ["Read", "Write", "Edit", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Glob", "Grep"]
 composes_with: ["project-profiler", "orchestrator"]
 spawned_by: []
 ---
@@ -64,7 +64,7 @@ Every SKILL.md starts with YAML frontmatter. See `references/frontmatter-spec.md
 
 Required fields:
 
-- `name` — kebab-case, max 64 chars, must NOT start with `claude-` or `anthropic-` (reserved)
+- `name` — kebab-case, max 64 chars. `claude-*` / `anthropic-*` prefixes are reserved by Anthropic; use them only as a documented exception when the skill targets the corresponding Anthropic product (e.g., `claude-design-brief`).
 - `version` — semver (start at 1.0.0), top-level
 - `description` — `[What] + [When] + [Capabilities]` anatomy (≤200 chars target, 1024 hard ceiling)
 
@@ -107,7 +107,7 @@ before reporting done.
 ### Step 5: Validate the Skill
 
 - [ ] Frontmatter has all required fields
-- [ ] `name` is kebab-case and does NOT start with `claude-` or `anthropic-`
+- [ ] `name` is kebab-case. If it starts with `claude-` or `anthropic-`, that's a documented exception (skill targets the corresponding Anthropic product)
 - [ ] No `<` or `>` anywhere in frontmatter
 - [ ] Description is ≤200 chars (target) and "pushy"; never exceeds 1024 chars (ceiling)
 - [ ] Body is ≤5,000 words (soft warning past 500 lines)

--- a/skills/meta/skill-writer/references/frontmatter-spec.md
+++ b/skills/meta/skill-writer/references/frontmatter-spec.md
@@ -43,7 +43,7 @@ spawned_by: ["orchestrator"]
 - **Type:** string
 - **Format:** kebab-case (lowercase, hyphens). No spaces, no capitals, no underscores.
 - **Max length:** 64 characters
-- **Reserved prefixes:** must not start with `claude-` or `anthropic-` — reserved by Anthropic for first-party skills
+- **Reserved prefixes:** should not start with `claude-` or `anthropic-` — reserved by Anthropic for first-party skills. **Exception:** skills that explicitly target an Anthropic product or feature (e.g., `claude-design-brief` for Claude's design canvas) may use the prefix when the name precisely describes the target. Document the exception in the skill body so future maintainers know it's intentional. `skill-review` WARNs on this pattern; it does not FAIL.
 - **Must match** the skill folder name
 - **Must be unique** across the ecosystem
 - **Examples:** `backend-agent`, `contract-author`, `skill-writer`
@@ -166,9 +166,12 @@ This repo's extensions for orchestrated builds. Not part of Anthropic's spec; pa
 
 These rules come from Anthropic's spec. `skill-review` enforces them.
 
-- **XML angle brackets `<` and `>`** anywhere in the frontmatter — security risk, since frontmatter loads into Claude's system prompt
-- **Names starting with `claude-` or `anthropic-`** — reserved by Anthropic for first-party skills
+- **XML angle brackets `<` and `>`** in field values — security risk, since frontmatter loads into Claude's system prompt. (YAML scalar style markers like `description: >` are structural and not affected by this rule.)
 - **Code execution in YAML** — parsers use safe-YAML; tagged Python objects and similar constructs will fail to parse
+
+## Discouraged in Frontmatter
+
+- **Names starting with `claude-` or `anthropic-`** — reserved by Anthropic for first-party skills; using these prefixes risks collision if Anthropic ships a first-party skill with the same name. Acceptable as a documented exception when the skill targets the corresponding Anthropic product (e.g., `claude-design-brief` for Claude Design). `skill-review` WARNs on this pattern; it does not FAIL.
 
 ## Body Length Guidance
 
@@ -215,7 +218,7 @@ When declaring `owns`, follow these precedence rules:
 
 `skill-review` enforces these.
 
-1. `name` is kebab-case, ≤64 chars, unique, and does NOT start with `claude-` or `anthropic-`
+1. `name` is kebab-case, ≤64 chars, and unique. Names starting with `claude-` or `anthropic-` trigger a WARN (not a FAIL) — acceptable when the skill targets the corresponding Anthropic product and the exception is documented in the skill body.
 2. `version` is valid semver (top-level or under `metadata`)
 3. `description` is present, ≤1024 chars, contains no `<` or `>`
 4. No `<` or `>` anywhere in frontmatter

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: [".gitignore"]
   shared_read: ["contracts/", ".claude/handoffs/"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: [
   "wiki-research", "llm-wiki", "repo-deep-dive",
   "brainstorming", "plan-builder", "writing-plans",

--- a/skills/roles/backend-agent/SKILL.md
+++ b/skills/roles/backend-agent/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: ["src/api/", "src/services/", "src/models/", "src/middleware/", "src/utils/"]
   patterns: []
   shared_read: ["contracts/", "shared/", "src/types/"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: ["frontend-agent", "qe-agent", "infrastructure-agent", "contract-author", "db-migration-agent", "observability-agent"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/roles/code-review-agent/SKILL.md
+++ b/skills/roles/code-review-agent/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Read", "Write", "Grep", "Glob"]
 composes_with: ["wiki-research", "qe-agent", "security-agent", "backend-agent", "frontend-agent"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/roles/db-migration-agent/SKILL.md
+++ b/skills/roles/db-migration-agent/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: ["migrations/", "seeds/", "prisma/", "alembic/"]
   patterns: []
   shared_read: ["src/models/"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: ["backend-agent", "infrastructure-agent", "qe-agent"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/roles/docs-agent/SKILL.md
+++ b/skills/roles/docs-agent/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: ["docs/"]
   patterns: ["README.md", "CHANGELOG.md", "CONTRIBUTING.md"]
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Glob", "Grep"]
 composes_with: ["backend-agent", "frontend-agent", "infrastructure-agent", "mermaid-charts", "contract-author"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/roles/frontend-agent/SKILL.md
+++ b/skills/roles/frontend-agent/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: ["src/components/", "src/pages/", "src/hooks/", "src/styles/", "public/"]
   patterns: ["*.tsx", "*.jsx", "*.vue", "*.svelte", "*.css"]
   shared_read: ["contracts/", "shared/", "src/types/", "assets/"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: ["backend-agent", "qe-agent", "infrastructure-agent", "contract-author", "frontend-design", "ui-ux-pro-max", "ui-brief", "nano-banana"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/roles/infrastructure-agent/SKILL.md
+++ b/skills/roles/infrastructure-agent/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: [".github/workflows/", "nginx/", "k8s/", "terraform/", "scripts/deploy/"]
   patterns: ["Dockerfile*", "docker-compose*", "Makefile", "justfile"]
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: ["backend-agent", "frontend-agent", "qe-agent", "deployment-checklist", "observability-agent"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/roles/observability-agent/SKILL.md
+++ b/skills/roles/observability-agent/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: ["src/telemetry/", "src/logging/", "monitoring/", "alerts/"]
   patterns: []
   shared_read: ["src/"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: ["backend-agent", "infrastructure-agent", "frontend-agent"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/roles/performance-agent/SKILL.md
+++ b/skills/roles/performance-agent/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: ["tests/performance/", "load-tests/"]
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: ["backend-agent", "infrastructure-agent", "qe-agent"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/roles/qe-agent/SKILL.md
+++ b/skills/roles/qe-agent/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: ["tests/", "e2e/", "__tests__/"]
   patterns: ["*.test.*", "*.spec.*", "qa-report.md", "qa-report.json"]
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: ["backend-agent", "frontend-agent", "infrastructure-agent", "security-agent", "contract-auditor", "performance-agent", "playwright"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/roles/security-agent/SKILL.md
+++ b/skills/roles/security-agent/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: [".github/security/"]
   patterns: ["SECURITY.md"]
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Grep", "Glob", "Bash"]
+allowed-tools: ["Read", "Write", "Grep", "Glob", "Bash"]
 composes_with: ["backend-agent", "frontend-agent", "qe-agent", "code-review-agent", "infrastructure-agent"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/workflows/architecture-rescue/SKILL.md
+++ b/skills/workflows/architecture-rescue/SKILL.md
@@ -9,7 +9,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Grep", "Glob", "Write"]
+allowed-tools: ["Read", "Grep", "Glob", "Write"]
 composes_with: ["grill-me", "maintain-context", "diagnose-loop"]
 spawned_by: []
 ---

--- a/skills/workflows/caveman/SKILL.md
+++ b/skills/workflows/caveman/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: []
   shared_read: []
-allowed_tools: []
+allowed-tools: []
 composes_with: []
 spawned_by: []
 ---

--- a/skills/workflows/claude-design-brief/SKILL.md
+++ b/skills/workflows/claude-design-brief/SKILL.md
@@ -10,12 +10,14 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]
+allowed-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]
 composes_with: ["ui-brief", "ui-ux-pro-max", "frontend-design", "brainstorming"]
 spawned_by: []
 ---
 
 # Claude Design Brief
+
+> **Naming exception:** This skill's name starts with `claude-` — a prefix Anthropic reserves for first-party skills. Kept deliberately: the skill targets **Claude Design** specifically, and a name that doesn't say "claude" would be less discoverable. Per `skills/meta/skill-writer/references/frontmatter-spec.md`, `skill-review` WARNs but does not FAIL on this pattern when the skill genuinely targets the corresponding Anthropic product.
 
 Produce paste-ready prompts for **Claude Design** (the artifact/design-canvas tool at claude.ai) that are vivid and project-specific enough that Claude Design has nothing left to ask — it opens its canvas and starts drawing on the first message.
 

--- a/skills/workflows/context-manager/SKILL.md
+++ b/skills/workflows/context-manager/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: [".claude/handoffs/"]
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob"]
 composes_with: ["orchestrator"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/workflows/deployment-checklist/SKILL.md
+++ b/skills/workflows/deployment-checklist/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Bash", "Glob", "Grep"]
 composes_with: ["infrastructure-agent", "qe-agent", "security-agent", "observability-agent"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/workflows/diagnose-loop/SKILL.md
+++ b/skills/workflows/diagnose-loop/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: []
   shared_read: []
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 composes_with: ["playwright", "qe-agent"]
 spawned_by: []
 ---

--- a/skills/workflows/grill-me/SKILL.md
+++ b/skills/workflows/grill-me/SKILL.md
@@ -9,7 +9,7 @@ owns:
   directories: []
   patterns: []
   shared_read: []
-allowed_tools: ["Read", "Grep", "Glob"]
+allowed-tools: ["Read", "Grep", "Glob"]
 composes_with: ["architecture-rescue", "maintain-context", "plan-builder"]
 spawned_by: []
 ---

--- a/skills/workflows/llm-wiki/SKILL.md
+++ b/skills/workflows/llm-wiki/SKILL.md
@@ -19,7 +19,7 @@ owns:
   directories: []
   patterns: ["index.md", "log.md", "overview.md"]
   shared_read: ["raw/", "wiki/"]
-allowed_tools: ["Read", "Write", "Edit", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Glob", "Grep"]
 composes_with: ["wiki-research", "repo-deep-dive", "project-profiler", "mermaid-charts"]
 spawned_by: []
 ---

--- a/skills/workflows/maintain-context/SKILL.md
+++ b/skills/workflows/maintain-context/SKILL.md
@@ -9,7 +9,7 @@ owns:
   directories: []
   patterns: ["CONTEXT.md", "docs/adr/**"]
   shared_read: []
-allowed_tools: ["Read", "Write", "Edit", "Grep", "Glob"]
+allowed-tools: ["Read", "Write", "Edit", "Grep", "Glob"]
 composes_with: ["grill-me", "architecture-rescue"]
 spawned_by: []
 ---

--- a/skills/workflows/mermaid-charts/SKILL.md
+++ b/skills/workflows/mermaid-charts/SKILL.md
@@ -20,7 +20,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Glob", "Grep"]
 composes_with:
   - docs-agent
   - backend-agent

--- a/skills/workflows/nano-banana/SKILL.md
+++ b/skills/workflows/nano-banana/SKILL.md
@@ -15,7 +15,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: ["frontend-agent", "docs-agent"]
 spawned_by: []
 ---

--- a/skills/workflows/plan-builder/SKILL.md
+++ b/skills/workflows/plan-builder/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Glob", "Grep"]
 composes_with: ["orchestrator", "project-profiler", "mermaid-charts", "contract-author"]
 spawned_by: []
 ---

--- a/skills/workflows/playwright/SKILL.md
+++ b/skills/workflows/playwright/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: ["qe-agent", "frontend-agent", "deployment-checklist"]
 spawned_by: ["orchestrator", "qe-agent"]
 ---

--- a/skills/workflows/project-profiler/SKILL.md
+++ b/skills/workflows/project-profiler/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: ["CLAUDE.md", ".claude/profile.yaml"]
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: ["skill-writer", "contract-author", "orchestrator"]
 spawned_by: ["orchestrator"]
 ---

--- a/skills/workflows/railway-deploy/SKILL.md
+++ b/skills/workflows/railway-deploy/SKILL.md
@@ -15,7 +15,7 @@ owns:
   directories: []
   patterns: ["railway.toml"]
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: ["infrastructure-agent", "deployment-checklist"]
 spawned_by: []
 ---

--- a/skills/workflows/render-sanity/SKILL.md
+++ b/skills/workflows/render-sanity/SKILL.md
@@ -4,7 +4,7 @@ version: 1.0.0
 description: |
   Catch the failure modes that pass a "tests green + dev server boots + 0 console errors" gate but visibly break the app when a human clicks around — stale mock IDs leaking into "live" pages, lone `?` / `—` / `undefined` / `Loading…` text where real data should be, repeated generic-fallback labels (the default string a component renders when its data prop is missing) appearing across rows that should show distinct content, "Couldn't load X" / "Unauthorized" / "Failed to fetch" dead-end shells on auth-gated routes, and lists that render plausibly but link to dead targets. Use this skill whenever a build is wrapping up and someone is about to claim "the UI works" without having clicked through it as a real user; whenever ux-review or qe-agent finishes its screenshot/contract pass; whenever the user says "is it actually working", "did anyone click around", "fix the app", "broken pages", "dead links", or after they paste a screenshot showing visible garbage like `?`, `—`, `undefined`, `null`, or a "Not found" detail page. Triggers BEFORE the build is declared done, not after the user finds the bug themselves. Also invoke proactively when a frontend agent has just rewired data sources from mocks → real backend, when auth was added to previously-public routes, when seed data was regenerated, or when a previously-broken page was "fixed" without a click-through verification.
 requires_claude_code: true
-allowed_tools: ["Read", "Bash", "Glob", "Grep",
+allowed-tools: ["Read", "Bash", "Glob", "Grep",
   "mcp__plugin_playwright_playwright__browser_navigate",
   "mcp__plugin_playwright_playwright__browser_snapshot",
   "mcp__plugin_playwright_playwright__browser_click",

--- a/skills/workflows/repo-deep-dive/SKILL.md
+++ b/skills/workflows/repo-deep-dive/SKILL.md
@@ -18,7 +18,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "Agent"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "Agent"]
 composes_with: ["project-profiler", "plan-builder", "mermaid-charts", "wiki-research", "llm-wiki"]
 spawned_by: []
 ---

--- a/skills/workflows/settings-consolidator/SKILL.md
+++ b/skills/workflows/settings-consolidator/SKILL.md
@@ -21,7 +21,7 @@ owns:
   directories: []
   patterns: ["settings.local.json"]
   shared_read: ["~/.claude/", "**/.claude/"]
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Glob"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob"]
 composes_with: ["sync-skills"]
 spawned_by: []
 ---

--- a/skills/workflows/setup-project-skills/SKILL.md
+++ b/skills/workflows/setup-project-skills/SKILL.md
@@ -11,7 +11,7 @@ owns:
   directories: ["docs/agents/"]
   patterns: []
   shared_read: []
-allowed_tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 composes_with: ["project-profiler", "sync-skills"]
 spawned_by: []
 ---

--- a/skills/workflows/sync-skills/SKILL.md
+++ b/skills/workflows/sync-skills/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: ["skills/workflows/sync-skills/"]
   patterns: []
   shared_read: ["skills/"]
-allowed_tools: ["Read", "Bash"]
+allowed-tools: ["Read", "Bash"]
 composes_with: ["skill-updater", "skill-audit"]
 spawned_by: []
 ---

--- a/skills/workflows/ui-brief/SKILL.md
+++ b/skills/workflows/ui-brief/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]
+allowed-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]
 composes_with: ["ui-ux-pro-max", "frontend-design", "frontend-agent", "orchestrator", "ux-review", "playwright", "brainstorming"]
 spawned_by: []
 ---

--- a/skills/workflows/wiki-research/SKILL.md
+++ b/skills/workflows/wiki-research/SKILL.md
@@ -19,7 +19,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["wiki/", "index.md"]
-allowed_tools: ["Read", "Glob", "Grep"]
+allowed-tools: ["Read", "Glob", "Grep"]
 composes_with: ["repo-deep-dive", "llm-wiki", "project-profiler"]
 spawned_by: ["orchestrator", "code-review-agent", "repo-deep-dive", "project-profiler", "backend-agent", "frontend-agent", "security-agent", "plan-builder"]
 ---

--- a/skills/workflows/work-item-brief/SKILL.md
+++ b/skills/workflows/work-item-brief/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: ["briefs/**/*.md"]
   shared_read: []
-allowed_tools: ["Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Read", "Write", "Grep", "Glob"]
 composes_with: ["grill-me", "plan-builder", "contract-author"]
 spawned_by: []
 ---

--- a/skills/workflows/zoom-out/SKILL.md
+++ b/skills/workflows/zoom-out/SKILL.md
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-allowed_tools: ["Read", "Grep", "Glob"]
+allowed-tools: ["Read", "Grep", "Glob"]
 composes_with: ["maintain-context"]
 spawned_by: []
 ---


### PR DESCRIPTION
## Summary

- **Phase 5 of the IMPROVEMENT_PLAN.md cycle** — bulk spec-compliance pass.
- Migrates all 45 publishable SKILL.md files from `allowed_tools` (underscore, deprecated alias) to `allowed-tools` (hyphen, Anthropic canonical form). No behavior change.
- Softens the reserved-prefix rule (`claude-*` / `anthropic-*`) from a hard FAIL to a WARN-with-documented-exception. Anthropic reserves these prefixes for first-party skills, but legitimate exceptions exist when a skill genuinely targets the corresponding Anthropic product.
- `claude-design-brief` (targeting Claude's design canvas) is kept by deliberate exception; its skill body now documents why.
- No version bumps on the bulk-migrated skills since the migration is a no-op rename to the canonical form.

## Changes

**Spec rule softening (8 docs):**
- `skills/meta/skill-writer/references/frontmatter-spec.md` — `name` section, `Forbidden in Frontmatter` section (now split into Forbidden + Discouraged), Validation Rules
- `skills/meta/skill-review/SKILL.md` — Spec compliance check now split into FAIL (`<`/`>` in field values, description >1024) and WARN (reserved prefix)
- `skills/meta/skill-review/references/audit-checklist.md`
- `skills/meta/skill-review/references/deep-review-rubric.md`
- `skills/meta/skill-update/references/validation-checklist.md`
- `skills/meta/skill-writer/SKILL.md` — `name` rules + checklist
- `CLAUDE.md` — top-level project doc reflects the new exception model

**Documented exception:**
- `skills/workflows/claude-design-brief/SKILL.md` — adds a "Naming exception" callout at the top of the body explaining the deliberate use of the `claude-` prefix

**Bulk migration (45 SKILL.md files):**
- All publishable skills migrated from `allowed_tools:` to `allowed-tools:` via a single deterministic sed pass. Spans `roles/`, `workflows/`, `contracts/`, `git/`, `meta/`, `orchestrator/`. The underscore form is still accepted as a deprecated alias per the Phase 1 spec, but new skills should use the hyphenated form and existing skills are now consistent.

## Test plan

- [ ] Verify zero remaining `^allowed_tools:` in publishable skills: \`grep -rE '^allowed_tools:' skills/ | grep -v archive | grep -v in-progress\` should return nothing
- [ ] Verify 45 skills now use the hyphenated form: \`grep -lE '^allowed-tools:' skills/**/SKILL.md skills/**/**/SKILL.md | sort -u | wc -l\`
- [ ] Confirm `claude-design-brief` still loads (skill body has the documented exception callout)
- [ ] Spot-read `frontmatter-spec.md` — confirm the Forbidden vs Discouraged split reads naturally
- [ ] Run \`/skill-review claude-design-brief\` (after merge) — confirm it WARNs but does not FAIL

## Conflict notes

This PR will conflict with **PR #4** (still open) on 6 files: `skill-writer/SKILL.md`, `skill-review/SKILL.md`, `skill-explorer/SKILL.md`, `wiki-research/SKILL.md`, `deployment-checklist/SKILL.md`, `plan-builder/SKILL.md`.

Cleanest merge order:
1. Merge #4 first (Phase 2-4, larger PR)
2. Merge #5 (acknowledgments, independent)
3. Rebase this PR against main, resolve conflicts (mostly trivial — `allowed_tools` → `allowed-tools` on one line each), merge

Each conflict is mechanical (a single line change). Resolution is "keep #4's added body content, change `allowed_tools` to `allowed-tools` in the frontmatter."

## What this closes out

This is the final phase of the `IMPROVEMENT_PLAN.md` cycle that began with Anthropic's "Complete Guide to Building Skills for Claude" PDF review. All 5 phases now have landed PRs:

- Phase 1: spec alignment (PR #3, MERGED)
- Phase 2: reference docs (PR #4, OPEN)
- Phase 3: thinking-move disciplines (PR #4, OPEN)
- Phase 4: process additions (PR #4, OPEN)
- Phase 5: spec compliance sweep (this PR)
- Acknowledgments: Anthropic credit (PR #5, OPEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)