### PR TITLE
feat: Publish Portable Skill Frontmatter Spec (PSFS) v1.1.0

### DIFF
--- a/.github/workflows/lint-skills.yml
+++ b/.github/workflows/lint-skills.yml
@@ -145,6 +145,46 @@ jobs:
       - name: Run scan-skills bats suite
         run: bats tests/scan-skills
 
+  # Frontmatter standard (P3): enforce the Portable Skill Frontmatter Spec
+  # (PSFS) as a real gate. The main lint job's schema cross-check degrades to
+  # an advisory when jsonschema is absent — this job installs it so the
+  # portable schema validates the whole tree authoritatively. Static commands
+  # only; no GitHub event input.
+  standard-ubuntu:
+    name: Frontmatter Standard / PSFS (Ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Verify python3
+        run: python3 --version
+
+      # The portable reference validator needs jsonschema; pyyaml parses the
+      # frontmatter. --break-system-packages is required on PEP 668 Pythons.
+      - name: Install jsonschema + pyyaml
+        run: python3 -m pip install --user --break-system-packages jsonschema pyyaml
+
+      - name: Install bats-core
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y bats
+
+      # Bind: the bash reference implementation reports the standard it serves.
+      - name: Report standard binding
+        run: scripts/lint-skills.sh --standard
+
+      # Authoritative gate: every real SKILL.md must validate against the
+      # portable schema. With jsonschema installed, lint-skills.sh runs the
+      # schema cross-check inline and fails on any structural violation.
+      - name: Lint with schema enforcement
+        run: scripts/lint-skills.sh skills/
+
+      # Behavioral suite: --standard output, schema well-formedness, the
+      # real-tree gate, and the positive/negative fixtures.
+      - name: Run frontmatter-standard bats suite
+        run: bash tests/standard/run-tests.sh
+
   # Smoke-check on macOS to catch bash 3.2 compatibility quirks.
   # Not a merge gate — continue-on-error prevents macOS-only failures
   # from blocking PRs authored on Linux/Windows.

--- a/BUILD_RESULTS.md
+++ b/BUILD_RESULTS.md
@@ -1,10 +1,10 @@
-# Build Results — AllTheSkills P0 + P1 + P2
+# Build Results — AllTheSkills P0 + P1 + P2 + P3
 
-**Date:** 2026-05-24 · **Orchestrated build** · **Status: P0 + P1 + P2 COMPLETE (all QA gates PASS), uncommitted**
-**Plan:** `DeepResearch/The-Hive/ecc_deepdive/source-material/14-alltheskills-frontier.md` → P0
-**Contract:** `contracts/hooks/hooks-layer.md` v1.0.0
+**Date:** 2026-05-24 · **Orchestrated build** · **Status: P0–P3 COMPLETE (all QA gates PASS)**
+**Plan:** `DeepResearch/The-Hive/ecc_deepdive/source-material/14-alltheskills-frontier.md`
+**Contracts:** `contracts/hooks/hooks-layer.md`, `contracts/installer/*`, `contracts/standards/psfs.md`
 
-> ⚠️ **Nothing is committed.** The user was remote and could not approve Touch ID / GitHub commit-or-branch signing, so the build ran with a hard "no git writes" constraint. All changes are uncommitted working-tree edits on `main`. Review and commit when ready.
+> **P0–P2 merged** as PR #8 (`93a55ad`) into `main`. **P3** is on branch `feat/psfs-frontmatter-standard` (this build) — not yet committed; review and commit when ready.
 
 ## What shipped (P0)
 
@@ -121,8 +121,34 @@ Added an additive blocking `security-ubuntu` job (`scan-skills.sh --check skills
 
 ---
 
-## Deferred (P3 — not built this session)
-- **P3** — publish the AllTheSkills frontmatter spec (`skills/meta/skill-writer/references/frontmatter-spec.md`) as a named standard with the lint rules as its reference validator, so other collections (incl. ECC) can converge on it.
+## P3 — Publish the frontmatter standard (DONE — branch `feat/psfs-frontmatter-standard`)
+
+Published the frontmatter convention as the **Portable Skill Frontmatter Spec (PSFS) v1.1.0**, turning a local convention into a portable, vendor-neutral standard other collections (incl. ECC, which is Node) can validate against in any language.
+
+### What shipped
+- `spec/PSFS.md` — the named, versioned standard. Two conformance tiers: **Core** (Anthropic-aligned, vendor-neutral) and **Extended** (Core + multi-agent fields). RFC-2119 normative language; names both reference validators; relationship-to-Anthropic-spec section.
+- `spec/frontmatter.schema.json` — **JSON Schema 2020-12**, the canonical portable validator. Per-file structure only (required fields, kebab-case `name`, semver `version`, ≤1024 desc, `^[^<>]*$` angle-bracket prohibition on every constrained string, `min_plan` enum, typed `owns`/`composes_with`/`spawned_by`). `additionalProperties: false` — validates all 47 real skills clean with zero added fields.
+- `scripts/lint-skills.sh` (additive) — `--standard` flag reports the PSFS binding + schema path; optional inline schema cross-check (ERROR on violation when `jsonschema` present, single WARN advisory when absent, mirroring the pyyaml pattern). No regression — `bash -n` clean, `lint-skills.sh skills/` still exits 0.
+- `tests/standard/` — 12 bats (all pass, 0 skip here): `--standard` output, schema well-formedness + `check_schema`, the real-tree gate (47 skills, 0 failures), positive/negative fixtures, lint regression.
+- `contracts/standards/psfs.md` — the P3 contract.
+- `contracts/installer/lint-rules.md` → **1.2.0**, bound to PSFS v1.1.0 (schema = portable validator, lint-skills.sh = bash reference impl).
+- `.github/workflows/lint-skills.yml` — new **Frontmatter Standard / PSFS (Ubuntu)** job that installs `jsonschema`+`pyyaml` and enforces the schema as a real gate (the main lint job degrades schema-check to advisory when jsonschema is absent).
+- `README.md` — new "Frontmatter standard — PSFS v1.1.0" subsection + `--standard` usage line.
+
+### Post-review bump (PSFS 1.0.0 → 1.1.0)
+After a spec review, `spec/PSFS.md` was bumped **1.0.0 → 1.1.0** (MINOR — new normative surface, fully backward-compatible: no field added/removed, no constraint changed). Added Parser Requirements (Core parsers MUST ignore unrecognized keys; `allowed-tools` wins over the deprecated `allowed_tools`), the angle-bracket threat model + intentional-strictness note, Skill Versioning and Spec Versioning sections, the `owns` object shape + ownership-resolution order, Core/Extended worked examples (both schema-validated), and scoped `name` uniqueness to the collection. Version bumped in lockstep across the doc, schema `title`/`description`, `lint-skills.sh` `PSFS_VERSION`, the `tests/standard` assertion, `lint-rules.md`, the `frontmatter-spec.md` pointer, and README. The build contract `contracts/standards/psfs.md` is left at its as-built 1.0.0 (historical record of the initial publication).
+
+A **second review pass** (also folded into 1.1.0, since it was still unreleased) turned two doc claims into enforced behavior: (1) the angle-bracket rule is now an always-on ERROR over the **whole** parsed frontmatter — `<`/`>` in any string value or key at any depth, including nested `metadata` (previously only schema-patterned typed fields, and only when `jsonschema` was present); (2) `composes_with`/`spawned_by` resolution now **excludes** plugin-namespaced (`plugin:name`) refs from the broken-reference WARN (they're external) — this dropped the tree's lint warnings 111 → 98. Spec also gained: tool-agnostic phrasing of ownership-resolution rule 3, a Reference-resolution rule, a "broadening `owns` is breaking" note, and a README-conformance-claim SHOULD (machine-readable manifest deferred). `lint-rules.md` → **1.3.0**. `tests/standard` → **14 tests** (+2 linter-behavior regressions). Real tree still exit 0.
+- `coordination/p3-qa-report.json` — QE gate **PASS** (contract_conformance 5, security 5, correctness 5, completeness 5, code_quality 5; self-validates against the qa-report schema + `qa-gate-validate.py` exit 0).
+
+### Verification (run by lead at the wave gate + QE, independently)
+- `scripts/lint-skills.sh --standard` → `Portable Skill Frontmatter Spec (PSFS) v1.1.0` + schema path, exit 0.
+- `scripts/lint-skills.sh skills/` → exit 0 (0 errors, 111 pre-existing advisory WARNs).
+- `bash tests/standard/run-tests.sh` → 12/12 pass.
+- Direct jsonschema pass over the tree → 47 skills, 0 failures. Schema passes `Draft202012Validator.check_schema`.
+
+### P3 issues (INFO — non-gating)
+- P3-I1 — 111 lint WARNs are pre-existing (long "pushy" descriptions, optional `owns`/`allowed_tools` on some role skills, plugin-external `composes_with`); 0 errors, unrelated to P3.
 
 ## Handoff for the user (when home)
 1. **Review the diff, then commit** (signing will prompt Touch ID): the additive edits to `convert.sh`/`install.sh`/`lint-skills.yml`/`README.md` + the new `hooks/`, `scripts/lint-hooks.sh`, `tests/hooks/`, `contracts/hooks/`, `coordination/`. Your earlier `skills/workflows/repo-deep-dive/` changes are also still uncommitted and unrelated — commit separately if you like.

--- a/README.md
+++ b/README.md
@@ -417,7 +417,12 @@ Outputs JUnit XML for GitHub Actions test results.
 ```bash
 ./scripts/lint-skills.sh                 # full lint
 ./scripts/lint-skills.sh --skill orchestrator  # one skill
+./scripts/lint-skills.sh --standard      # report the frontmatter standard it validates
 ```
+
+### Frontmatter standard — PSFS v1.1.0
+
+The frontmatter convention is published as a named, versioned standard: the **Portable Skill Frontmatter Spec (PSFS) v1.1.0** at [`spec/PSFS.md`](spec/PSFS.md). It defines two conformance tiers — **Core** (Anthropic-aligned, vendor-neutral; the tier any collection can adopt) and **Extended** (Core plus the multi-agent fields `owns` / `composes_with` / `spawned_by` / `requires_*`). The portable, tool-agnostic reference validator is [`spec/frontmatter.schema.json`](spec/frontmatter.schema.json) (JSON Schema 2020-12 — runnable in any language); `scripts/lint-skills.sh` is the bash reference implementation and adds the cross-file checks (name uniqueness, name-matches-directory, `owns` non-overlap) that a per-file schema can't express.
 
 ### `/sync-skills` (Claude Code slash command)
 

--- a/contracts/installer/lint-rules.md
+++ b/contracts/installer/lint-rules.md
@@ -1,18 +1,21 @@
 # Contract: Lint Rules
 
 **Build:** Multi-Tool Installer (Slice A)
-**Version:** 1.1.0
+**Version:** 1.3.0
 **Owner:** orchestrator (authored Phase 4)
 **Consumed by:** scripts-agent (lint-skills.sh), infrastructure-agent (CI workflow), qe-agent (lint test fixtures)
+**Conforms to:** Portable Skill Frontmatter Spec (PSFS) v1.1.0 — `spec/PSFS.md`
 
 **Changelog:**
+- 1.3.0 — Made the PSFS angle-bracket rule a real, always-on gate: `<`/`>` in **any** frontmatter string value or key, at any depth (including inside the free-form `metadata` object), is an ERROR (see Frontmatter Safety below). Previously this was only enforced via the schema pattern on named typed fields and only when `jsonschema` was installed; the linter now walks the whole parsed frontmatter independently of jsonschema. Also: `composes_with`/`spawned_by` reference resolution now excludes plugin-namespaced (`plugin:name`, i.e. any `:`-containing) refs from the broken-reference WARN — they are external by definition. Scoped `name` uniqueness wording to "within the collection."
+- 1.2.0 — Bound to the published **Portable Skill Frontmatter Spec (PSFS) v1.1.0** (`spec/PSFS.md`). `lint-skills.sh` is the standard's **bash reference validator** (`--standard` reports the binding); the portable, tool-agnostic canonical validator is `spec/frontmatter.schema.json` (JSON Schema 2020-12). The lint script gained an optional inline schema cross-check (ERROR on structural violation when `jsonschema` is available; WARN advisory when absent). The split is normative: the schema covers per-file structure; this contract's cross-skill checks (name uniqueness, name==dirname, `owns` non-overlap) remain validator-only.
 - 1.1.0 — Demoted `description` length checks from ERROR to WARN at every threshold. Reason: `CLAUDE.md` explicitly endorses "pushy" descriptions that over-enumerate trigger contexts to combat under-triggering. Hard ERROR-on-length conflicted with the ecosystem's intentional design. Length is now a quality signal, not a CI gate.
 
 ## Purpose
 
 Defines what `scripts/lint-skills.sh` validates against every `skills/**/SKILL.md`. The lint script is the CI gate — failures block PR merges via `.github/workflows/lint-skills.yml`.
 
-The canonical frontmatter spec is at `skills/meta/skill-writer/references/frontmatter-spec.md`. This contract translates that spec into machine-checkable rules.
+The canonical frontmatter spec is at `skills/meta/skill-writer/references/frontmatter-spec.md`, published as the **Portable Skill Frontmatter Spec (PSFS) v1.1.0** (`spec/PSFS.md`). This contract translates that spec into machine-checkable rules; `spec/frontmatter.schema.json` is the portable reference validator and this script is the bash reference implementation.
 
 ## Severity Levels
 
@@ -51,10 +54,18 @@ These checks require reading multiple skills:
 
 | Check | Severity |
 |---|---|
-| `name` is unique across the ecosystem | ERROR (collision) |
+| `name` is unique within the collection | ERROR (collision) |
 | `owns.directories` between two agent role skills do not overlap (resolution rules in `frontmatter-spec.md` § Ownership Resolution apply) | ERROR (conflict) |
-| Every name in `composes_with` resolves to an existing skill | WARN (broken reference) |
-| Every name in `spawned_by` resolves to an existing skill | WARN (broken reference) |
+| Every in-collection name in `composes_with` resolves to an existing skill (plugin-namespaced `plugin:name` refs are external — excluded) | WARN (broken reference) |
+| Every in-collection name in `spawned_by` resolves to an existing skill (plugin-namespaced `plugin:name` refs are external — excluded) | WARN (broken reference) |
+
+## Frontmatter Safety (ERROR)
+
+| Check | Severity |
+|---|---|
+| No `<` or `>` in any frontmatter string value or key, at any depth (including nested `metadata` values) | ERROR |
+
+Frontmatter is injected verbatim into the model's system prompt, where `<...>` can be read as control/tool tags or abused for prompt injection. The linter walks parsed YAML *values* (not raw text), so block-scalar indicators (`description: >`, `description: |`) are structural and never trip the rule. This check runs independently of `jsonschema`; the JSON Schema's `^[^<>]*$` patterns on named fields are a portable complement, not the sole enforcement.
 
 ## Body Validation
 

--- a/contracts/standards/psfs.md
+++ b/contracts/standards/psfs.md
@@ -1,0 +1,75 @@
+# Contract: Portable Skill Frontmatter Spec (PSFS) — Publish as a Named Standard (P3)
+
+**Version:** 1.0.0
+**Status:** ACTIVE — orchestrator, AllTheSkills P3
+**Source plan:** `DeepResearch/The-Hive/ecc_deepdive/source-material/14-alltheskills-frontier.md` (P3 — "Publish the frontmatter standard")
+**Models:** This repo's own `skills/meta/skill-writer/references/frontmatter-spec.md` (the crown-jewel spec) + `scripts/lint-skills.sh` (the existing bash validator) + `contracts/installer/lint-rules.md` (the machine-checkable rule translation).
+
+## Intent
+
+`frontmatter-spec.md` is already more complete than ECC's frontmatter and is effectively a spec for "what a portable, ownership-aware, composable skill declares." P3 turns that local convention into **ecosystem leverage**: publish it as a *named, versioned standard* — the **Portable Skill Frontmatter Spec (PSFS), v1.0.0** — with a **portable, tool-agnostic JSON Schema** as the canonical machine-readable validator and `lint-skills.sh` as the bash reference implementation. Other collections (including ECC, which is Node, not bash) can then validate conformance in any language by running the schema, and converge on the standard without adopting this repo's tooling.
+
+## Hard guardrails
+
+- **Do not weaken the existing lint gate.** `scripts/lint-skills.sh skills/` MUST still exit 0 on the current tree after all P3 changes. The schema and the bash linter must AGREE on the current tree (every real `SKILL.md` validates clean against the schema).
+- **No new source of truth that drifts.** The PSFS standard doc, the JSON Schema, and `frontmatter-spec.md` describe the *same* fields. The published standard (`spec/PSFS.md`) becomes canonical; `frontmatter-spec.md` stays the in-repo authoring reference and gains a one-line pointer declaring PSFS as the published standard it conforms to. Do NOT fork the field definitions into three diverging copies.
+- **No git operations. No network. No LLM calls in the validator.** Bash 3.2 portable; reuse `scripts/lib/term.sh` helpers. Schema validation uses `python3` stdlib + (optionally) the `jsonschema` package *if present*; if absent, degrade to a clear advisory (mirror the existing `pyyaml` advisory pattern — WARN, never hard-fail the environment).
+- **Conformance, not coercion.** The standard defines two tiers (Core / Extended). It does not require every collection to adopt the multi-agent extensions.
+
+## The two conformance tiers (define these precisely in PSFS.md)
+
+- **Core conformance** — valid `name` (kebab-case, ≤64, matches folder), `version` (semver), `description` (present, ≤1024 chars, no `<`/`>`), plus any Anthropic-spec optionals (`compatibility`, `license`, `allowed-tools`, `metadata`, `argument-hint`, `disable-model-invocation`) used correctly. **No Extended field is required.** This is the tier ECC and other vendor-neutral collections can claim.
+- **Extended conformance** — Core + correct use of this repo's multi-agent extensions where present (`requires_agent_teams`, `requires_claude_code`, `min_plan`, `owns`, `composes_with`, `spawned_by`). Required for orchestrated builds.
+
+## Components & ownership
+
+### Agent A — Standards Author (`spec/PSFS.md` + pointer)
+OWNS exclusively:
+- `spec/PSFS.md` — the published standard. Must contain, in this order: a titled header `# Portable Skill Frontmatter Spec (PSFS)` with `**Version:** 1.0.0` and a `**Status:** Published` line; a one-paragraph abstract; the two conformance tiers above stated normatively (RFC-2119 MUST/SHOULD/MAY language); the full field catalog (Core then Extended) — you MAY reproduce the field tables from `frontmatter-spec.md` but framed as a standard (normative, versioned), not a how-to; a **Reference Validators** section naming BOTH `spec/frontmatter.schema.json` (canonical, portable, JSON Schema 2020-12) AND `scripts/lint-skills.sh --standard` (bash reference impl) and stating exactly which checks are schema-expressible (per-file structure) vs validator-only (cross-file: name-uniqueness, name==dirname, `owns` non-overlap); a **Conformance** statement (how a collection claims Core vs Extended); a **Relationship to Anthropic's Agent Skills spec** section (Core is a strict superset-compatible profile; Extended fields are ignored safely by Anthropic parsers); and a **Changelog** (`1.0.0 — initial publication`).
+- A one-line alignment pointer appended near the top of `skills/meta/skill-writer/references/frontmatter-spec.md`: a sentence stating this reference conforms to **PSFS v1.0.0** (`spec/PSFS.md`), the published standard, and that the schema + lint rules are its reference validators. **Additive only — do not restructure the existing spec.**
+
+MUST NOT touch: `spec/frontmatter.schema.json`, `scripts/`, `tests/`, `.github/workflows/`, `contracts/`, any other `skills/` file.
+
+### Agent B — Schema + Validator (`spec/frontmatter.schema.json` + `lint-skills.sh --standard` + tests)
+OWNS exclusively:
+- `spec/frontmatter.schema.json` — **JSON Schema draft 2020-12** (`$schema`, `$id` referencing PSFS v1.0.0, `title`, `description`). Encodes per-file structural conformance:
+  - required: `name`, `version`, `description`.
+  - `name`: `type: string`, `pattern: "^[a-z][a-z0-9-]*$"`, `maxLength: 64`.
+  - `version`: `type: string`, `pattern: "^\\d+\\.\\d+\\.\\d+$"`.
+  - `description`: `type: string`, `maxLength: 1024`, `pattern: "^[^<>]*$"` (no angle brackets — anywhere a string field is constrained, forbid `<`/`>`).
+  - Anthropic optionals typed: `compatibility` (string, 1–500), `license` (string), `allowed-tools` (array of string) **plus the deprecated alias `allowed_tools`** (array of string — accept both, document `allowed-tools` as canonical), `argument-hint` (string), `disable-model-invocation` (boolean), `metadata` (object, free-form — `additionalProperties: true` inside).
+  - Extended optionals typed: `requires_agent_teams` (boolean), `requires_claude_code` (boolean), `min_plan` (enum `starter|pro|team|enterprise`), `owns` (object with optional `directories`/`patterns`/`shared_read`, each array-of-string), `composes_with` (array of string), `spawned_by` (array of string).
+  - Top-level `additionalProperties`: enumerate every documented field above and set `additionalProperties: false` **only if** that keeps the real tree green; if any current skill uses a legitimate field not listed, ADD it to the schema (and note it for the standards author) rather than loosening to `true`. Decide empirically by running against the full real tree.
+  - The schema expresses **per-file structure only**. Cross-file checks (uniqueness, name==dirname, `owns` non-overlap) are explicitly out of scope for JSON Schema and remain in `lint-skills.sh` — add a top-level `description` note in the schema saying so.
+- Additive changes to `scripts/lint-skills.sh`:
+  - `--standard` flag: prints the PSFS standard name + version this linter implements (e.g. `Portable Skill Frontmatter Spec (PSFS) v1.0.0`) and the path to the canonical schema, then exits 0. Wire into the existing `case` arg parser (around line 553) and `usage()` (line 546) and the header comment block (lines 12–16).
+  - Optional schema cross-check: when `python3` + the `jsonschema` package are available, validate each parsed frontmatter object against `spec/frontmatter.schema.json` and emit any schema violation as an **ERROR** (it's a structural defect). When `jsonschema` is absent, emit a single WARN advisory (`install python3 jsonschema for schema validation`) and continue with the existing checks — mirror the existing pyyaml-absent advisory at lines 225–226. Reuse the existing python3 helper (lines 80–132) rather than spawning a new interpreter per file where avoidable.
+  - Keep the script bash 3.2 clean (`bash -n` passes) and under the existing structure; do not regress any current behavior or exit code.
+- `tests/standard/` — bats (bash 3.2), with a `run-tests.sh` mirroring `tests/skill-health/run-tests.sh`:
+  - `--standard` prints a line containing `PSFS` and `1.0.0`; exit 0.
+  - schema is itself valid JSON and parses as a JSON Schema (`python3 -c "import json; json.load(...)"`; if `jsonschema` present, `Draft202012Validator.check_schema`).
+  - **regression (the gate): every real `skills/**/SKILL.md` frontmatter validates against `spec/frontmatter.schema.json`** (skip `archive/` + `in-progress/` consistent with catalog/scan). If `jsonschema` is unavailable in the test env, this test SKIPs with a clear message rather than failing.
+  - positive/negative fixtures under a temp dir: a minimal Core-valid frontmatter passes; a frontmatter with a bad-semver `version`, a non-kebab `name`, a `<` in `description`, and a bad `min_plan` enum each fail schema validation.
+  - `scripts/lint-skills.sh skills/` still exits 0 on the real tree (regression that the gate wasn't weakened).
+
+MUST NOT touch: `spec/PSFS.md`, `skills/`, `.github/workflows/`, `contracts/`, `README.md`, any other `scripts/*.sh` besides `lint-skills.sh`.
+
+### Orchestrator (NOT the agents) — integration, owned by lead
+- Wire schema validation into CI (`.github/workflows/lint-skills.yml`) — agents must not touch the workflow.
+- Bind the standard into `contracts/installer/lint-rules.md` (version bump + a "Conforms to PSFS v1.0.0" note) — contract edits are the lead's job.
+- README pointer to `spec/PSFS.md`; `coordination/MISSION_SKILLS.md` + `BUILD_RESULTS.md` updates.
+
+## QE (Wave 2) — gate, owned by qe-agent
+OWNS: `coordination/p3-qa-report.json` (conforms to the qe-agent qa-report schema; reuse `hooks/scripts/qa-gate-validate.py` to self-validate the report). Independently verifies (by execution + read, not by editing source):
+- `scripts/lint-skills.sh skills/` exits 0 (gate not weakened).
+- `scripts/lint-skills.sh --standard` reports PSFS v1.0.0.
+- Every real `SKILL.md` validates against the schema (run a standalone `jsonschema` pass over the whole tree; if the package is unavailable, record this as an environment limitation in the report, not a pass).
+- `bats tests/standard` passes; `bash -n scripts/lint-skills.sh` clean.
+- `spec/PSFS.md` exists, is versioned 1.0.0, names BOTH reference validators, and defines Core vs Extended tiers; `frontmatter-spec.md` carries the PSFS pointer.
+- Schema and bash linter do not disagree on any current skill.
+
+## DoD
+PSFS v1.0.0 published (`spec/PSFS.md`), portable `spec/frontmatter.schema.json` validates the entire real tree clean, `lint-skills.sh --standard` binds the bash impl to the named standard + optional schema cross-check, tests pass, existing lint gate still exits 0, CI wired by lead, `lint-rules.md` bound to PSFS, QA gate passed. **No git ops in agents. No real `~/.claude` writes.**
+
+## Changelog
+- 1.0.0 — initial (orchestrator, P3).

--- a/coordination/MISSION_SKILLS.md
+++ b/coordination/MISSION_SKILLS.md
@@ -1,0 +1,37 @@
+# Mission skill manifest — AllTheSkills runtime layer (ECC deep-dive build list)
+
+Source: `DeepResearch/The-Hive/ecc_deepdive/source-material/14-alltheskills-frontier.md` · Scanned: 2026-05-24
+
+This is a CLI / docs / tooling build (bash + python3 + JSON Schema + Markdown). It has
+**no UI surface**, so the creative and render-validation skills (`nano-banana`,
+`ui-ux-pro-max`, `frontend-design`, `ux-review`, `render-sanity`) do not apply and are
+recorded N/A below rather than left as empty boxes.
+
+## Phase P0 — Hooks layer (shipped PR #8)
+- [x] `orchestrator` — ✅ coordinated; contracts under `contracts/hooks/`.
+- [x] `qe-agent` — ✅ `coordination/hooks-p0-qa-report.json`.
+
+## Phase P1 — Plan/apply install + catalog invariant (shipped PR #8)
+- [x] `orchestrator` — ✅ coordinated; `contracts/installer/{catalog-invariant,plan-apply}.md`.
+- [x] `qe-agent` — ✅ `coordination/p1-qa-report.json`.
+
+## Phase P2 — Skill-health telemetry + supply-chain scanner (shipped PR #8)
+- [x] `orchestrator` — ✅ coordinated; `contracts/installer/{skill-health,skill-scan}.md`.
+- [x] `qe-agent` — ✅ `coordination/p2-qa-report.json`.
+
+## Phase P3 — Publish the frontmatter standard (this build)
+- [x] `orchestrator` — ✅ coordinated; contract `contracts/standards/psfs.md`.
+- [x] `contract-author` — ✅ folded into the lead (contract authored directly by orchestrator).
+- [x] `qe-agent` — ✅ `coordination/p3-qa-report.json` (PASS, 5/5 across the board).
+- [x] `repo-deep-dive` — ✅ invoked in the prior session; it produced the source material
+  (`ecc_deepdive/source-material/`) this entire build list derives from.
+- [x] `llm-wiki` / `wiki-research` — ✅ the deep-dive's findings were filed into the
+  DeepResearch Obsidian wiki (`wiki/comparisons/ecc-vs-alltheskills.md`) in the prior session.
+
+## N/A for this build (no UI surface)
+- `nano-banana`, `ui-ux-pro-max`, `frontend-design`, `ux-review`, `render-sanity` — N/A:
+  this build ships scripts, a JSON Schema, a Markdown standard, and bats tests; there is
+  nothing to render in a browser.
+- `code-review` / `security-review` — folded into the QE pass (the PSFS security surface —
+  the `^[^<>]*$` angle-bracket prohibition on frontmatter strings — was verified there and
+  scored security 5/5).

--- a/coordination/p3-qa-report.json
+++ b/coordination/p3-qa-report.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "1.0.0",
+  "timestamp": "2026-05-25T01:32:06Z",
+  "agent_role": "qe",
+  "build_session_id": "alltheskills-p3-psfs-publish",
+  "status": "PASS",
+  "scores": {
+    "correctness": {
+      "score": 5,
+      "notes": "lint-skills.sh skills/ exits 0 (0 errors, 111 non-blocking WARNs); --standard reports 'PSFS v1.0.0' + canonical schema path; bats tests/standard 12/12 pass; schema negative fixtures (bad semver, non-kebab name, '<' in description, bad min_plan) all correctly rejected; valid Core passes."
+    },
+    "completeness": {
+      "score": 5,
+      "notes": "All DoD artifacts present: spec/PSFS.md (v1.0.0 Published, both tiers normative w/ RFC-2119, field catalog, Reference Validators naming both validators, changelog), spec/frontmatter.schema.json (draft 2020-12), lint --standard binding, tests/standard, frontmatter-spec.md PSFS pointer."
+    },
+    "code_quality": {
+      "score": 5,
+      "notes": "bash -n scripts/lint-skills.sh clean; schema passes Draft202012Validator.check_schema; schema description documents per-file vs cross-file split; allowed-tools canonical with documented allowed_tools alias; additionalProperties:false at top-level and on owns without breaking the real tree."
+    },
+    "security": {
+      "score": 5,
+      "notes": "Angle-bracket prohibition (^[^<>]*$) present on 11 constrained string fields incl. description, name domain, compatibility, license, allowed-tools/allowed_tools items, argument-hint, owns.*, composes_with, spawned_by — preventing injection into the system prompt. '<' and '>' in description both rejected. No network/LLM/git in validators; jsonschema degrades to advisory when absent."
+    },
+    "contract_conformance": {
+      "score": 5,
+      "notes": "Matches contracts/standards/psfs.md QE gate exactly: lint gate not weakened (exit 0), --standard reports PSFS v1.0.0, all 47 real SKILL.md validate clean against schema (archive/ + in-progress/ excluded), tiers defined, both reference validators named, pointer present, schema and bash linter agree on the current tree (both green on identical set)."
+    }
+  },
+  "test_results": {
+    "unit": { "pass": 0, "fail": 0, "skip": 0 },
+    "integration": { "pass": 12, "fail": 0, "skip": 0 },
+    "e2e": { "pass": 0, "fail": 0, "skip": 0 },
+    "contract": { "pass": 47, "fail": 0, "skip": 0 },
+    "security_scan": { "pass": 11, "fail": 0, "skip": 0 }
+  },
+  "blockers": [],
+  "issues": [
+    {
+      "id": "P3-I1",
+      "severity": "INFO",
+      "category": "lint_warnings",
+      "file": null,
+      "line": null,
+      "description": "lint-skills.sh emits 111 WARNs on the real tree (long descriptions, missing optional allowed_tools/owns on some role skills, composes_with references to plugin-external skills like 'frontend-design', 'brainstorming', 'ui-ux-pro-max'). All are advisory; 0 errors. Pre-existing and unrelated to P3 schema/standard work; do not weaken any gate.",
+      "suggested_fix": "No action required for P3 gate. Optionally tighten descriptions / add allowed_tools later; plugin-external composes_with refs are expected to resolve outside this repo."
+    },
+    {
+      "id": "P3-I2",
+      "severity": "INFO",
+      "category": "test_taxonomy",
+      "file": "coordination/p3-qa-report.json",
+      "line": null,
+      "description": "Test results mapped to the qa-report schema's fixed buckets: bats suite -> integration (12); per-file schema validation of every real SKILL.md -> contract (47); angle-bracket-prohibition string-field checks -> security_scan (11). No unit or e2e suites exist for this deliverable.",
+      "suggested_fix": "None; mapping documented for orchestrator clarity."
+    }
+  ],
+  "recommendations": [
+    "Lead may wire spec/frontmatter.schema.json into CI (.github/workflows/lint-skills.yml) and bind PSFS v1.0.0 into contracts/installer/lint-rules.md per the contract's orchestrator section.",
+    "When jsonschema is guaranteed in CI, the lint-skills.sh optional schema cross-check upgrades structural defects to ERRORs end-to-end; document the install requirement in CI."
+  ],
+  "gate_decision": {
+    "proceed": true,
+    "reason": "All QE gate criteria from contracts/standards/psfs.md satisfied: lint gate not weakened (scripts/lint-skills.sh skills/ exit 0, 0 errors); scripts/lint-skills.sh --standard reports PSFS v1.0.0 + canonical schema; all 47 real SKILL.md validate clean against spec/frontmatter.schema.json via jsonschema 4.26.0 (0 failures); schema passes Draft202012Validator.check_schema and declares draft 2020-12; bats tests/standard 12/12 pass; bash -n clean; spec/PSFS.md published v1.0.0 with both tiers and both reference validators named; frontmatter-spec.md carries the PSFS pointer; schema and bash linter agree on the current tree. No CRITICAL/HIGH blockers."
+  }
+}

--- a/scripts/lint-skills.sh
+++ b/scripts/lint-skills.sh
@@ -13,6 +13,8 @@
 #   --verbose        Show INFO output
 #   --fix-trivial    Auto-fix trivial issues (prompts before each fix)
 #   --format FORMAT  Output format: text (default) or junit
+#   --standard       Print the PSFS standard + version this linter implements
+#                    and the canonical schema path, then exit 0
 #   --help           Print this and exit
 #
 # PATH may be a directory (recurse) or an individual SKILL.md.
@@ -33,6 +35,18 @@ LIB_DIR="$SCRIPT_DIR/lib"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SKILLS_ROOT="$REPO_ROOT/skills"
 
+# Named standard this linter implements (see spec/PSFS.md).
+PSFS_NAME="Portable Skill Frontmatter Spec (PSFS)"
+PSFS_VERSION="1.1.0"
+SCHEMA_PATH="$REPO_ROOT/spec/frontmatter.schema.json"
+
+# print_standard — bind this bash impl to the named, versioned standard.
+print_standard() {
+  printf '%s v%s\n' "$PSFS_NAME" "$PSFS_VERSION"
+  printf 'Canonical schema: %s\n' "$SCHEMA_PATH"
+  printf 'Reference implementation: scripts/lint-skills.sh (bash)\n'
+}
+
 # ---------------------------------------------------------------------------
 # CLI state
 # ---------------------------------------------------------------------------
@@ -49,6 +63,9 @@ LINT_PATHS=()
 ERRORS=()    # "FILE:LINE:MESSAGE"
 WARNS=()
 INFOS=()
+
+# Emit the "jsonschema absent" advisory at most once across the whole run.
+JSONSCHEMA_ADVISED=false
 
 record_error() { ERRORS+=("$1"); }
 record_warn()  { WARNS+=("$1"); }
@@ -81,10 +98,12 @@ emit_issue() {
 # ---------------------------------------------------------------------------
 _lint_py3() {
   local file="$1"
-  python3 - "$file" <<'PYEOF'
+  local schema="${2:-}"
+  python3 - "$file" "$schema" <<'PYEOF'
 import sys, json, re
 
 path = sys.argv[1]
+schema_path = sys.argv[2] if len(sys.argv) > 2 else ''
 
 with open(path) as f:
     content = f.read()
@@ -97,6 +116,8 @@ result = {
     "data": {},
     "body_lines": [],
     "body_word_count": 0,
+    "schema_errors": [],
+    "jsonschema_missing": False,
 }
 
 # Check opening ---
@@ -136,6 +157,31 @@ except ImportError:
 result["ok"] = True
 result["data"] = data
 
+# Angle-bracket safety: '<' and '>' are forbidden in ANY frontmatter string
+# value or key, at any depth — including inside the free-form `metadata` object.
+# Frontmatter is injected verbatim into the model's system prompt, where '<...>'
+# can be read as control/tool tags or abused for prompt injection. Checked
+# against parsed VALUES (not raw text), so YAML block-scalar indicators such as
+# 'description: >' or 'description: |' are never false positives.
+def _angle_hits(obj, path=""):
+    hits = []
+    if isinstance(obj, str):
+        if "<" in obj or ">" in obj:
+            hits.append(path or "(root)")
+    elif isinstance(obj, dict):
+        for k, v in obj.items():
+            ks = str(k)
+            kp = f"{path}.{ks}" if path else ks
+            if "<" in ks or ">" in ks:
+                hits.append(f"{kp} (key)")
+            hits += _angle_hits(v, kp)
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            hits += _angle_hits(v, f"{path}[{i}]")
+    return hits
+
+result["angle_hits"] = _angle_hits(data)
+
 # Body analysis
 body_lines = lines[fm_end + 1:]
 result["body_lines"] = body_lines
@@ -171,6 +217,24 @@ result["has_action_verb"] = any(w in action_verbs for w in first_words_lower)
 
 # Check trigger context hint (when/for/whenever/if)
 result["has_trigger_context"] = bool(re.search(r'\b(when|for|whenever|if)\b', desc, re.IGNORECASE))
+
+# Optional schema cross-check (PSFS frontmatter.schema.json).
+# Only attempts when a schema path was passed AND jsonschema is importable.
+# Missing jsonschema is an environment advisory (WARN), mirroring pyyaml.
+if schema_path:
+    try:
+        import jsonschema
+        try:
+            with open(schema_path) as sf:
+                schema = json.load(sf)
+            validator = jsonschema.Draft202012Validator(schema)
+            for err in sorted(validator.iter_errors(data), key=str):
+                loc = '/'.join(str(p) for p in err.absolute_path) or '(root)'
+                result["schema_errors"].append(f"{loc}: {err.message}")
+        except Exception as e:  # noqa: BLE001 — never block lint on schema-read issues
+            result["schema_errors"].append(f"schema validation error: {e}")
+    except ImportError:
+        result["jsonschema_missing"] = True
 
 print(json.dumps(result))
 PYEOF
@@ -208,9 +272,12 @@ lint_one() {
     return
   fi
 
-  # Run python3 analysis
+  # Run python3 analysis (passing the schema path enables the optional
+  # PSFS schema cross-check when the jsonschema package is available)
+  local schema_arg=""
+  [[ -f "$SCHEMA_PATH" ]] && schema_arg="$SCHEMA_PATH"
   local json_out
-  json_out="$(_lint_py3 "$file")"
+  json_out="$(_lint_py3 "$file" "$schema_arg")"
   if [[ -z "$json_out" ]]; then
     emit_issue ERROR "$file" "" "python3 lint helper returned no output"
     return
@@ -237,6 +304,34 @@ lint_one() {
   body_lc="$(printf '%s' "$json_out" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('body_line_count',0))")"
   has_verb="$(printf '%s' "$json_out" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('has_action_verb',False))")"
   has_trigger="$(printf '%s' "$json_out" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('has_trigger_context',False))")"
+
+  # ---------------------------------------------------------------------------
+  # Optional PSFS schema cross-check (mirrors the pyyaml-absent advisory above)
+  # ---------------------------------------------------------------------------
+  local jsonschema_missing
+  jsonschema_missing="$(printf '%s' "$json_out" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('jsonschema_missing',False))")"
+  if [[ "$jsonschema_missing" == "True" ]]; then
+    if ! $JSONSCHEMA_ADVISED; then
+      emit_issue WARN "$file" "1" "install python3 jsonschema for schema validation"
+      JSONSCHEMA_ADVISED=true
+    fi
+  else
+    # Emit each schema violation as an ERROR (structural defect).
+    while IFS= read -r schema_err; do
+      [[ -z "$schema_err" ]] && continue
+      emit_issue ERROR "$file" "1" "schema: $schema_err"
+    done < <(printf '%s' "$json_out" | python3 -c "import sys,json; [print(e) for e in json.load(sys.stdin).get('schema_errors',[])]")
+  fi
+
+  # Angle-bracket safety (always-on, independent of jsonschema). This is the
+  # enforcement home for the no-'<'/'>' rule: the JSON Schema can only pattern
+  # the named typed fields, not arbitrary string leaves under the free-form
+  # `metadata` object, and the schema check is skipped when jsonschema is absent.
+  while IFS= read -r angle_path; do
+    [[ -z "$angle_path" ]] && continue
+    emit_issue ERROR "$file" "$fm_end_line" \
+      "frontmatter contains '<' or '>' in '$angle_path' (forbidden — frontmatter is injected into the system prompt)"
+  done < <(printf '%s' "$json_out" | python3 -c "import sys,json; [print(e) for e in json.load(sys.stdin).get('angle_hits',[])]")
 
   # Derive slug and category from path
   local skill_dir slug category
@@ -405,6 +500,9 @@ cross_validate() {
   for f in "${files[@]}"; do
     while IFS= read -r ref_name; do
       [[ -z "$ref_name" ]] && continue
+      # Plugin-namespaced refs (plugin:name) are external by definition — out of
+      # scope for in-collection resolution, so they are never flagged.
+      [[ "$ref_name" == *:* ]] && continue
       if ! printf '%s\n' "$all_names" | grep -qxF "$ref_name"; then
         emit_issue WARN "$f" "" "composes_with references unknown skill '$ref_name'"
       fi
@@ -412,6 +510,7 @@ cross_validate() {
 
     while IFS= read -r ref_name; do
       [[ -z "$ref_name" ]] && continue
+      [[ "$ref_name" == *:* ]] && continue
       if ! printf '%s\n' "$all_names" | grep -qxF "$ref_name"; then
         emit_issue WARN "$f" "" "spawned_by references unknown skill '$ref_name'"
       fi
@@ -544,7 +643,7 @@ print_junit_report() {
 # Main
 # ---------------------------------------------------------------------------
 usage() {
-  sed -n '3,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '3,21p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
   exit 0
 }
 
@@ -555,6 +654,7 @@ main() {
       --verbose)      VERBOSE=true; shift ;;
       --fix-trivial)  FIX_TRIVIAL=true; shift ;;  # future: implement trivial auto-fixes
       --format)       FORMAT="${2:?'--format requires a value'}"; shift 2 ;;
+      --standard)     print_standard; exit 0 ;;
       --help|-h)      usage ;;
       -*)             ats_err "Unknown option: $1"; exit 2 ;;
       *)              LINT_PATHS+=("$1"); shift ;;

--- a/skills/meta/skill-writer/references/frontmatter-spec.md
+++ b/skills/meta/skill-writer/references/frontmatter-spec.md
@@ -4,6 +4,8 @@ Canonical reference for all SKILL.md frontmatter fields in the skill ecosystem.
 
 This spec aligns with Anthropic's official Agent Skills frontmatter standard while adding fields specific to multi-agent orchestration (`owns`, `composes_with`, `spawned_by`, `requires_*`, `min_plan`). Skills written to this spec load correctly on Claude Code, Claude.ai, Claude Desktop, and the Agent SDK — the multi-agent extensions are ignored safely by parsers that don't understand them.
 
+This reference conforms to **PSFS v1.1.0** (`spec/PSFS.md`), the published standard, whose reference validators are `spec/frontmatter.schema.json` (canonical JSON Schema) and `scripts/lint-skills.sh --standard` (bash reference implementation).
+
 ## Quick Reference
 
 ```yaml
@@ -45,7 +47,7 @@ spawned_by: ["orchestrator"]
 - **Max length:** 64 characters
 - **Reserved prefixes:** should not start with `claude-` or `anthropic-` — reserved by Anthropic for first-party skills. **Exception:** skills that explicitly target an Anthropic product or feature (e.g., `claude-design-brief` for Claude's design canvas) may use the prefix when the name precisely describes the target. Document the exception in the skill body so future maintainers know it's intentional. `skill-review` WARNs on this pattern; it does not FAIL.
 - **Must match** the skill folder name
-- **Must be unique** across the ecosystem
+- **Must be unique** within the collection
 - **Examples:** `backend-agent`, `contract-author`, `skill-writer`
 
 ### version

--- a/spec/PSFS.md
+++ b/spec/PSFS.md
@@ -1,0 +1,349 @@
+# Portable Skill Frontmatter Spec (PSFS)
+
+**Version:** 1.1.0
+**Status:** Published
+
+The Portable Skill Frontmatter Spec (PSFS) is a named, versioned standard for the YAML
+frontmatter that a skill declares in its `SKILL.md`. It defines a small, tool-agnostic
+set of fields and two conformance tiers — **Core** and **Extended** — so that skill
+collections written by different teams, in different languages and toolchains, can
+validate against the *same* contract without adopting any one repository's tooling. PSFS
+Core is a compatibility-preserving profile of Anthropic's open Agent Skills frontmatter:
+a Core-conformant skill uploads to Claude.ai and runs on Claude Code and the Agent SDK
+unchanged. The optional Extended fields add multi-agent coordination metadata that
+non-understanding parsers ignore safely.
+
+> **Motivation (non-normative).** Portability and convergence matter because skills are
+> increasingly shared across ecosystems. A single normative spec plus a portable
+> machine-readable validator lets any collection claim conformance and interoperate,
+> rather than each vendor inventing a divergent frontmatter dialect.
+
+## Conformance Tiers
+
+The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT,
+RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in
+RFC 2119.
+
+### Core
+
+A skill claiming **Core** conformance:
+
+- MUST declare a `name` that is kebab-case, at most 64 characters, and matches its
+  containing folder name.
+- MUST declare a `version` that is valid semantic versioning (`MAJOR.MINOR.PATCH`).
+- MUST declare a `description` that is present, at most 1024 characters, and contains no
+  `<` or `>` characters.
+- MUST NOT include `<` or `>` characters anywhere in any frontmatter string value (see
+  the angle-bracket rule under Field Catalog for the rationale).
+- MAY include any of the Anthropic Agent Skills optional fields (`compatibility`,
+  `license`, `allowed-tools`, `metadata`, `argument-hint`, `disable-model-invocation`),
+  and where present those fields MUST be used with the correct type and semantics defined
+  in the field catalog below.
+- SHOULD keep `description` at or under a 200-character target so triggers stay tight and
+  scannable; the 1024-character ceiling is the hard limit.
+- SHOULD NOT use a `name` beginning with `claude-` or `anthropic-`; these prefixes are
+  reserved by Anthropic for first-party skills.
+- **No Extended field is REQUIRED.** Core is the tier that vendor-neutral collections —
+  including ECC (Everything Claude Code) — can claim.
+
+> **Reserved-prefix exception (non-normative).** A skill that precisely targets a
+> corresponding Anthropic product or feature (for example, a skill named
+> `claude-design-brief` for Claude's design canvas) may reasonably use a reserved prefix.
+> This is author judgement, not a validator-checkable constraint; reference
+> implementations treat a reserved-prefix `name` as a warning, not a failure.
+
+### Extended
+
+A skill claiming **Extended** conformance:
+
+- MUST satisfy every Core requirement.
+- MUST use this standard's multi-agent extension fields (`requires_agent_teams`,
+  `requires_claude_code`, `min_plan`, `owns`, `composes_with`, `spawned_by`) correctly
+  where present, with the types and semantics defined in the field catalog below.
+- MUST claim Extended conformance if it participates in orchestrated, multi-agent builds,
+  because ownership and composition metadata is required for zero-conflict parallel work.
+- MAY omit any individual Extended field that does not apply; Extended conformance
+  constrains the *correctness* of these fields, not their presence.
+
+### Parser requirements
+
+- A PSFS parser operating at Core tier MUST accept and ignore frontmatter keys it does
+  not recognize. This is what lets an Extended skill load unchanged under a Core-only
+  parser, and what lets future PSFS versions add fields without breaking older parsers.
+- When both `allowed-tools` (canonical) and `allowed_tools` (deprecated alias) are
+  present, a parser MUST treat `allowed-tools` as authoritative and SHOULD emit a warning
+  about the redundant alias.
+
+## Field Catalog
+
+This catalog is normative. Field names, types, and constraints are part of PSFS v1.1.0.
+
+**Angle-bracket rule.** Any string-typed field MUST NOT contain `<` or `>`. Frontmatter
+is injected verbatim into the model's system prompt, where `<...>` sequences can be
+interpreted as control or tool tags, or abused as a prompt-injection vector. The ban is
+on the literal characters and is intentionally strict: it also rejects otherwise-benign
+uses such as `n <= 5` or `a > b`. Authors should phrase these as `at most` / `greater
+than`, or use the Unicode forms `≤` / `≥`. Reliably distinguishing a benign angle bracket
+from an injection vector inside a system-prompt context is not worth the risk, so PSFS
+forbids the literal characters outright rather than attempting to allow "safe" ones.
+
+This constraint applies to every string value **and key**, at any depth — including
+those nested inside the free-form `metadata` object. Enforcement is split: the JSON
+Schema constrains the named typed fields, and the bash reference validator walks the
+entire parsed frontmatter to cover arbitrary leaves (such as `metadata` values), a
+constraint JSON Schema cannot express over a free-form object. The check runs against
+parsed YAML *values*, so block-scalar indicators like `description: >` or
+`description: |` are structural and never trip the rule.
+
+### Core Fields
+
+| Field | Required | Type | Constraints | Semantics |
+|-------|----------|------|-------------|-----------|
+| `name` | MUST | string | kebab-case `^[a-z][a-z0-9-]*$`, ≤64 chars, matches folder name, unique within the collection | Stable identifier for the skill. |
+| `version` | MUST | string | semver `^\d+\.\d+\.\d+$` | Top-level semantic version. See Skill Versioning below. |
+| `description` | MUST | string | present, ≤1024 chars, no `<`/`>`; ≤200 chars RECOMMENDED | Primary trigger text. Claude reads this to decide whether to invoke the skill: `[what it does] + [when to use] + [key capabilities/keyword variants]`. |
+| `compatibility` | MAY | string | 1–500 chars, no `<`/`>` | Human-readable declaration of host, required packages, network, and MCP servers. For programmatic gating use the `requires_*` booleans. |
+| `license` | MAY | string | no `<`/`>` | Per-skill SPDX license override (e.g. `MIT`, `Apache-2.0`). Usually unnecessary; the repo-level license applies. |
+| `allowed-tools` | MAY | string[] | each item no `<`/`>` | **Canonical.** Whitelist of tools the skill may invoke. |
+| `allowed_tools` | MAY | string[] | each item no `<`/`>` | **Deprecated alias** of `allowed-tools` (underscore form). Accepted for back-compat; new skills SHOULD use `allowed-tools`. If both appear, `allowed-tools` wins (see Parser requirements). |
+| `argument-hint` | MAY | string | short, no `<`/`>` | Hint shown in Claude Code's slash-command UI for skills taking a positional argument. |
+| `disable-model-invocation` | MAY | boolean | default `false` | When `true`, the skill is invocable only by an orchestrator or explicit slash-command, not by Claude's model-driven auto-trigger. Recognized by the Claude Code runtime. |
+| `metadata` | MAY | object | free-form key/value | Attribution and cataloging. See the metadata note below. |
+
+**metadata note.** `metadata` is an OPTIONAL free-form object. The keys `author`,
+`category`, `tags`, `mcp-server`, `documentation`, and `support` are RECOMMENDED
+conventional keys with the obvious meanings; additional keys MAY appear. PSFS does not
+constrain `metadata` values beyond the angle-bracket rule on any string within them. This
+mirrors Anthropic's nested-metadata form.
+
+### Extended Fields
+
+These fields are this standard's multi-agent extensions. They are not part of Anthropic's
+Agent Skills spec; parsers that do not understand them MUST be able to ignore them safely
+(see Parser requirements). They are evaluated for correctness only under Extended
+conformance.
+
+| Field | Type | Constraints | Semantics |
+|-------|------|-------------|-----------|
+| `requires_agent_teams` | boolean | default `false` | `true` if the skill requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`. Such skills SHOULD degrade gracefully when teams are unavailable. |
+| `requires_claude_code` | boolean | default `false` | `true` if the skill requires the Claude Code CLI (bash, filesystem access). |
+| `min_plan` | enum | one of `starter`, `pro`, `team`, `enterprise`; default `starter` | Minimum plan tier required to run the skill. |
+| `owns` | object | OPTIONAL object; see owns note below | Ownership declaration for agent role skills. |
+| `composes_with` | string[] | each item no `<`/`>` | Other skill names this one naturally works with (informational). Plugin-external refs use a `plugin:name` prefix. |
+| `spawned_by` | string[] | each item no `<`/`>` | Which skills spawn this one. Plugin-external refs use a `plugin:name` prefix. |
+
+**owns note.** `owns` is an OPTIONAL object with three OPTIONAL properties, each an array
+of strings (no other properties are permitted):
+
+- `owns.directories` — directories this agent skill owns exclusively.
+- `owns.patterns` — file glob patterns this agent owns.
+- `owns.shared_read` — directories this agent reads but does not own.
+
+An `owns` object MAY be empty (`owns: {}`) and any single property MAY be omitted; for
+example, a skill MAY declare `owns.patterns` without `owns.directories`. The non-overlap
+of `owns.directories` between agent skills is a cross-file rule (see Validator-only
+checks), not a per-file one.
+
+**Ownership resolution.** When ownership of a path is contested, resolve in this order:
+(1) directory ownership takes precedence over pattern ownership — a file matching agent
+A's glob but living under agent B's owned directory belongs to B; (2) a more specific
+subdirectory carve-out overrides a parent directory — an agent owning `tests/performance/`
+keeps it even if another owns `tests/`; (3) any conflict unresolved by (1)–(2) is
+**undefined behavior at the PSFS layer** — a runtime that consumes PSFS metadata SHOULD
+provide a deterministic resolution mechanism and MUST surface any conflict it cannot
+resolve. (An orchestrated multi-agent build, for example, resolves at spawn time and
+escalates an unresolvable conflict to a human; a static analyzer might simply report it.)
+
+**Reference resolution.** A `composes_with` or `spawned_by` entry that names an in-collection
+skill SHOULD resolve to a skill that exists in the collection; an unresolved in-collection
+reference is a warning, not an error (these fields are informational and a dangling
+reference does not make the skill malformed). A plugin-namespaced reference — any value
+containing a `:` (e.g. `superpowers:brainstorming`), matching the prevailing Anthropic
+plugin `plugin:name` convention — is external by definition: it is out of scope for
+in-collection resolution and MUST NOT be flagged as unresolved.
+
+## Skill Versioning
+
+`version` is the skill's own semantic version (distinct from the PSFS spec version; see
+Spec Versioning and Stability). Start at `1.0.0`. For a skill, treat as **breaking**
+(MAJOR) any change to behavior a caller or a composing skill could depend on: renaming the
+skill (its `name`/folder), removing a tool from `allowed-tools`, narrowing `owns`,
+changing `spawned_by`/`composes_with` relationships, or altering `description` such that
+the skill's trigger semantics shift materially. *Broadening* `owns` is also breaking at
+the collection level — it can claim territory another skill relied on or create an
+ownership overlap — even though it is additive from the broadening skill's own
+perspective. Bump MINOR for additive capability and
+PATCH for fixes that change nothing a caller relies on. When in doubt, defer to
+[semver.org](https://semver.org); "breaking" means "a dependent could observe the
+difference."
+
+## Reference Validators
+
+PSFS v1.1.0 has two reference validators:
+
+1. **`spec/frontmatter.schema.json`** — the canonical, portable machine-readable
+   validator. It is a JSON Schema 2020-12 document, runnable in any language with a
+   conforming JSON Schema implementation, and is the authoritative encoding of per-file
+   structural conformance.
+2. **`scripts/lint-skills.sh --standard`** — the bash reference implementation. It binds
+   the linter to the named standard (reporting `Portable Skill Frontmatter Spec (PSFS)
+   v1.1.0` and the canonical schema path) and, where `python3` and the `jsonschema`
+   package are available, cross-checks each parsed frontmatter object against the
+   canonical schema. It additionally performs the cross-file checks below, which a per-file
+   schema cannot express.
+
+The two validators are kept in agreement by a regression test (`tests/standard/`) that
+asserts every skill in the collection validates identically under both, run in CI by the
+`Frontmatter Standard / PSFS` job.
+
+### Schema-expressible checks (per-file structure)
+
+The JSON Schema expresses everything verifiable by inspecting a single frontmatter object
+in isolation:
+
+- Required fields present: `name`, `version`, `description`.
+- `name` is kebab-case (`^[a-z][a-z0-9-]*$`) and at most 64 characters.
+- `version` matches the semver pattern `^\d+\.\d+\.\d+$`.
+- `description` is at most 1024 characters and contains no `<`/`>`.
+- No `<`/`>` in any constrained string field.
+- Correct enum values (e.g. `min_plan` is one of `starter`, `pro`, `team`, `enterprise`).
+- Correct types for every documented optional field, including the `owns` sub-object shape.
+
+### Validator-only / cross-file checks
+
+These require knowledge beyond a single file and are out of scope for JSON Schema. They
+live in `scripts/lint-skills.sh`:
+
+- **Name uniqueness within the collection** — each `name` appears in exactly one skill in
+  the validated collection. (Global uniqueness across all PSFS collections is not claimed:
+  it would require a registry PSFS does not define.)
+- **`name` equals directory name** — the `name` field MUST match the skill's folder name
+  on disk.
+- **`owns.directories` non-overlap between agents** — no two agent skills declare ownership
+  of the same directory, resolved by the Ownership resolution rules above.
+- **In-collection reference resolution** — each in-collection `composes_with` / `spawned_by`
+  name resolves to an existing skill (WARN if not); plugin-namespaced refs (containing `:`)
+  are external and not checked. See Reference resolution above.
+
+## Conformance
+
+A collection declares its conformance level explicitly:
+
+- A collection claims **Core conformance** when every skill it ships satisfies all Core
+  requirements above. Vendor-neutral collections that do not use the multi-agent
+  extensions — such as ECC — claim Core. Core conformance is verified end-to-end by
+  running `spec/frontmatter.schema.json` against each skill's frontmatter (per-file
+  structure) plus the cross-file checks listed under Reference Validators.
+- A collection claims **Extended conformance** when, in addition to Core, every skill that
+  uses an Extended field uses it correctly per the field catalog, and the cross-file
+  `owns.directories` non-overlap rule holds across all agent skills.
+
+A skill or collection states the tier and the standard version it targets — for example,
+`Conforms to PSFS v1.1.0 (Core)` — and validates that claim with the reference validators
+named above. A collection SHOULD declare this claim in its root README. A machine-readable
+conformance manifest (for example a `psfs.json` file a registry could consume) is
+intentionally deferred: its shape is reserved for the version that introduces a consuming
+registry, rather than being specified speculatively here.
+
+## Relationship to Anthropic's Agent Skills Spec
+
+PSFS Core is a compatibility-preserving profile of Anthropic's open Agent Skills
+frontmatter standard:
+
+- A Core-conformant skill uses only `name`, `version`, `description`, and the Anthropic
+  Agent Skills optional fields (`compatibility`, `license`, `allowed-tools`, `metadata`,
+  `argument-hint`, `disable-model-invocation`). Such a skill uploads to Claude.ai and runs
+  on Claude Code and the Agent SDK without modification.
+- The Extended fields (`requires_agent_teams`, `requires_claude_code`, `min_plan`, `owns`,
+  `composes_with`, `spawned_by`) are additive metadata. Spec-compliant parsers ignore
+  unrecognized frontmatter keys, so a skill carrying Extended fields remains loadable
+  everywhere Core is loadable.
+
+In short: Core does not diverge from Anthropic's spec, and Extended never breaks
+compatibility with it.
+
+## Examples
+
+A minimal **Core** skill (no Extended fields):
+
+```yaml
+---
+name: simplify
+version: 1.2.0
+description: |
+  Refactor code for readability without changing behavior. Use when the user asks to
+  simplify, clean up, or reduce complexity in a function or module.
+allowed-tools: ["Read", "Edit"]
+metadata:
+  author: jane-doe
+  category: workflows
+  tags: [refactoring, readability]
+  documentation: https://example.com/skills/simplify
+---
+```
+
+An **Extended** skill (an orchestrated agent that declares ownership):
+
+```yaml
+---
+name: backend-agent
+version: 2.0.1
+description: |
+  Build and own backend services in an orchestrated multi-agent build. Use when the
+  orchestrator dispatches API, service, or data-layer work.
+allowed-tools: ["Read", "Write", "Edit", "Bash"]
+requires_claude_code: true
+min_plan: starter
+owns:
+  directories: ["src/api/", "src/services/"]
+  patterns: ["Dockerfile*"]
+  shared_read: ["contracts/"]
+composes_with: ["contract-author"]
+spawned_by: ["orchestrator"]
+---
+```
+
+## Spec Versioning and Stability
+
+This versions the **standard itself**, not the skills that conform to it.
+
+- **Canonical identifier.** The standard is `spec/PSFS.md` in the Skill-Madness
+  repository; its machine-readable form is `spec/frontmatter.schema.json`, whose `$id`
+  carries the same version. The document `Version` header and the schema `title`/`$id` are
+  bumped in lockstep.
+- **Versioning policy.** PSFS uses semantic versioning. A MAJOR bump removes or
+  incompatibly redefines a field or constraint; a MINOR bump adds an optional field or
+  relaxes a constraint in a backward-compatible way (existing conformant skills stay
+  conformant); a PATCH bump is editorial. Because Core parsers MUST ignore unrecognized
+  keys, additive MINOR releases do not break older parsers.
+- **Deprecation.** A field is marked deprecated at least one MINOR release before any
+  MAJOR release removes it (as `allowed_tools` is deprecated in favor of `allowed-tools`).
+  Deprecated fields continue to validate until the removing MAJOR release.
+
+## Changelog
+
+This section tracks every released version of the standard.
+
+- 1.1.0 — Editorial and normative clarifications from spec review; backward-compatible
+  (no field added or removed, no constraint changed, every previously-conformant skill
+  stays conformant). Folded across two review passes:
+  - *Initial 1.1.0 changes.* Added a **Parser Requirements** section (Core parsers MUST
+    accept and ignore unrecognized keys; `allowed-tools` is authoritative when the
+    deprecated `allowed_tools` alias is also present); documented the angle-bracket threat
+    model and its intentional strictness; added **Skill Versioning** and **Spec Versioning
+    and Stability** sections; defined the `owns` object shape and the ownership-resolution
+    order; added Core and Extended worked examples; scoped `name` uniqueness to the
+    collection (not a global "ecosystem"); moved the rationale into a non-normative
+    Motivation note.
+  - *Second review pass.* Clarified that the angle-bracket rule applies to every string
+    value and key at any depth (including `metadata`) and documented the split enforcement
+    (schema for typed fields, bash validator walks the whole frontmatter) — the reference
+    validator was updated to enforce this. Made ownership-resolution rule (3) tool-agnostic
+    (undefined at the PSFS layer; runtimes SHOULD resolve deterministically and MUST surface
+    unresolvable conflicts). Added a **Reference resolution** rule for
+    `composes_with`/`spawned_by` (in-collection refs WARN if unresolved, plugin-namespaced
+    refs are external and not flagged) — the validator was updated to stop flagging
+    `plugin:` refs. Noted that *broadening* `owns` is breaking at the collection level.
+    Recommended declaring the conformance claim in the collection README (machine-readable
+    manifest deferred).
+- 1.0.0 — initial publication.

--- a/spec/frontmatter.schema.json
+++ b/spec/frontmatter.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/the-hive-ecosystem/Skill-Madness/spec/frontmatter.schema.json",
+  "title": "Portable Skill Frontmatter Spec (PSFS) v1.1.0",
+  "description": "Canonical, portable, tool-agnostic JSON Schema for SKILL.md frontmatter, conforming to the Portable Skill Frontmatter Spec (PSFS) v1.1.0 (see spec/PSFS.md). This schema expresses PER-FILE STRUCTURE ONLY: required fields, types, patterns, and enumerations for a single SKILL.md frontmatter object. CROSS-FILE checks are explicitly OUT OF SCOPE for JSON Schema and remain in scripts/lint-skills.sh: name uniqueness within the collection, name == directory name, and owns.directories non-overlap between role skills. Core fields (name, version, description plus Anthropic optionals) define Core conformance; the multi-agent extension fields define Extended conformance.",
+  "type": "object",
+  "required": ["name", "version", "description"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Skill identifier. Kebab-case, must match the skill folder name (folder match enforced by lint-skills.sh, not this schema).",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "maxLength": 64
+    },
+    "version": {
+      "type": "string",
+      "description": "Semantic version MAJOR.MINOR.PATCH.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "description": {
+      "type": "string",
+      "description": "Primary trigger text. No XML angle brackets ('<' or '>') — frontmatter loads into Claude's system prompt.",
+      "maxLength": 1024,
+      "pattern": "^[^<>]*$"
+    },
+
+    "compatibility": {
+      "type": "string",
+      "description": "Human-readable environment requirements. No angle brackets.",
+      "minLength": 1,
+      "maxLength": 500,
+      "pattern": "^[^<>]*$"
+    },
+    "license": {
+      "type": "string",
+      "description": "Per-skill license override. No angle brackets.",
+      "pattern": "^[^<>]*$"
+    },
+    "allowed-tools": {
+      "type": "array",
+      "description": "Canonical: whitelist of tool names the skill may invoke.",
+      "items": {
+        "type": "string",
+        "pattern": "^[^<>]*$"
+      }
+    },
+    "allowed_tools": {
+      "type": "array",
+      "description": "Deprecated alias of allowed-tools (underscore form). Accepted for back-compat; new skills should use allowed-tools.",
+      "items": {
+        "type": "string",
+        "pattern": "^[^<>]*$"
+      }
+    },
+    "argument-hint": {
+      "type": "string",
+      "description": "Hint shown in Claude Code's slash-command UI for skills taking a positional argument. No angle brackets.",
+      "pattern": "^[^<>]*$"
+    },
+    "disable-model-invocation": {
+      "type": "boolean",
+      "description": "When true, the skill is invocable only by an orchestrator or explicit slash-command, not Claude's normal auto-trigger."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Free-form attribution, cataloging, and integration metadata.",
+      "additionalProperties": true
+    },
+
+    "requires_agent_teams": {
+      "type": "boolean",
+      "description": "Extended: true if the skill requires CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1."
+    },
+    "requires_claude_code": {
+      "type": "boolean",
+      "description": "Extended: true if the skill requires the Claude Code CLI (bash, filesystem access)."
+    },
+    "min_plan": {
+      "type": "string",
+      "description": "Extended: minimum plan tier required.",
+      "enum": ["starter", "pro", "team", "enterprise"]
+    },
+    "owns": {
+      "type": "object",
+      "description": "Extended: ownership declaration for agent role skills. Cross-file non-overlap of owns.directories is enforced by lint-skills.sh, not this schema.",
+      "properties": {
+        "directories": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[^<>]*$" }
+        },
+        "patterns": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[^<>]*$" }
+        },
+        "shared_read": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[^<>]*$" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "composes_with": {
+      "type": "array",
+      "description": "Extended: other skill names this naturally works with (informational).",
+      "items": { "type": "string", "pattern": "^[^<>]*$" }
+    },
+    "spawned_by": {
+      "type": "array",
+      "description": "Extended: which skills spawn this one.",
+      "items": { "type": "string", "pattern": "^[^<>]*$" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/standard/01-standard.bats
+++ b/tests/standard/01-standard.bats
@@ -1,0 +1,228 @@
+#!/usr/bin/env bats
+# 01-standard.bats — PSFS standard: schema + lint-skills.sh --standard.
+#
+# Contract: contracts/standards/psfs.md v1.0.0 (P3, Agent B).
+#
+# Cases:
+#   - `lint-skills.sh --standard` prints a line containing PSFS and 1.1.0; exit 0
+#   - spec/frontmatter.schema.json is valid JSON
+#   - schema passes Draft202012Validator.check_schema (skips if jsonschema absent)
+#   - GATE: every real skills/**/SKILL.md frontmatter validates against the
+#     schema, excluding archive/ + in-progress/ (skips if jsonschema absent)
+#   - negative fixtures (bad semver, non-kebab name, '<' in description,
+#     bad min_plan enum) each FAIL schema validation; a minimal Core-valid
+#     frontmatter PASSES (skips if jsonschema absent)
+#   - regression: `lint-skills.sh skills/` exits 0 on the real tree
+
+setup_file() {
+  export REPO_ROOT
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  export LINTER="$REPO_ROOT/scripts/lint-skills.sh"
+  export SCHEMA="$REPO_ROOT/spec/frontmatter.schema.json"
+  # Detect jsonschema once for skip gating.
+  export HAS_JSONSCHEMA=false
+  if python3 -c "import jsonschema" >/dev/null 2>&1; then
+    HAS_JSONSCHEMA=true
+  fi
+}
+
+@test "--standard prints PSFS and 1.1.0 and exits 0" {
+  run "$LINTER" --standard
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PSFS"* ]]
+  [[ "$output" == *"1.1.0"* ]]
+}
+
+@test "--standard names the canonical schema path" {
+  run "$LINTER" --standard
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"frontmatter.schema.json"* ]]
+}
+
+@test "schema is valid JSON" {
+  run python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$SCHEMA"
+  [ "$status" -eq 0 ]
+}
+
+@test "schema declares JSON Schema draft 2020-12" {
+  run python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('\$schema',''))" "$SCHEMA"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"2020-12"* ]]
+}
+
+@test "schema passes Draft202012Validator.check_schema" {
+  if [ "$HAS_JSONSCHEMA" != "true" ]; then
+    skip "python3 jsonschema not installed"
+  fi
+  run python3 -c "import json,sys; from jsonschema import Draft202012Validator; Draft202012Validator.check_schema(json.load(open(sys.argv[1])))" "$SCHEMA"
+  [ "$status" -eq 0 ]
+}
+
+@test "GATE: every real SKILL.md validates against the schema" {
+  if [ "$HAS_JSONSCHEMA" != "true" ]; then
+    skip "python3 jsonschema not installed — cannot run real-tree schema gate"
+  fi
+  run python3 - "$REPO_ROOT/skills" "$SCHEMA" <<'PY'
+import os, sys, json, yaml
+from jsonschema import Draft202012Validator
+skills_root, schema_path = sys.argv[1], sys.argv[2]
+validator = Draft202012Validator(json.load(open(schema_path)))
+failures = []
+checked = 0
+for dp, dn, fn in os.walk(skills_root):
+    parts = dp.split(os.sep)
+    if "archive" in parts or "in-progress" in parts:
+        continue
+    if "SKILL.md" not in fn:
+        continue
+    f = os.path.join(dp, "SKILL.md")
+    lines = open(f).read().split("\n")
+    if not lines or lines[0].strip() != "---":
+        failures.append(f"{f}: missing opening ---"); continue
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i; break
+    if end is None:
+        failures.append(f"{f}: no closing ---"); continue
+    try:
+        data = yaml.safe_load("\n".join(lines[1:end])) or {}
+    except Exception as e:
+        failures.append(f"{f}: YAML error {e}"); continue
+    checked += 1
+    for err in sorted(validator.iter_errors(data), key=str):
+        loc = "/".join(str(p) for p in err.absolute_path) or "(root)"
+        failures.append(f"{f}: {loc}: {err.message}")
+print(f"checked {checked} files")
+if failures:
+    for x in failures:
+        print("FAIL", x)
+    sys.exit(1)
+PY
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"checked"* ]]
+}
+
+# _validate <yaml-frontmatter-text> — returns schema validator exit code.
+# 0 = valid, 1 = invalid. Body of the file is irrelevant for schema check.
+_validate() {
+  local fm="$1"
+  local tmp
+  tmp="$(mktemp "${TMPDIR:-/tmp}/ats-std-fix.XXXXXX")"
+  printf '%s\n' "$fm" > "$tmp"
+  python3 - "$tmp" "$SCHEMA" <<'PY'
+import sys, json, yaml
+from jsonschema import Draft202012Validator
+data = yaml.safe_load(open(sys.argv[1]).read()) or {}
+v = Draft202012Validator(json.load(open(sys.argv[2])))
+errs = list(v.iter_errors(data))
+sys.exit(1 if errs else 0)
+PY
+  local rc=$?
+  rm -f "$tmp"
+  return $rc
+}
+
+@test "fixture: minimal Core-valid frontmatter PASSES" {
+  if [ "$HAS_JSONSCHEMA" != "true" ]; then
+    skip "python3 jsonschema not installed"
+  fi
+  run _validate "name: good-skill
+version: 1.0.0
+description: A valid Core skill used as a positive fixture."
+  [ "$status" -eq 0 ]
+}
+
+@test "fixture: bad-semver version FAILS" {
+  if [ "$HAS_JSONSCHEMA" != "true" ]; then
+    skip "python3 jsonschema not installed"
+  fi
+  run _validate "name: good-skill
+version: 1.0
+description: Bad semver fixture."
+  [ "$status" -eq 1 ]
+}
+
+@test "fixture: non-kebab name FAILS" {
+  if [ "$HAS_JSONSCHEMA" != "true" ]; then
+    skip "python3 jsonschema not installed"
+  fi
+  run _validate "name: Bad_Name
+version: 1.0.0
+description: Non-kebab name fixture."
+  [ "$status" -eq 1 ]
+}
+
+@test "fixture: '<' in description FAILS" {
+  if [ "$HAS_JSONSCHEMA" != "true" ]; then
+    skip "python3 jsonschema not installed"
+  fi
+  run _validate "name: good-skill
+version: 1.0.0
+description: has a < angle bracket which is forbidden"
+  [ "$status" -eq 1 ]
+}
+
+@test "fixture: bad min_plan enum FAILS" {
+  if [ "$HAS_JSONSCHEMA" != "true" ]; then
+    skip "python3 jsonschema not installed"
+  fi
+  run _validate "name: good-skill
+version: 1.0.0
+description: Bad min_plan enum fixture.
+min_plan: gold"
+  [ "$status" -eq 1 ]
+}
+
+@test "regression: lint-skills.sh skills/ exits 0 on the real tree" {
+  run "$LINTER" "$REPO_ROOT/skills/"
+  [ "$status" -eq 0 ]
+}
+
+# --- linter behavior (not schema-only): angle-bracket walk + plugin-ref skip ---
+# These exercise scripts/lint-skills.sh directly via a temp skill whose folder
+# name matches its `name` (the linter requires name == directory name). They
+# need pyyaml (the linter's parser), not jsonschema.
+
+_has_pyyaml() { python3 -c "import yaml" >/dev/null 2>&1; }
+
+# _make_skill <name> <body-of-SKILL.md-after-name-line...>  -> echoes the file path
+_make_skill() {
+  local name="$1"; shift
+  local dir="$BATS_TEST_TMPDIR/$name"
+  mkdir -p "$dir"
+  printf '%s\n' "$1" > "$dir/SKILL.md"
+  printf '%s\n' "$dir/SKILL.md"
+}
+
+@test "linter: '<' in a metadata value is an ERROR (not just typed fields)" {
+  _has_pyyaml || skip "python3 pyyaml not installed"
+  local f
+  f="$(_make_skill meta-angle '---
+name: meta-angle
+version: 1.0.0
+description: A clean Core skill whose metadata hides a forbidden angle bracket.
+metadata:
+  note: "value with <angle> brackets"
+---
+Body content long enough to clear the stub-length check with plenty of real words here.')"
+  run "$LINTER" "$f"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"metadata.note"* ]]
+  [[ "$output" == *"'<' or '>'"* ]]
+}
+
+@test "linter: plugin-namespaced composes_with ref is NOT flagged as unknown" {
+  _has_pyyaml || skip "python3 pyyaml not installed"
+  local f
+  f="$(_make_skill plugin-ref '---
+name: plugin-ref
+version: 1.0.0
+description: A clean Core skill that composes with an external plugin skill only.
+composes_with: ["superpowers:brainstorming"]
+---
+Body content long enough to clear the stub-length check with plenty of real words here.')"
+  run "$LINTER" "$f"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"unknown skill 'superpowers:brainstorming'"* ]]
+}

--- a/tests/standard/run-tests.sh
+++ b/tests/standard/run-tests.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# run-tests.sh — Run the PSFS standard test suite.
+#
+# Contract: contracts/standards/psfs.md v1.0.0 (P3, Agent B).
+#
+# Covers: scripts/lint-skills.sh --standard, spec/frontmatter.schema.json
+# validity, the real-tree schema gate, and positive/negative fixtures.
+#
+# Requires bats-core:
+#   macOS:  brew install bats-core
+#   Ubuntu: apt install bats
+#
+# The real-tree schema gate SKIPs (does not fail) when the python3
+# `jsonschema` package is unavailable in the environment.
+#
+# Usage:
+#   bash tests/standard/run-tests.sh              # run all .bats files
+#   bash tests/standard/run-tests.sh --filter 01  # run only matching files
+#
+# Exit codes:
+#   0  all tests passed
+#   1  at least one test failed
+#   2  bats not found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FILTER="${1:-}"
+[[ "$FILTER" == "--filter" ]] && FILTER="${2:-}"
+
+if ! command -v bats >/dev/null 2>&1; then
+  printf '[run-tests] ERROR: bats-core is not installed.\n' >&2
+  printf '[run-tests]   macOS:  brew install bats-core\n' >&2
+  printf '[run-tests]   Ubuntu: apt install bats\n' >&2
+  exit 2
+fi
+
+TEST_FILES=()
+while IFS= read -r f; do
+  if [[ -z "$FILTER" ]] || [[ "$(basename "$f")" == *"$FILTER"* ]]; then
+    TEST_FILES+=("$f")
+  fi
+done < <(find "$SCRIPT_DIR" -name "*.bats" -type f | sort)
+
+if [[ ${#TEST_FILES[@]} -eq 0 ]]; then
+  printf '[run-tests] No .bats files found matching filter: %s\n' "${FILTER:-*}" >&2
+  exit 1
+fi
+
+if [[ -t 1 ]]; then
+  bats --timing "${TEST_FILES[@]}"
+else
+  bats --tap "${TEST_FILES[@]}"
+fi


### PR DESCRIPTION
## Summary

- Publishes the repo's frontmatter convention as a named, versioned, **portable** standard — the Portable Skill Frontmatter Spec (PSFS) v1.1.0 — so other collections (incl. ECC, which is Node) can validate conformance in any language and converge on a shared vocabulary.
- Ships a tool-agnostic **JSON Schema 2020-12** as the canonical reference validator, with `lint-skills.sh --standard` as the bash reference implementation; adds a CI job that enforces the schema as a real gate.
- Defines two conformance tiers — **Core** (Anthropic-aligned, vendor-neutral) and **Extended** (multi-agent fields) — and turns previously-unenforced spec claims into actual validator behavior.

## Changes

- `spec/PSFS.md` — the published standard: conformance tiers, normative field catalog, parser requirements, ownership-resolution rules, skill + spec versioning policy, worked Core/Extended examples, reference-validator split.
- `spec/frontmatter.schema.json` — canonical portable validator (validates all 47 skills clean).
- `scripts/lint-skills.sh` — `--standard` binding; always-on angle-bracket walk over the whole parsed frontmatter (incl. nested `metadata`, independent of `jsonschema`); skips plugin-namespaced `composes_with`/`spawned_by` refs (dropped tree warnings 111 → 98).
- `tests/standard/` — 14 bats (real-tree gate, schema well-formedness, positive/negative fixtures, + 2 linter-behavior regressions).
- `.github/workflows/lint-skills.yml` — new **Frontmatter Standard / PSFS (Ubuntu)** job (installs `jsonschema`, enforces the schema).
- `contracts/installer/lint-rules.md` → 1.3.0 (Frontmatter Safety ERROR + plugin-ref exclusion); `contracts/standards/psfs.md` (build contract); README + `frontmatter-spec.md` pointer + BUILD_RESULTS + MISSION_SKILLS + QE report.

## Test plan

- [x] `scripts/lint-skills.sh skills/` exits 0 (0 errors) — gate not weakened
- [x] `scripts/lint-skills.sh --standard` reports PSFS v1.1.0 + schema path
- [x] `bash tests/standard/run-tests.sh` → 14/14 pass
- [x] Schema passes `Draft202012Validator.check_schema`; all 47 skills validate clean
- [x] Both spec examples validate against the schema
- [ ] CI: confirm the new `Frontmatter Standard / PSFS (Ubuntu)` job passes on the runner
- [ ] markdownlint on `spec/*.md` + README (not run locally — npx unavailable in env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)