### PR TITLE
feat: Add plan-intake + living-plan skills for report→ledger intake

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/ivy00johns"
   },
   "metadata": {
-    "description": "All the skills, all the agents, all the chaos — a contract-first multi-agent orchestrator and the 47-skill library it draws from.",
+    "description": "All the skills, all the agents, all the chaos — a contract-first multi-agent orchestrator and the 49-skill library it draws from.",
     "version": "0.1.0",
     "homepage": "https://github.com/ivy00johns/Skill-Madness",
     "license": "MIT"
@@ -15,7 +15,7 @@
     {
       "name": "skill-madness",
       "source": "./",
-      "description": "Install all 47 Skill-Madness skills: the 14-phase orchestrator, 9 role agents with exclusive file ownership, 3 contract skills (OpenAPI/AsyncAPI/Pydantic/TS/JSON Schema), 5 git workflow skills, 9 meta/skill-management skills, 13 cross-cutting workflows (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …), and the interactive-doc workflow.",
+      "description": "Install all 49 Skill-Madness skills: the 14-phase orchestrator, 9 role agents with exclusive file ownership, 3 contract skills (OpenAPI/AsyncAPI/Pydantic/TS/JSON Schema), 5 git workflow skills, 9 meta/skill-management skills, 13 cross-cutting workflows (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …), and the interactive-doc workflow.",
       "version": "0.1.0",
       "author": {
         "name": "ivy00johns"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-madness",
-  "description": "Contract-first multi-agent orchestrator with 47 skills: a 14-phase orchestrator that authors machine-readable contracts before code, dispatches 10 role agents in parallel with exclusive file ownership, and blocks the merge on a structured QA report. Plus meta-skills, git conventions, and cross-cutting workflow tools (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …).",
+  "description": "Contract-first multi-agent orchestrator with 49 skills: a 14-phase orchestrator that authors machine-readable contracts before code, dispatches 10 role agents in parallel with exclusive file ownership, and blocks the merge on a structured QA report. Plus meta-skills, git conventions, and cross-cutting workflow tools (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …).",
   "version": "0.1.0",
   "author": {
     "name": "ivy00johns",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/ivy00johns/Skill-Madness/actions/workflows/lint-skills.yml"><img src="https://github.com/ivy00johns/Skill-Madness/actions/workflows/lint-skills.yml/badge.svg" alt="Skill Lint" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
-  <img src="https://img.shields.io/badge/skills-47-success.svg" alt="47 skills" />
+  <img src="https://img.shields.io/badge/skills-49-success.svg" alt="49 skills" />
   <img src="https://img.shields.io/badge/role%20agents-10-blueviolet.svg" alt="10 role agents" />
   <img src="https://img.shields.io/badge/orchestrator-14%20phases-success.svg" alt="14-phase orchestrator" />
   <img src="https://img.shields.io/badge/hosts-11-orange.svg" alt="11 hosts" />
@@ -40,13 +40,13 @@ Every AI coding tool ships the same trap: one agent, one context window, one set
 - 📜 **Contract-first** — `contract-author` writes OpenAPI / AsyncAPI / Pydantic / TypeScript / JSON Schema *before* a line of implementation. `contract-auditor` verifies every shipped module against the spec. Agents can't drift; the contract is the truth.
 - 🤖 **Ten role agents, exclusive ownership** — backend, frontend, infrastructure, QE, security, docs, observability, db-migration, performance, code-review. Each declares `owns.directories` / `owns.files` in its frontmatter. No two agents touch the same path. Conflicts get resolved before spawn, not after.
 - 🛡️ **QA gate that blocks** — `qe-agent` emits a `qa-report.json` with critical / high / medium / low findings plus contract-conformance and security scores. The orchestrator gates the merge on the report. Agents can't self-declare "done."
-- 🪜 **Progressive disclosure** — frontmatter (~100 tokens) always loaded, body loaded on trigger, references loaded on demand. A 47-skill library stays cheap to host.
+- 🪜 **Progressive disclosure** — frontmatter (~100 tokens) always loaded, body loaded on trigger, references loaded on demand. A 49-skill library stays cheap to host.
 - 🔁 **Two-runtime degradation** — Agent Teams (parallel tmux) → subagents (Task tool) → sequential. The orchestrator picks the highest mode the host supports; role skills work standalone in any of them.
-- 🧰 **47 skills, six categories, all CI-linted** — orchestrator, roles, contracts, meta-skills (skill-writer, skill-explorer, skill-review, skill-update), git workflow conventions, and 26 cross-cutting workflow skills (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, diagnose-loop, grill-me, …). Frontmatter, body length, and cross-skill ownership all gated on every push.
+- 🧰 **49 skills, six categories, all CI-linted** — orchestrator, roles, contracts, meta-skills (skill-writer, skill-explorer, skill-review, skill-update), git workflow conventions, and 26 cross-cutting workflow skills (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, diagnose-loop, grill-me, …). Frontmatter, body length, and cross-skill ownership all gated on every push.
 - 🌐 **Portable across eleven hosts** — `SKILL.md` is the canonical source; converters emit Claude Code, Copilot, Cursor, Aider, Windsurf, OpenCode, Qwen, OpenClaw, Gemini CLI, Antigravity, and Kimi formats. The orchestrator's parallel-dispatch metadata is Claude-Code-specific, but everything else (role definitions, contracts, workflows, git conventions, meta-skills) ports cleanly. See [Also works on ten other hosts](#-also-works-on-ten-other-hosts).
 
 > **Status — read before you pitch this to anyone:**
-> - **The orchestrator + 47-skill library is the mature part.** All bodies under 500 lines, zero ownership conflicts, zero broken cross-references, full Ubuntu + macOS lint matrix on every push.
+> - **The orchestrator + 49-skill library is the mature part.** All bodies under 500 lines, zero ownership conflicts, zero broken cross-references, full Ubuntu + macOS lint matrix on every push.
 > - **Claude Code is the end-to-end-verified host.** Multi-agent dispatch with file-ownership exclusivity and the `qa-report.json` gate runs live on Claude Code today. The other ten hosts receive skill *content* but don't run the orchestrator's parallel dispatch.
 > - **Lossy conversion is announced.** When a skill is converted to a non-Claude-Code host, orchestration-only fields (`allowed_tools`, `owns`, `composes_with`, `spawned_by`, `requires_agent_teams`) are stripped with a stderr line per skill. Skills marked `requires_claude_code: true` are skipped entirely for those targets. See `contracts/installer/per-tool-output-spec.md`.
 
@@ -77,7 +77,7 @@ From inside Claude Code:
 /plugin install skill-madness@skill-madness
 ```
 
-That installs all 47 skills into Claude Code's plugin storage. No clone, no symlink, no edits-to-the-repo workflow. Use this if you just want the skills.
+That installs all 49 skills into Claude Code's plugin storage. No clone, no symlink, no edits-to-the-repo workflow. Use this if you just want the skills.
 
 To update later: `/plugin update skill-madness`.
 
@@ -174,7 +174,7 @@ flowchart TB
         gpmc[git-post-merge-cleanup]
     end
 
-    subgraph workflows["⚙️ workflows/ — 26 skills"]
+    subgraph workflows["⚙️ workflows/ — 28 skills"]
         direction TB
         pb[plan-builder]
         cm[context-manager]
@@ -249,7 +249,7 @@ flowchart TB
 
 ## 🧰 Skill catalog
 
-47 skills organized into six categories. All bodies under 500 lines, all frontmatter validated, zero ownership conflicts, zero broken cross-references.
+49 skills organized into six categories. All bodies under 500 lines, all frontmatter validated, zero ownership conflicts, zero broken cross-references.
 
 <details>
 <summary><b>📚 Full skill table</b> (click to expand)</summary>
@@ -519,7 +519,7 @@ Almost always a `pyyaml` version skew. CI installs `pyyaml` explicitly on macOS 
 </details>
 
 <details>
-<summary><b>"My non-Claude-Code host doesn't see all 47 skills"</b></summary>
+<summary><b>"My non-Claude-Code host doesn't see all 49 skills"</b></summary>
 
 Expected. Skills with `requires_claude_code: true` (notably the `orchestrator` and most of `roles/`) are skipped for hosts that can't execute multi-agent dispatch. Run `./scripts/convert.sh --verbose` to see the skip list per host.
 </details>
@@ -546,7 +546,7 @@ Set the override env var documented in `scripts/README.md` (e.g. `CURSOR_RULES_D
 
 ## 🗺️  Roadmap
 
-- [x] **Skill library** — 47 skills, six categories, all linted
+- [x] **Skill library** — 49 skills, six categories, all linted
 - [x] **Multi-tool installer** — convert / install / lint, eleven host adapters
 - [x] **CI matrix** — Ubuntu + macOS lint on every push
 - [x] **Contract-first specs** — OpenAPI / AsyncAPI / Pydantic / TypeScript / JSON Schema templates

--- a/skills/workflows/living-plan/SKILL.md
+++ b/skills/workflows/living-plan/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: living-plan
+version: 1.0.0
+description: |
+  Document and set up the living-plan convention: a front door (START-HERE.md), a
+  strategic doc, a tactical ledger, and a frontier doc, wired to an intake loop so
+  reports become tracked entries rather than rotting. Use when the user says "set up
+  a living plan", "make this plan a living doc", "organize project plans", "give this
+  project a planning front door", "stop my docs from rotting", or wants to establish
+  a report-to-ledger intake loop on a project.
+requires_agent_teams: false
+requires_claude_code: true
+min_plan: starter
+owns:
+  directories: []
+  patterns: []
+  shared_read: ["*"]
+allowed-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]
+composes_with: ["plan-intake", "plan-builder", "repo-deep-dive", "work-item-brief"]
+spawned_by: []
+---
+
+# Living Plan
+
+> **Purpose:** Make plans that stay alive. A living plan has a single front door, three
+> canonical documents, and one intake loop. Reports become tracked work — they never just rot.
+
+## The Convention
+
+A living plan has **three layers + one front door + one intake loop**.
+
+### 1. Front door — `START-HERE.md` (one screen)
+
+The single place to land. Contains:
+
+- **Status at a glance** — current milestones or waves and their state. A few lines, updated regularly.
+- **Ownership map** — which docs are canonical (edit these), which are frozen reference (read, don't edit), and which are archived (history, superseded). One-line description per doc.
+- **How work flows in** — one sentence pointing to the intake loop.
+
+Keep it to one screen. If it grows longer, something belongs in one of the canonical docs instead.
+
+### 2. Strategic doc — `BUILD-PLAN.md` or `PLAN.md`
+
+The roadmap: waves or milestones with their scope and exit criteria, plus a **closure log** that records what shipped and when. The strategic doc answers "where are we going and what have we finished?"
+
+### 3. Tactical ledger — `docs/REMAINING-WORK.md`
+
+Every open item, ID'd, prioritized, and sourced. Must document its own entry format and ID scheme at the top so new items are formatted consistently. The tactical ledger answers "what exactly needs to be done?"
+
+Entry shape (adapt to project conventions):
+
+| ID | Priority | Wave | Area | Source | Summary | Status | Owner |
+|----|----------|------|------|--------|---------|--------|-------|
+
+IDs are stable and never reused. Priority (P0–P3 or equivalent), Wave/Phase, and Source are the minimum useful columns.
+
+### 4. Frontier doc — `docs/FUTURE.md`
+
+Items explicitly out of scope for the current roadmap. Keeps them from cluttering the tactical ledger while ensuring they aren't lost. Short, updated as scope decisions are made.
+
+### Small-project collapse
+
+Small projects may collapse layers 2–4 into a single file (e.g. one `PLAN.md` with sections for roadmap, open items, and out-of-scope ideas). Always keep the front door and the intake loop — those are non-negotiable.
+
+## The Intake Loop (the load-bearing rule)
+
+Reports don't rot here. Any finished report — deep dive, audit, skill-review, QA findings — enters the living plan via this loop:
+
+```
+report  →  plan-intake skill  →  proposed entries  →  human approval  →  ledger + closure log
+```
+
+The rule: **every report-producing workflow ends by proposing entries.** `repo-deep-dive` invokes `plan-intake` on its gap/integration findings. Audit and skill-review outputs go through `plan-intake` before they're filed. Nothing is "done" until it has either landed in the ledger or been explicitly dismissed.
+
+`plan-intake` is fail-closed: nothing writes to the ledger without explicit human approval.
+
+## Setting It Up on a New Project
+
+### Step 1 — Copy the front-door template
+
+```bash
+cp template/START-HERE.template.md START-HERE.md
+```
+
+Open `START-HERE.md` and fill every `{{PLACEHOLDER}}`. The ownership map is the most important part: list every planning doc and classify it as canonical, frozen reference, or archived. This is the map new contributors (and future Claude sessions) use to navigate.
+
+### Step 2 — Ensure the three canonical docs exist
+
+Check whether `BUILD-PLAN.md` (or `PLAN.md`), `docs/REMAINING-WORK.md`, and `docs/FUTURE.md` exist. If any are missing:
+
+- Use `plan-builder` to create a strategic doc + tactical ledger from scratch when none exist.
+- Create `docs/FUTURE.md` as a simple markdown list — it doesn't need a formal structure.
+- If the project already has equivalent docs under different names, use those; update `START-HERE.md` to name them correctly.
+
+### Step 3 — Point CLAUDE.md and README at START-HERE.md
+
+Add a line near the top of `CLAUDE.md` (and optionally `README.md`) directing new sessions to `START-HERE.md`. Example:
+
+```markdown
+> Start here: see `START-HERE.md` for the current status and ownership map.
+```
+
+### Step 4 — Adopt the intake loop
+
+Install or sync the `plan-intake` skill so it's available in the project's skill set. Announce to the team (or to your future self in `START-HERE.md`) that reports go through `plan-intake` before being filed.
+
+## Reference Implementation
+
+**The Hive** (`/Users/johns/Repos/the-hive-ecosystem/The-Hive`) is the canonical example:
+
+| Role | File |
+|------|------|
+| Front door | `START-HERE.md` |
+| Strategic doc | `BUILD-PLAN.md` |
+| Tactical ledger | `docs/REMAINING-WORK.md` |
+| Frontier doc | `docs/FUTURE.md` |
+| Intake skill | `plan-intake` (invoked after every deep dive or audit) |
+
+The Hive's `docs/REMAINING-WORK.md` header documents its ID scheme (prefixed, stable, never reused), priority labels (P0–P3), wave labels (A/B/C/—), and area taxonomy — the exact information `plan-intake` needs to format new entries correctly.
+
+## Relation to Other Skills
+
+```text
+repo-deep-dive / skill-review / audit
+              |
+              v
+          plan-intake  ←──  living-plan convention
+              |
+              v
+      ledger entries  →  orchestrator / work-item-brief
+```
+
+- **`plan-intake`** is the intake loop made executable. `living-plan` documents the convention; `plan-intake` runs it.
+- **`plan-builder`** creates a strategic doc + ledger from scratch. Use it in Step 2 when neither exists.
+- **`repo-deep-dive`** ends by calling `plan-intake` on its findings whenever the target project has a ledger.
+- **`work-item-brief`** expands individual ledger entries into full implementation briefs.

--- a/skills/workflows/living-plan/template/START-HERE.template.md
+++ b/skills/workflows/living-plan/template/START-HERE.template.md
@@ -1,0 +1,28 @@
+# {{PROJECT_NAME}} — Start Here
+
+> The one place to land. If you're lost, read this first.
+> **Last updated:** {{DATE}}
+
+## Status at a glance
+
+<!-- One small table or short paragraph: current milestones/waves and their state. Keep it to a few lines. -->
+{{STATUS_SNAPSHOT}}
+
+## Which doc is which (ownership map)
+
+**Canonical — the living plan (edit these):**
+- {{STRATEGIC_DOC}} — strategic roadmap + closure log
+- {{TACTICAL_LEDGER}} — every open item, ID'd + prioritized
+- {{FRONTIER_DOC}} — explicitly out of scope
+
+**Frozen reference (read, don't edit):**
+- {{SPEC_OR_REFERENCE}} <!-- e.g. a frozen spec, ADRs, external research; or remove this block -->
+
+**Archived (history; superseded):**
+- {{ARCHIVE_DIR}} <!-- where superseded drafts live, each with a breadcrumb -->
+
+## How work flows in
+
+Reports don't rot here. A deep-dive, audit, or review report becomes tracked work via the
+report→ledger intake loop: run the `plan-intake` skill on the report, approve the proposed
+entries, and they land in the ledger. See the `living-plan` skill for the full convention.

--- a/skills/workflows/plan-intake/SKILL.md
+++ b/skills/workflows/plan-intake/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: plan-intake
+version: 1.0.0
+description: |
+  Turn any report (repo-deep-dive output, audit, skill-review, QA findings, design audit) into approved entries in a project's living-plan ledger. Use when the user says "intake this report", "add findings to the plan", "turn this audit into work items", "update the ledger from this report", "feed the deep-dive into the plan", or has a finished report and wants it tracked instead of rotting. Format-agnostic: adopts the target project's existing entry format.
+requires_agent_teams: false
+requires_claude_code: true
+min_plan: starter
+owns:
+  directories: []
+  patterns: []
+  shared_read: ["*"]
+allowed-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]
+composes_with: ["plan-builder", "repo-deep-dive", "skill-review", "work-item-brief"]
+spawned_by: []
+---
+
+# Plan Intake
+
+> **Purpose:** Reports become tracked work instead of rotting. Plan-intake is the bridge between a finished report and a project's living tactical ledger.
+
+## When this skill applies
+
+Use this skill when:
+
+- A `repo-deep-dive`, audit, `skill-review`, QA findings doc, or any other report exists and its findings are not yet reflected in the project's ledger.
+- The user wants findings ingested as first-class tracked work items, not left as a one-off doc.
+- The project already has a living ledger (e.g. `docs/REMAINING-WORK.md`) with its own entry format and ID scheme.
+
+**This skill is not for creating a plan from scratch.** For that, use `plan-builder`. Plan-intake appends to an existing living plan — it never replaces or restructures the ledger's existing organization.
+
+## What to do
+
+Translate a finished report into approved, consistently-formatted entries in the target project's tactical ledger.
+
+**Announce at start:** "Using plan-intake to turn the report into approved ledger entries."
+
+## Inputs
+
+1. **Report file** — a markdown document produced by `repo-deep-dive`, a design audit, `skill-review`, QA findings, or any other structured analysis. The user will @-mention or point to the file.
+2. **Target ledger** — the project's living tactical ledger. Default: `docs/REMAINING-WORK.md`. The user may specify a different path.
+3. **Strategic companion** — the project's high-level closure log or roadmap. Default: `BUILD-PLAN.md`. The user may specify a different file or indicate none exists.
+
+## Workflow
+
+### Step 1 — Read the ledger's own rules first
+
+Before touching any content, open the target ledger and read its header section. Most well-maintained ledgers document:
+
+- Entry format (fields, column order, required vs optional)
+- ID scheme (prefix conventions, numeric ranges, or slug patterns; IDs that are stable and never reused)
+- Status vocabulary (open, in-progress, done, deferred, etc.)
+- Priority and wave/phase labels
+- Area or category taxonomy
+
+Adopt that project's format exactly. Never impose this skill's own format onto the ledger. If the ledger has no documented format, infer the format from the existing entries and note the inference in your proposal.
+
+Example: The Hive's `REMAINING-WORK.md` "How this is organized" section defines Priority P0–P3, Wave A/B/C/— , Area, Source, Status, and Owner columns, plus a stable never-reused ID prefix scheme. A report from a Glass UI audit would get fresh IDs in the `G`-prefixed namespace (or whatever prefix the report source calls for), formatted to match every existing entry in that table.
+
+### Step 2 — Extract findings from the report
+
+Read the full report and identify every distinct actionable finding. Each finding that could stand alone as a work item becomes one candidate entry. Non-actionable observations (summaries, background, rationale) are context only — do not convert them into entries.
+
+Criteria for a candidate entry:
+
+- It describes something that could be done or fixed.
+- It is scoped tightly enough to be assigned and tracked.
+- It is not already implied by a broader entry already in the ledger.
+
+### Step 3 — Deduplicate against the existing ledger
+
+For each candidate entry, grep the ledger for existing entries covering the same subject, the same source link, or the same affected file or component. Flag likely duplicates — do not propose them as new entries. When in doubt, flag and let the human decide; do not silently drop candidates.
+
+### Step 4 — Propose a review table
+
+Present all non-duplicate candidates as a table for human review before writing anything. The table columns match the project's ledger format. At minimum show:
+
+| Proposed ID | Priority | Wave/Phase | Area | Source | Entry summary (one line) |
+
+- Assign proposed IDs using the project's ID scheme. For a new report source, use a fresh never-reused prefix bundle (check existing IDs to avoid collisions).
+- Keep each entry summary to one line.
+- If the ledger uses additional columns (Owner, Status, etc.), include them with appropriate defaults (e.g. Status: open, Owner: —).
+- Annotate any entry flagged as a possible duplicate with a note pointing to the existing entry.
+
+### Step 5 — Gate: get explicit human approval
+
+Present the proposal table and **wait for explicit approval before writing anything.** This skill is fail-closed: no approval, no writes.
+
+The human may:
+
+- Approve the full table as-is.
+- Approve a subset (strike individual rows).
+- Edit priorities, waves, or IDs before approving.
+- Reject and ask for a revised proposal.
+
+Do not proceed until approval is unambiguous. If the response is ambiguous, ask once for clarification.
+
+### Step 6 — Write approved entries into the ledger
+
+On a feature branch (never directly on the default branch):
+
+1. Insert each approved entry into the correct Area section of the ledger, maintaining the existing sort order within that section (typically by priority, then by ID).
+2. If the project uses a strategic companion (e.g. `BUILD-PLAN.md`), and any approved entry is P0 or P1 priority (or the project's equivalent of high-urgency), add a brief note in the companion's open-items or closure-log section referencing the new IDs.
+3. Never modify documents marked frozen, archived, or read-only (e.g. a spec doc with a "Status: Frozen" header). If the report source is one of those docs, read it for findings but do not edit it.
+
+### Step 7 — Report what landed
+
+After writing, report back:
+
+- How many entries were proposed, how many approved, how many written.
+- The IDs of every entry written (list them explicitly so the human can verify).
+- The branch name and which files were modified.
+- Any candidates that were dropped as duplicates, with pointers to the existing entries they matched.
+
+## Behavior rules
+
+- **Fail-closed.** No approval from the human, no writes to the ledger. This is non-negotiable.
+- **Format-agnostic.** This skill has no opinion about what a ledger entry should look like. It adopts the project's existing format exactly. Two different projects may produce completely different entry shapes; that is correct.
+- **Never touch frozen docs.** A report source marked frozen, archived, or read-only is read-only for findings extraction. Do not edit it.
+- **Feature branch only.** All writes happen on a feature branch. Never write directly to the default branch (main/master).
+- **Infer, don't invent.** If the ledger has no documented format, infer from existing entries and state the inference explicitly in the proposal table. Do not silently impose a format.
+- **Conservative deduplication.** When unsure if a candidate duplicates an existing entry, flag it rather than silently dropping it. The human sees the flag and decides.
+- **One skill, one ledger.** Process one target ledger per invocation. If the user wants findings distributed across multiple ledgers, run the skill once per ledger.
+
+## Relation to other skills
+
+```text
+repo-deep-dive / skill-review / audit   →   plan-intake   →   ledger entries
+                                                                      ↓
+                                                              orchestrator consumes
+```
+
+- **`plan-builder`** creates a plan from scratch. `plan-intake` appends to an existing plan. Use plan-builder when there is no ledger yet; use plan-intake when the ledger already exists.
+- **`repo-deep-dive`** produces the reports that plan-intake most commonly consumes.
+- **`skill-review`** produces skill-quality findings that plan-intake can route into a skill-collection ledger.
+- **`work-item-brief`** produces detailed briefs for individual items; plan-intake creates the items in the ledger that work-item-brief would then expand.

--- a/skills/workflows/repo-deep-dive/SKILL.md
+++ b/skills/workflows/repo-deep-dive/SKILL.md
@@ -93,6 +93,14 @@ Read `references/parallelization.md` for: the subagent strategy across phases, h
 
 > **Forbidden:** Dropping the series into a detected knowledge vault but skipping Phase 5. An unlinked deep-dive folder inside a wiki is an orphan — if the target is a vault, integrate it (source/entity/concept/comparison pages + index + log) per the vault's own conventions.
 
+## Final step: feed findings into the living plan
+
+After producing the reference series, if the target project has a living plan/ledger
+(look for `START-HERE.md`, `BUILD-PLAN.md`, or `docs/REMAINING-WORK.md`), invoke the
+`plan-intake` skill on the integration/gap findings so they become tracked entries
+rather than a static report. Skip only if the project has no ledger.
+(For skill-creator / skill-review reports, run `plan-intake` manually on the report — same loop.)
+
 ## Reference Files
 
 - `references/phases.md` — detailed instructions for Phases 1-4 with measurement commands and subagent dispatch patterns


### PR DESCRIPTION
## Summary

- Closes the gap where deep-dive/audit/review **reports rot** — generated, then never turned into tracked work.
- Adds `plan-intake`: a format-agnostic engine that reads a report, dedupes against an existing ledger, proposes entries, and writes them **only after explicit human approval** (fail-closed).
- Adds `living-plan`: documents the reusable convention (front door + strategic doc + tactical ledger + frontier doc, wired to the intake loop) and ships a `START-HERE.template.md`.
- Wires `repo-deep-dive` to hand its findings to `plan-intake` as a final phase, so the loop closes automatically.

## Changes

- `skills/workflows/plan-intake/SKILL.md` — new skill (PSFS-conformant frontmatter; 7-step gated workflow).
- `skills/workflows/living-plan/SKILL.md` + `template/START-HERE.template.md` — new convention skill + scaffold.
- `skills/workflows/repo-deep-dive/SKILL.md` — appended "feed findings into the living plan" final step.

## Test plan

- [x] Both new skills pass PSFS frontmatter validation (name/version/description + extended fields).
- [x] `repo-deep-dive` references `plan-intake`; target skill exists.
- [x] Dogfooded end-to-end in the sibling The-Hive repo: `plan-intake` turned a 20-finding Glass UI audit into 18 approved ledger entries (GA1–GA18) behind the human-approval gate.
- [ ] Reviewer: confirm the convention reads clearly and the intake loop is the load-bearing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)