### PR TITLE
fix: Consolidate Playwright skill outputs under .playwright/<run-id>/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,13 @@
 .workspaces/
 *-workspace/
 
-# Playwright test outputs — screenshots and results per run
+# Playwright test outputs — all ephemeral artifacts consolidate under one root
+.playwright/
+# Defaults Playwright/MCP write to when a project's own config is used — ignored as noise
+.playwright-mcp/
+playwright-report/
+test-results/
+# Legacy pre-consolidation dirs (kept so old runs don't show as untracked)
 playwright-screenshots/
 playwright-results/
 

--- a/skills/workflows/playwright/SKILL.md
+++ b/skills/workflows/playwright/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playwright
-version: 1.3.0
+version: 1.4.0
 description: |
   Run browser-based E2E tests, capture screenshots, and validate user flows using Playwright with visible Chrome. Use this skill when testing a web UI end-to-end, capturing screenshots for visual review, checking responsive layouts, or auditing accessibility in a real browser. Trigger on: "e2e test", "screenshot the UI", "click through the app", "responsive layout check", "accessibility audit". Also invoke when qe-agent needs browser-level integration testing.
 requires_agent_teams: false
@@ -56,13 +56,13 @@ npx playwright install chromium
 
 3. **Execute the run.** The standard `RUN_ID=$(date +%Y-%m-%d_%H-%M-%S)` command for both `@playwright/test` runner and standalone `npx tsx` execution is in `references/selectors-guide.md`.
 
-4. **Lay out the outputs.** All runs go under `playwright-screenshots/<run-id>/` (PNG screenshots) and `playwright-results/<run-id>/` (reports, traces, JSON). Both directories are gitignored. See `references/screenshot-workflow.md` for the exact directory layout and naming convention.
+4. **Lay out the outputs.** Everything from a run lives under a single gitignored root: `.playwright/<run-id>/`, with `screenshots/` (PNGs) and `results/` (traces, raw JSON, logs, the test script) beneath it. One root keeps a project's working tree from sprouting `playwright-screenshots/`, `playwright-results/`, `.playwright-mcp/`, and `test-results/` side by side. See `references/screenshot-workflow.md` for the exact directory layout and naming convention.
 
-5. **Produce the report.** Report mode emits two files in the results directory: `playwright-report.json` (structured) and `playwright-report.md` (human-readable). See `references/screenshot-workflow.md` for the exact JSON schema and markdown template.
+5. **Produce the report.** Report mode emits two files at the run-dir top level: `.playwright/<run-id>/report.json` (structured) and `report.md` (human-readable). See `references/screenshot-workflow.md` for the exact JSON schema and markdown template.
 
 ## Coordination with QE Agent
 
-When spawned by qe-agent during Phase 2 (Integration Verification): qe-agent provides base URL + flows + acceptance criteria; you return `playwright-report.json` + the screenshot directory path; qe-agent incorporates the findings into the overall QA report. Full handoff details — and standalone invocation — are in `references/screenshot-workflow.md`.
+When spawned by qe-agent during Phase 2 (Integration Verification): qe-agent provides base URL + flows + acceptance criteria; you return the run-dir path (`.playwright/<run-id>/`) — its `report.json` plus the `screenshots/` directory; qe-agent incorporates the findings into the overall QA report. Full handoff details — and standalone invocation — are in `references/screenshot-workflow.md`.
 
 ## Troubleshooting
 

--- a/skills/workflows/playwright/references/screenshot-workflow.md
+++ b/skills/workflows/playwright/references/screenshot-workflow.md
@@ -4,21 +4,28 @@ How runs are laid out on disk, and the exact format of the structured + human-re
 
 ## Output Directories
 
-All outputs go into gitignored directories at the project root:
+Everything a run produces lives under **one** gitignored root: `.playwright/`. A single root is deliberate — Playwright and the Playwright MCP server otherwise scatter artifacts across `playwright-screenshots/`, `playwright-results/`, `.playwright-mcp/`, `playwright-report/`, and `test-results/` at the project root, which is the mess this convention exists to prevent.
 
-- **`playwright-screenshots/<run-id>/`** — PNG screenshots captured during the run
-- **`playwright-results/<run-id>/`** — test reports, traces, and the structured JSON summary
+Per run:
+
+```text
+.playwright/<run-id>/
+  screenshots/   — PNG screenshots captured during the run
+  results/       — the test script, traces, raw JSON reporter output, output.log
+  report.json    — the structured summary (this skill's schema, below)
+  report.md      — the human-readable summary
+```
 
 The `<run-id>` is a timestamp: `YYYY-MM-DD_HH-MM-SS` (e.g., `2026-04-08_14-32-07`).
 
-These directories are gitignored — they exist for local review only, never committed.
+`.playwright/` is gitignored — it exists for local review only, never committed. If a project still has loose `playwright-screenshots/`, `playwright-results/`, `.playwright-mcp/`, or a stray `playwright.config.ts.bak` from before this convention, those are pre-consolidation debris and safe to delete.
 
 ## Screenshot Naming Convention
 
-Within a run directory, screenshots follow this layout:
+Within a run, screenshots follow this layout:
 
 ```text
-playwright-screenshots/<run-id>/
+.playwright/<run-id>/screenshots/
   <flow-name>/
     01-<step-description>.png
     02-<step-description>.png
@@ -28,7 +35,7 @@ playwright-screenshots/<run-id>/
 Example:
 
 ```text
-playwright-screenshots/2026-04-08_14-32-07/
+.playwright/2026-04-08_14-32-07/screenshots/
   login-flow/
     01-login-page-loaded.png
     02-credentials-entered.png
@@ -40,9 +47,9 @@ playwright-screenshots/2026-04-08_14-32-07/
 
 ## Report Mode Output
 
-After a run completes, produce two files in the results directory.
+After a run completes, produce two files at the run-dir top level (`.playwright/<run-id>/`).
 
-### playwright-report.json
+### report.json
 
 ```json
 {
@@ -81,9 +88,9 @@ After a run completes, produce two files in the results directory.
 }
 ```
 
-### playwright-report.md
+### report.md
 
-Human-readable summary with inline screenshot references. Use this format:
+Human-readable summary with inline screenshot references. Screenshot paths are relative to the run's `screenshots/` directory. Use this format:
 
 ```markdown
 # Playwright Test Report
@@ -125,7 +132,7 @@ Screenshots still go into the timestamped directory even in spot-check mode — 
 When spawned by qe-agent during Phase 2 (Integration Verification):
 
 - qe-agent provides: base URL, user flows to test, acceptance criteria
-- You return: `playwright-report.json` and the screenshot directory path
+- You return: the run-dir path `.playwright/<run-id>/` — its `report.json` and `screenshots/` directory
 - qe-agent incorporates your findings into their overall QA report
 - Your screenshots serve as evidence for pass/fail assertions in the QA report
 

--- a/skills/workflows/playwright/references/selectors-guide.md
+++ b/skills/workflows/playwright/references/selectors-guide.md
@@ -13,7 +13,7 @@ From the inputs you receive (plan excerpt, acceptance criteria, user request), b
 
 ## Writing the Test Script
 
-Create a Playwright test file in your run's results directory. The test launches **non-headless Chromium** so screenshots show the actual rendered UI:
+Create a Playwright test file in your run's results directory (`.playwright/<run-id>/results/`). Write screenshots to `.playwright/<run-id>/screenshots/` — pass the run dir in via an env var (e.g. `RUN_DIR`) so the script knows where to put them. The test launches **non-headless Chromium** so screenshots show the actual rendered UI:
 
 ```typescript
 import { test, expect } from '@playwright/test';
@@ -40,19 +40,22 @@ test.use({
 
 ```bash
 RUN_ID=$(date +%Y-%m-%d_%H-%M-%S)
-mkdir -p playwright-screenshots/$RUN_ID playwright-results/$RUN_ID
+export RUN_DIR=.playwright/$RUN_ID
+mkdir -p "$RUN_DIR/screenshots" "$RUN_DIR/results"
 
-npx playwright test playwright-results/$RUN_ID/test.spec.ts \
+npx playwright test "$RUN_DIR/results/test.spec.ts" \
   --project=chromium \
   --reporter=json \
-  --output=playwright-results/$RUN_ID \
-  2>&1 | tee playwright-results/$RUN_ID/output.log
+  --output="$RUN_DIR/results" \
+  2>&1 | tee "$RUN_DIR/results/output.log"
 ```
+
+`--output` redirects Playwright's per-test artifacts (traces, videos) into the run dir instead of the default top-level `test-results/`. The test script reads `RUN_DIR` to place its screenshots under `$RUN_DIR/screenshots/`.
 
 If tests are written as standalone scripts (not using `@playwright/test` runner), execute directly:
 
 ```bash
-npx tsx playwright-results/$RUN_ID/test-script.ts
+npx tsx "$RUN_DIR/results/test-script.ts"
 ```
 
 ## Accessibility Quick-Check

--- a/skills/workflows/playwright/references/setup.md
+++ b/skills/workflows/playwright/references/setup.md
@@ -59,18 +59,19 @@ npx tsx --version 2>/dev/null || npm install -D tsx
 
 ## Playwright Configuration
 
-If the project doesn't have a `playwright.config.ts`, you don't necessarily need one — tests can be run with CLI flags. But if the project has one, respect its settings and only override what's needed for screenshots.
+If the project doesn't have a `playwright.config.ts`, you don't necessarily need one — tests can be run with CLI flags. But if the project has one, respect its settings and only override what's needed for screenshots. If you do edit an existing config, edit it in place — don't leave a `playwright.config.ts.bak` behind; that stray backup is exactly the kind of clutter this skill avoids.
 
 ### Minimal Config for Screenshot Runs
 
-When you need a config (e.g., for custom viewports or multiple projects):
+When you need a config (e.g., for custom viewports or multiple projects), keep every artifact under the single `.playwright/` root by overriding the two paths Playwright otherwise writes to the project root (`outputDir` defaults to `./test-results`, the HTML reporter to `./playwright-report`):
 
 ```typescript
 // playwright.config.ts
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './playwright-results',
+  outputDir: '.playwright/artifacts',                                  // traces/videos (default: ./test-results)
+  reporter: [['html', { outputFolder: '.playwright/html-report', open: 'never' }]], // default: ./playwright-report
   timeout: 30_000,
   expect: { timeout: 5_000 },
   fullyParallel: false, // sequential for predictable screenshots


### PR DESCRIPTION
## Summary

- Playwright outputs were scattered across five different project-root directories — `playwright-screenshots/`, `playwright-results/`, `playwright-report/`, `test-results/`, and `.playwright-mcp/`. Half came from the skills, half from Playwright/MCP defaults leaking through.
- This collapses every ephemeral artifact into a single gitignored root: `.playwright/<run-id>/` with `screenshots/`, `results/`, and `report.{json,md}`.

## Changes

- **`playwright` skill (v1.3.0 → 1.4.0)** — SKILL.md steps 4/5 + QE handoff rewritten to the single root; `screenshot-workflow.md`, `selectors-guide.md`, and `setup.md` updated to match. The config example now redirects Playwright's own defaults (`outputDir` → `.playwright/artifacts`, HTML reporter → `.playwright/html-report`) so `test-results/` and `playwright-report/` stop appearing at project root.
- **`.gitignore`** — ignores `.playwright/` plus the default-leak dirs (`.playwright-mcp/`, `playwright-report/`, `test-results/`); legacy two lines kept so old runs don't show as untracked.
- **`ux-review`** (global, `~/.claude/skills/`, v1.1.0) got the same convention — sets a `RUN_DIR`, passes it to `browser_take_screenshot`, and reconciles any MCP-dropped shots into the run dir. *Not in this repo, so not part of this PR's diff.*
- **`render-sanity`** — takes no screenshots (no `browser_take_screenshot` in its allowed-tools); only output is its durable `docs/` report. Unaffected.

## Test plan

- [ ] Run the `playwright` skill on a project and confirm screenshots/results/reports all land under `.playwright/<run-id>/` and nothing else appears at project root.
- [ ] Confirm `git status` stays clean after a run (everything gitignored).