### PR TITLE
feat: Add mobile-responsive playbook to frontend-agent and ui-brief

### DIFF
--- a/skills/roles/frontend-agent/SKILL.md
+++ b/skills/roles/frontend-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-agent
-version: 1.3.0
+version: 1.5.0
 disable-model-invocation: true
 description: "Orchestrator-dispatched only. Builds user interfaces, client-side state, and presentation layers for multi-agent builds. Composes with frontend-design and ui-ux-pro-max for visual quality. Not user-invocable."
 compatibility: "Claude Code; requires Bash + Node toolchain"
@@ -130,7 +130,19 @@ EventSource or fetch+ReadableStream. Handle chunk/done/error per contract. Accum
 
 ### 6. Styling
 
-Responsive by default, 4.5:1 contrast, no opacity-0 on interactive elements, visible focus states.
+Baseline: 4.5:1 contrast, no opacity-0 on interactive elements, visible focus states.
+
+**Before you write any CSS, read `references/mobile-responsive.md`.** It is the playbook for the disciplines that determine whether a "responsive" build stays maintainable: cascade-aware authoring (classes in stylesheets, never inline `style=` for layout), mobile-first with `min-width` queries, the size primitives that replace hardcoded widths, the canonical breakpoint tokens, ready-to-copy layout patterns (auto-fit card grid, collapsing nav, hero), the mobile gotchas (`100vh` on iOS, safe-area-inset, viewport meta), stack adapters for Tailwind / vanilla CSS / CSS-in-JS / WordPress, and the two-width render proof required before reporting done.
+
+Two rules from that file matter enough to repeat here so the rest of this step makes sense:
+
+- **Layout CSS lives in stylesheets, not in `style=` attributes.** An inline `style` beats any non-`!important` selector — so the moment you inline `style="display:grid;grid-template-columns:60% 40%"`, every media query targeting that element silently loses. Once one rule needs `!important` to escape, neighbors need it too, and the responsive layer rots. Class + stylesheet rule, every time. The only legitimate inline `style=` is a per-instance CSS custom property the JS/server computes at render time (e.g. `style="--progress: 72%"`).
+
+- **No hardcoded `width: <px>` on layout containers.** `width: 1200px` on a wrapper locks the layout off mobile entirely. Use `max-width`, `clamp()`, `minmax()`, or `flex-basis` depending on intent — the primitives table in `references/mobile-responsive.md` picks for you. Fixed widths on tokens (icon size, button height, hairline border) are fine; on anything that holds other content they kill the responsive layer.
+
+If you reach for `!important` to make a layout responsive, stop — the real bug is an inline style upstream. Move it to a class.
+
+For server-rendered themes (WordPress / Rails / Phoenix / Django / PHP) the same rules apply, plus the platform-specific stylesheet-registration mechanism — see the "Server-rendered themes" section of `references/mobile-responsive.md` (e.g. `wp_enqueue_style()` with `filemtime()` versioning for WordPress). Templates carry `class=` attributes only; no `<style>` blocks.
 
 ### 7. Accessibility (non-negotiable)
 
@@ -156,6 +168,11 @@ Focus indicators, labels on inputs, descriptive button text, alt text, keyboard 
 | Types diverge from contract | Mirror contracts/types |
 | Using innerHTML for rendering | Use createElement + textContent to prevent XSS |
 | Over-engineering vanilla JS | No build tools, no frameworks for simple projects |
+| Inline `style=` on elements for layout | Class + stylesheet rule — inline styles can't be overridden by media queries without `!important` |
+| `!important` to make a layout responsive | The real bug is an inline style upstream; move it to a class instead |
+| Hand-written `<style>`/`style=` in server templates | Enqueue/register the stylesheet (e.g. `wp_enqueue_style`); templates carry `class=` only |
+| Hardcoded `width: <px>` on layout containers | Pick from the size primitives in `references/mobile-responsive.md` — `max-width`, `clamp()`, `minmax()`, `flex-basis` — by intent |
+| Desktop-first with `max-width` media-query patches | Invert: write mobile-first base rules, layer with `min-width` queries |
 
 ## Validation
 

--- a/skills/roles/frontend-agent/references/mobile-responsive.md
+++ b/skills/roles/frontend-agent/references/mobile-responsive.md
@@ -1,0 +1,247 @@
+# Mobile-First & Responsive Discipline
+
+The patterns, tokens, and verification that keep a "responsive" build from rotting into inline styles, hardcoded widths, and an `!important` pile. SKILL.md points here before any CSS is written. Read top-to-bottom the first time; come back to the patterns section to copy.
+
+## Why this file exists
+
+Agents that read only SKILL.md repeatedly ship the same three failures: inline grid layouts on elements, fixed pixel widths on layout containers, and desktop-first patched with `@media (max-width: …)` queries that fight the base rules. Each one is recoverable individually; together they compound into a layout that needs `!important` to do anything, and at that point the responsive layer is unmaintainable.
+
+This file is the playbook that prevents that. It is opinionated on purpose — when there is one right answer, it gives one.
+
+## The three failure modes to avoid
+
+1. **Inline `style=` for layout.** An inline `style` attribute beats any non-`!important` selector in a stylesheet. The moment you inline `style="display:grid;grid-template-columns:60% 40%"`, every media query targeting that element silently loses. The only way back is `!important`, which then needs to propagate to neighboring rules, and the cascade is dead.
+
+2. **Hardcoded `width: <px>` on layout containers.** `width: 1200px` on a wrapper locks the layout off mobile entirely. `width: 600px` on a card means it ignores its grid cell. Fixed widths belong on *tokens* (icon sizes, button heights, hairline borders) — not on anything that holds other content.
+
+3. **Desktop-first with `max-width` patches.** Writing `.thing { grid-template-columns: 1fr 1fr; }` and then `@media (max-width: 768px) { .thing { grid-template-columns: 1fr; } }` is the workflow that produces the other two failures. The base rule is more complex than it needs to be, and every device width below the threshold is a "patch" fighting it. Inverting the order — simple base for mobile, layered enhancements above — makes the base naturally responsive and the rest additive.
+
+## Breakpoint tokens (canonical)
+
+Use these. Match Tailwind's defaults so cross-stack equivalents are obvious, and so devs new to the project don't have to learn a private vocabulary.
+
+```css
+:root {
+  --bp-sm:   640px;  /* large phone / small tablet portrait */
+  --bp-md:   768px;  /* tablet portrait */
+  --bp-lg:  1024px;  /* tablet landscape / small laptop */
+  --bp-xl:  1280px;  /* desktop */
+  --bp-2xl: 1536px;  /* wide desktop */
+}
+```
+
+Then always layer up with `min-width`:
+
+```css
+.thing { /* base — mobile */ }
+@media (min-width: 768px)  { .thing { /* tablet+ */ } }
+@media (min-width: 1024px) { .thing { /* laptop+ */ } }
+```
+
+Invent project-private breakpoints only when the content genuinely demands one — e.g. a chart whose legend wraps at 880px regardless of overall layout. Even then, name it for the content (`--bp-chart-legend: 880px`), not a new tier.
+
+## Size primitives — pick by intent, not by reflex
+
+The reason hardcoded `width: 600px` keeps appearing is that "container should be 600px" is what the design mock says. It's almost never what the design actually *needs*. Pick the primitive that matches intent:
+
+| Intent | Primitive | Example |
+|---|---|---|
+| Container should grow up to a ceiling | `max-width` | `max-width: 80ch;` |
+| Container should shrink to its content | `width: fit-content` | `width: fit-content;` |
+| Fluid between a floor and a ceiling | `clamp()` | `width: clamp(20rem, 60vw, 60rem);` |
+| Side-by-side that wraps when cramped | `flex-basis` + `flex-wrap` | `flex: 1 1 20rem;` |
+| Auto-fitting card grid | `repeat(auto-fit, minmax())` | `grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));` |
+| Reading-comfortable text width | `max-width` in `ch` | `max-width: 65ch;` |
+
+If you find yourself typing `width: <number>px` on anything that contains other elements, stop and pick from this table. Tokens (icons, button heights, hairlines) are the exception.
+
+## Fluid type and spacing
+
+Fixed `font-size: 48px` headings look comical on phones and tiny on 4K. Use `clamp()` so headings scale with viewport between a floor and a ceiling:
+
+```css
+h1 { font-size: clamp(1.75rem, 4vw + 1rem, 3.5rem); }
+h2 { font-size: clamp(1.5rem, 2.5vw + 0.75rem, 2.5rem); }
+```
+
+The middle term — `<px or rem> + <vw>` — is the magic. Pure `vw` over-scales; `clamp(min, vw, max)` is what gives the "fluid but not crazy" feel.
+
+Body text stays static at **16px floor minimum**. iOS Safari auto-zooms inputs under 16px, which is jarring; the same floor on body type keeps things consistent.
+
+For spacing, prefer `rem` (scales with user's font preference) for layout gaps. Use `px` only for hairlines (1–2px borders) and tokens that must hold a physical-pixel shape.
+
+## Layout patterns to copy
+
+These are the patterns that come up in nearly every build. Copy them; don't reinvent.
+
+### Page shell with content max-width
+
+```css
+.shell { width: 100%; padding-inline: clamp(1rem, 4vw, 2rem); }
+.shell > * { max-width: 80ch; margin-inline: auto; }
+```
+
+The shell handles the gutter; children get a reading width and auto-center. No media queries needed for the basic case.
+
+### Two-column that collapses on mobile
+
+```css
+.two-col {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: 1fr;        /* base: stacked */
+}
+@media (min-width: 768px) {
+  .two-col { grid-template-columns: 60% 40%; }
+}
+```
+
+### Auto-fit card grid (no breakpoints needed)
+
+```css
+.cards {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+```
+
+This is one of the most underused patterns. Cards reflow from 1-up on mobile to 4-up on desktop without a single media query. The `16rem` is the floor — adjust per card content.
+
+### Responsive nav (horizontal → hamburger)
+
+```css
+.nav { display: flex; gap: 1rem; flex-wrap: wrap; }
+.nav-toggle { display: none; }
+
+@media (max-width: 767px) {
+  .nav         { display: none; }
+  .nav.is-open { display: flex; flex-direction: column; }
+  .nav-toggle  { display: inline-flex; }
+}
+```
+
+The toggle button gets `display: none` by default and shows on small screens. The base nav is `flex-wrap: wrap` so it degrades gracefully even before the breakpoint kicks in.
+
+### Hero that doesn't collapse to nothing
+
+```css
+.hero {
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+  grid-template-columns: 1fr;           /* base: stacked */
+}
+@media (min-width: 1024px) {
+  .hero { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
+}
+```
+
+The `minmax(0, 1fr)` (instead of just `1fr`) is the fix for "my image inside a grid column blows the column wider than 50%" — grid items default to `min-width: auto`, which is "their content's intrinsic min", which for a big image is the image's natural width.
+
+### Image that doesn't break layout
+
+```css
+img, video { max-width: 100%; height: auto; display: block; }
+```
+
+Put this in your base reset. Forgetting it is the #1 source of "the page has a horizontal scrollbar on mobile and I can't find why."
+
+## Touch targets
+
+Minimum **44 × 44 CSS pixels** for any tap target on mobile (Apple HIG; WCAG 2.5.5 sets 24 × 24 as AA minimum, but 44 is the safer floor). On dense desktop UIs you can shrink, but the same control on a phone needs the larger hit area.
+
+```css
+.btn { min-height: 44px; padding: 0.625rem 1rem; }
+```
+
+A hover-only interaction (tooltip, dropdown trigger) is broken on touch. Every hover state needs a tap-or-focus equivalent — usually `:focus-visible` plus a click handler that toggles the same state.
+
+## Mobile gotchas that will bite you
+
+| Gotcha | Fix |
+|---|---|
+| `<meta viewport>` missing → page renders at "fake desktop" zoom | `<meta name="viewport" content="width=device-width, initial-scale=1">` in every `<head>`, no exceptions |
+| `100vh` on iOS Safari includes the URL bar and jumps when scrolled | Use `100dvh` (dynamic) or `min-height: 100svh` (smallest). Fall back: `min-height: 100vh; min-height: 100dvh;` (second wins where supported) |
+| Inputs under 16px font cause auto-zoom on iOS focus | Body inputs stay ≥ 16px. If you need a visually smaller input, set `font-size: 16px` and use `transform: scale()` for the visual shrink |
+| Mysterious horizontal scrollbar on mobile | A child element or image is wider than viewport. Don't band-aid with `overflow-x: hidden` on body — find the offender with `* { outline: 1px solid red; }` in devtools |
+| Notched devices clip content under the notch | Use `env(safe-area-inset-*)`: `padding-inline: max(1rem, env(safe-area-inset-left)) max(1rem, env(safe-area-inset-right));` |
+| `position: fixed` bars get pushed above the fold by iOS keyboard | Prefer `position: sticky` for headers; for chat-style inputs, listen for `visualViewport` resize events |
+| Image with intrinsic width breaks grid column | `minmax(0, 1fr)` in `grid-template-columns`, and `max-width: 100%; height: auto;` on the image |
+
+## Stack adapters
+
+The rules above are stack-neutral. Apply them through your stack's mechanism:
+
+### Tailwind / shadcn
+
+Tailwind's default breakpoints (`sm: 640`, `md: 768`, `lg: 1024`, `xl: 1280`, `2xl: 1536`) match the tokens above. Use `md:`, `lg:`, `xl:` prefixes mobile-first. Helpful utilities:
+
+- `max-w-prose`, `max-w-screen-md`, `container` — content widths
+- `min-h-dvh` (Tailwind 3.4+) instead of `min-h-screen` — mobile-safe full-height
+- `grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3` — explicit responsive grid
+- `grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))]` — auto-fit grid
+- `aspect-video`, `aspect-square` — instead of fixed widths/heights on media
+
+Don't redefine the default breakpoints unless the design system requires it. Don't use `style={}` props for layout — same cascade trap as inline `style=` attributes.
+
+### Vanilla CSS
+
+Tokens in `:root`, classes in stylesheets, mobile-first, `min-width` queries. No framework needed; the patterns above work as-is.
+
+### CSS-in-JS (styled-components, emotion, Linaria, vanilla-extract)
+
+Same rules apply. Base styles in the component's styled definition, media queries in the same scope. Avoid `style={}` JSX props for layout — they generate inline `style=` and inherit its specificity problem.
+
+### Server-rendered themes (WordPress / Rails / Phoenix / Django / PHP)
+
+Same rules, plus one platform constraint: there's no bundler injecting your CSS, so you must register the stylesheet through the platform's mechanism and reference classes from templates. Hand-writing `<style>` blocks or `style=` attributes in templates to "just get it working" is the failure mode.
+
+- **WordPress:** enqueue every stylesheet via `wp_enqueue_style()` in `functions.php`. Order matters — set up a dependency chain (`tokens → base → responsive`) so cascade is predictable. Version each file with `filemtime( get_stylesheet_directory() . '/path/to.css' )` so edits actually reach the browser instead of being served stale. Templates (`front-page.php`, `page-*.php`, etc.) contain markup with `class=` attributes only.
+- **Rails / ERB:** put CSS in `app/assets/stylesheets/`, register via `stylesheet_link_tag` in the layout. Same class-only discipline in templates.
+- **Phoenix LiveView:** put CSS in `assets/css/app.css`, let esbuild handle it. Live components carry `class=` attributes.
+
+A base stylesheet that ends up *smaller* than the responsive stylesheet is a strong signal that layout leaked into the templates. Investigate.
+
+## The two-width render proof (required before reporting done)
+
+A `@media` rule in CSS proves nothing if an inline style overrides it, and a `grep` for `@media` proves even less. Before reporting done, actually render the page at both widths and verify with your eyes (or a screenshot):
+
+- **375 × 667** (iPhone SE / small mobile). Browser devtools → device toolbar → 375 × 667. Or Playwright: `await page.setViewportSize({ width: 375, height: 667 })`.
+- **1440 × 900** (laptop). Same drill.
+
+At each width, check:
+
+- [ ] No horizontal scrollbar
+- [ ] Text wraps; nothing clipped
+- [ ] Images scale (no overflow)
+- [ ] Tap targets look ≥ 44 × 44 at 375px
+- [ ] Navigation is reachable (hamburger works on mobile if collapsed)
+- [ ] Hero / primary CTA visible without scrolling at the top of each width
+
+If the `playwright` skill is composable in your environment, take screenshots — they're cheap and provide receipts. Otherwise capture manually via browser devtools. The validation-checklist depends on this proof; do not skip it.
+
+## Bugs and where they actually come from
+
+| Symptom | Root cause |
+|---|---|
+| "Works in dev but breaks on phone" | Missing `<meta viewport>`, or inline `style=` overriding media query |
+| "Added a media query and nothing happened" | Inline style upstream is winning specificity. Move to a class |
+| "Layout jumps when browser resizes" | Mixed `vw` / `px` without `clamp()`, or `position: absolute` on a layout container |
+| "Cards don't wrap" | `flex-wrap: wrap` missing, or fixed `width` on cards instead of `flex-basis` |
+| "Page is wider than viewport on mobile" | A child has fixed `width: <px>` larger than viewport, or an unconstrained image. Find with `* { outline: 1px solid red; }` |
+| "Hero looks tiny on 4K, huge on phone" | Fixed `font-size: 48px`. Use `clamp()` |
+| "Everything is `!important` and I can't tell which rule wins" | Inline styles upstream. Remove them and rebuild the cascade from scratch |
+| "Image blows out grid column to its natural width" | `minmax(0, 1fr)` in `grid-template-columns` + `max-width: 100%; height: auto;` on the image |
+
+## The rules in one screen
+
+1. **Mobile-first.** Base rules unprefixed; enhancements in `min-width` queries.
+2. **Layout CSS lives in stylesheets, keyed by class.** Never inline `style=` for grid/flex/sizing. The only legitimate inline `style=` is a per-instance CSS custom property the JS/server computes (e.g. `style="--progress: 72%"`).
+3. **No hardcoded `width: <px>` on layout containers.** Use `max-width`, `clamp()`, `minmax()`, or `flex-basis` — pick by intent from the primitives table. Tokens (icons, button heights, hairlines) are the exception.
+4. **Use the canonical breakpoint tokens** (sm 640 / md 768 / lg 1024 / xl 1280 / 2xl 1536). Project-private breakpoints only when content genuinely demands it.
+5. **Fluid type with `clamp()`** for headings; static **≥ 16px** for body and inputs.
+6. **Tap targets ≥ 44 × 44** on mobile. Every hover state has a tap/focus equivalent.
+7. **`<meta viewport>` always.** Use `100dvh` / `100svh` instead of `100vh`.
+8. **Two-width render proof** at 375px and 1440px before reporting done.
+9. **If you reach for `!important`, stop** — the bug is an inline style upstream.

--- a/skills/roles/frontend-agent/references/validation-checklist.md
+++ b/skills/roles/frontend-agent/references/validation-checklist.md
@@ -114,8 +114,65 @@ If the backend is not yet available: flag CORS verification as **BLOCKED** in yo
 - Empty states display correctly
 - Loading states appear during API calls
 - Error states appear when backend is down
-- Responsive at 375px width (mobile) and 1440px (desktop)
 - Zero console errors or warnings during primary user flow
+
+## Responsive Verification
+
+The full responsive playbook is in `references/mobile-responsive.md`. The bar below is the minimum gate before reporting done — meet all of it, or do not report done.
+
+### 1. Actually render at both widths
+
+A `@media` rule in CSS proves nothing if an inline style is overriding it. Open the page at both widths and look. Capture a screenshot at each (Playwright is cheap if available; browser devtools otherwise) and include the path in your completion report so reviewers can verify.
+
+- **375 × 667** (mobile, e.g. iPhone SE) — no horizontal scrollbar; tap targets look ≥ 44 × 44; text wraps without clipping; navigation is reachable (hamburger works if collapsed); hero / primary CTA visible at the top.
+- **1440 × 900** (desktop laptop) — layout uses the extra width; no awkward giant gaps; nothing clipped.
+
+### 2. Viewport meta tag is present
+
+```bash
+grep -rE '<meta[^>]+name="viewport"[^>]+width=device-width' \
+  --include='*.html' --include='*.php' --include='*.erb' --include='*.tsx' --include='*.jsx' .
+```
+
+Every served page needs `<meta name="viewport" content="width=device-width, initial-scale=1">` in `<head>`. Without it the page renders at fake-desktop zoom on phones and none of your responsive rules matter.
+
+### 3. No hardcoded `width: <px>` on layout containers
+
+Hardcoded pixel widths on wrappers, sections, cards, columns, or any container that holds other content lock the layout off mobile. Tokens (icons, button heights, hairlines) are fine.
+
+```bash
+# Surface every fixed-pixel width declaration in CSS for human review.
+# Expect to see most matches in token files (icon-size, button-height, etc.)
+# and very few in layout files. Investigate any match in a layout-shaped file.
+grep -rnE 'width:\s*[0-9]+(px|rem)\s*;?' \
+  --include='*.css' --include='*.scss' --include='*.module.css' . \
+  | grep -viE '(icon|btn|button|avatar|chip|badge|border|hairline|--w-)'
+```
+
+For each remaining match, replace with the size primitive that matches the container's intent — `max-width`, `clamp()`, `minmax()`, or `flex-basis`. See the primitives table in `references/mobile-responsive.md`.
+
+### 4. Inline `style=` is near-zero for layout
+
+Layout CSS belongs in stylesheets; inline `style=` beats media queries on specificity and silently breaks the responsive layer. A handful of inline styles feeding CSS custom properties (e.g. `style="--progress: 72%"`) is fine; inline `display: grid` / `width: …` / `flex: …` is not.
+
+```bash
+grep -rno 'style=' \
+  --include='*.php' --include='*.erb' --include='*.html' \
+  --include='*.html.heex' --include='*.jsx' --include='*.tsx' . \
+  | wc -l
+```
+
+Read each match if the count is non-trivial. Move every layout/sizing/grid/flex inline style into a class.
+
+### 5. `!important` count is near-zero
+
+`!important` is an escape hatch, not a layout tool. A responsive stylesheet larger than its base stylesheet, or one that leans on `!important`, almost always means inline styles upstream are being clawed back.
+
+```bash
+grep -rn '!important' --include='*.css' --include='*.scss' . | wc -l
+```
+
+If the count is non-trivial, fix the source (remove the inline styles or fixed widths that prompted it) rather than adding more `!important`.
 
 ## Accessibility Verification
 

--- a/skills/workflows/ui-brief/SKILL.md
+++ b/skills/workflows/ui-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-brief
-version: 1.1.0
+version: 1.2.0
 description: |
   Generate opinionated, design-led briefs for building or rebuilding UIs so they lead with the product's actual moat instead of converging on a generic shadcn-default SaaS dashboard. Use whenever the user wants a detailed UI prompt or spec to hand off — greenfield OR rebuild. Trigger on "write me a UI brief", "the current UI sucks, redesign it", "make this not look like every shadcn admin", "I need a prompt for the frontend", "design brief for X", "the design feels generic", "build a UI for [project] like [reference]", or before non-trivial UI work when the user names a reference app or named visual style. Output is a standalone Markdown file with positioning, design-language rules, page-by-page treatment, component primitives, motion discipline, and a verifiable Definition of Done.
 requires_agent_teams: false
@@ -81,7 +81,7 @@ The briefs that work follow a specific shape. Each section earns its presence:
 5. **Page-by-Page Brief** — every primary route gets a layout treatment with what belongs and what does not.
 6. **Component Primitives** — name 8–12 reusable pieces with implied APIs (e.g. `<MetricNumber>`, `<DenseTable>`).
 7. **Motion / Sound / Notifications** — usually missing from briefs; including this section prevents drift toward over-animation or zero animation.
-8. **Accessibility & Responsive Baseline** — explicit, not aspirational. axe AA, specific viewports.
+8. **Accessibility & Responsive Baseline** — explicit, not aspirational. axe AA, specific viewports (default 375 × 667 mobile + 1440 × 900 desktop), mobile-first with `min-width` queries, the canonical breakpoint tokens (sm/md/lg/xl/2xl), no hardcoded `width: <px>` on layout containers, no inline `style=` for layout. These are contract clauses for the implementing agent — see `skills/roles/frontend-agent/references/mobile-responsive.md` for the playbook they will execute against.
 9. **Implementation Discipline** — which skills compose during the build (brainstorming → orchestrator → frontend-agent → playwright → ux-review).
 10. **Definition of Done** — verifiable items. Must include "loads in a browser with zero console errors" and a screenshot-diff item (vs old screenshot for rebuilds, vs target reference for greenfield).
 11. **Notes for the Operator** — guardrails to prevent drift back to generic defaults during the build.

--- a/skills/workflows/ui-brief/references/brief-template.md
+++ b/skills/workflows/ui-brief/references/brief-template.md
@@ -176,13 +176,19 @@ Often missing from briefs. Include it explicitly:
 
 ```markdown
 - **Pass axe AA on every route.** Wire it into the [test framework] suite, fail CI on violations.
-- **Keyboard navigable everywhere.** Tab order matches visual order. Focus rings visible.
-- **Responsive baseline**: [primary viewport] primary, must remain usable at [secondary], must show "this UI is built for [desktop/mobile]" at < [tertiary].
+- **Keyboard navigable everywhere.** Tab order matches visual order. Focus rings visible on every interactive element.
 - **Color contrast 4.5:1 minimum.** Use a checker.
 - **`prefers-reduced-motion` respected** — disables [the animations from Section 8].
+- **Mobile-first, not mobile-as-afterthought.** Base layout assumes 375px wide; larger layouts layer in via `min-width` media queries. Desktop-first with `max-width` patches is the workflow that ships hardcoded widths and inline `style=` grids — disallowed.
+- **Breakpoint tokens** (use the sm/md/lg/xl/2xl set; do not invent project-private breakpoints unless content genuinely demands one).
+- **Render proof at two widths before shipping**: 375 × 667 (mobile) and 1440 × 900 (desktop). No horizontal scroll at either; tap targets ≥ 44 × 44 on mobile; hero / primary CTA visible above the fold at both. Screenshots required — a `@media` rule in CSS proves nothing if an inline style is beating it.
+- **No hardcoded `width: <px>` on layout containers.** Use `max-width`, `clamp()`, `minmax()`, or `flex-basis` by intent. Fixed widths on tokens (icons, button heights, hairlines) are fine; on wrappers/columns/cards they lock the layout off mobile.
+- **No inline `style=` for layout.** Class + stylesheet rule, every time. The only legitimate inline `style=` is a per-instance CSS custom property the JS/server computes (e.g. `style="--progress: 72%"`).
 ```
 
-**Length:** ~80 words.
+For the full responsive playbook the frontend agent will work from, see `skills/roles/frontend-agent/references/mobile-responsive.md` — patterns, tokens, mobile gotchas, stack adapters. The bullets above are the contract; the reference is the toolkit.
+
+**Length:** ~140 words.
 
 ---
 


### PR DESCRIPTION
## Summary

- Builds kept shipping inline `style=` grids, hardcoded `width: 1200px` wrappers, and desktop-first layouts patched with `max-width` media queries — despite frontend-agent's SKILL.md technically containing responsive guidance.
- Root cause: the guidance was buried mid-file in a 188-line body competing with six other process steps. The agent reads SKILL.md once at spawn; "mobile-first" lost to whatever it was thinking about API contracts.
- Fix: move the playbook into a dedicated `references/mobile-responsive.md` loaded on demand, tighten the always-in-context surface to a hard pointer + the two highest-leverage rules, give the validation gate real teeth, and have `ui-brief` seed the contract in every brief so frontend-agent sees it alongside the API contract.

## Changes

**`frontend-agent` (v1.4.0 → 1.5.0)**
- **New `references/mobile-responsive.md`** (247 lines, stack-neutral) — the three failure modes named, canonical breakpoint tokens (sm/md/lg/xl/2xl matching Tailwind), size-primitives picker table (`max-width` / `clamp()` / `minmax()` / `flex-basis` by intent), fluid type, copy-pasteable layout patterns (page shell, two-col, auto-fit card grid, responsive nav, hero with `minmax(0, 1fr)` fix), touch targets, mobile gotchas (`100vh` on iOS, safe-area-inset, viewport meta, mystery horizontal scroll), stack adapters for Tailwind/shadcn/vanilla/CSS-in-JS/WordPress/Rails/Phoenix, two-width render proof, bug → root-cause table, one-screen rule summary.
- **`SKILL.md` Step 6** opens with **"Before you write any CSS, read `references/mobile-responsive.md`"** and inlines the two rules that catch the most failures (no inline `style=` for layout, no hardcoded `width: <px>` on containers) so an agent that skips the ref still gets them.
- **Common Pitfalls** table gains rows for hardcoded widths and desktop-first patching.
- **`validation-checklist.md`** — the one-line responsive bullet becomes a five-gate **Responsive Verification** section with grep scripts: render proof at 375 + 1440, viewport meta check, hardcoded-width grep (filtered to exclude tokens), inline `style=` count, `!important` count. Each has a pointer back into `mobile-responsive.md` for the fix.

**`ui-brief` (v1.1.0 → 1.2.0)**
- **`references/brief-template.md` Section 9** expands from 5 placeholder bullets to 9 concrete contract clauses naming the anti-patterns explicitly (no hardcoded widths on containers, no inline `style=` for layout, breakpoint tokens, mobile-first authoring, render proof at two widths).
- **`SKILL.md`** Section 8 in "What Makes A Good Brief" spells out the same clauses and points downstream at the frontend-agent reference, so briefs ship the contract instead of gesturing at it.

## Test plan

- [ ] On the next non-trivial UI build, confirm frontend-agent reads `references/mobile-responsive.md` early in the run (visible in transcript) and that its output is free of inline `style=` for layout and hardcoded `width: <px>` on containers.
- [ ] Run the new validation-checklist grep scripts against a recent build's output — expect near-zero hits.
- [ ] Generate a `ui-brief` for a new UI and confirm Section 9 now contains the explicit responsive contract clauses rather than placeholders.
- [ ] Optional: spawn parallel skill-creator eval (v1.4.0 vs v1.5.0) against a small UI prompt; grade outputs on the three failure modes.