### PR TITLE
fix: Resolve P0 audit blockers (install, QA gate, scores, paths)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -48,6 +48,8 @@
     "./skills/meta/skill-explorer",
 
     "./skills/workflows/plan-builder",
+    "./skills/workflows/living-plan",
+    "./skills/workflows/plan-intake",
     "./skills/workflows/context-manager",
     "./skills/workflows/deployment-checklist",
     "./skills/workflows/dependency-coordinator",
@@ -61,6 +63,7 @@
     "./skills/workflows/mermaid-charts",
     "./skills/workflows/nano-banana",
     "./skills/workflows/playwright",
+    "./skills/workflows/render-sanity",
     "./skills/workflows/repo-deep-dive",
     "./skills/workflows/llm-wiki",
     "./skills/workflows/railway-deploy",

--- a/skills/roles/docs-agent/SKILL.md
+++ b/skills/roles/docs-agent/SKILL.md
@@ -22,7 +22,7 @@ spawned_by: ["orchestrator"]
 
 # Docs Agent
 
-> **Pipeline position.** Spawned by `orchestrator` after contracts are authored. Reads `contract-author`'s output from `/contracts/`. Generated docs feed into qe-agent completeness score. Owns: `docs/`.
+> **Pipeline position.** Spawned by `orchestrator` after contracts are authored. Reads `contract-author`'s output from `/contracts/`. Your generated docs are an input the qe-agent may weigh in its `completeness` and `code_quality` scores — but neither of those dimensions gates the build (only `contract_conformance`, `security`, and CRITICAL blockers do). Owns: `docs/`.
 
 Generate and maintain project documentation. You read the code and contracts — you don't write application code.
 
@@ -120,4 +120,4 @@ Before reporting completion:
 - [ ] CHANGELOG follows Keep a Changelog format
 - [ ] No broken internal links
 
-The **qe-agent** validates documentation quality as part of the QA report. `qa-report.json` includes `completeness` and `code_quality` scores which cover documentation adequacy. CRITICAL blockers or scores < 3 block the build.
+The **qe-agent** weighs documentation quality in its `completeness` and `code_quality` scores. Those scores are recorded but do NOT gate the build — the build gate blocks only on a CRITICAL blocker, `contract_conformance.score < 3`, or `security.score < 3`. Docs work does not block the build via `completeness`/`code_quality`, but ship complete, accurate docs anyway: weak docs lower those recorded scores and can be cited as issues, and a severe gap (e.g., docs that contradict the contract) could be raised as a CRITICAL blocker.

--- a/skills/roles/observability-agent/SKILL.md
+++ b/skills/roles/observability-agent/SKILL.md
@@ -22,7 +22,7 @@ spawned_by: ["orchestrator"]
 
 # Observability Agent
 
-> **Pipeline position.** Spawned by `orchestrator` after contracts are authored. Reads `contract-author`'s output from `/contracts/`. Instrumentation feeds into qe-agent observability score and qa-report.json sources. Owns: `src/telemetry/`, `src/logging/`, `monitoring/`, `alerts/`.
+> **Pipeline position.** Spawned by `orchestrator` after contracts are authored. Reads `contract-author`'s output from `/contracts/`. Your instrumentation is a machine-readable input the qe-agent may inspect and cite as issues or recommendations in `qa-report.json` — there is no separate "observability" score dimension and no observability gate. Owns: `src/telemetry/`, `src/logging/`, `monitoring/`, `alerts/`.
 
 Set up logging, monitoring, metrics, and alerting. You instrument — you don't write business logic.
 
@@ -132,4 +132,4 @@ Before reporting completion:
 - [ ] Alert rules defined with thresholds documented
 - [ ] Logging/telemetry modules export clean public APIs for backend-agent to import
 
-The **qe-agent** validates observability as part of the QA report. `qa-report.json` includes `security` and `contract_conformance` scores — health checks and logging are evaluated. CRITICAL blockers or scores < 3 block the build. Do not report done until your instrumentation would pass that gate.
+The **qe-agent** may inspect your instrumentation when assembling the QA report. There is no "observability" score dimension and no observability gate — `qa-report.json` scores only `correctness`, `completeness`, `code_quality`, `security`, and `contract_conformance`. The qe-agent may cite missing health checks or logging gaps as issues or recommendations (and, if severe enough, as a CRITICAL blocker). The build gate blocks only on a CRITICAL blocker, `contract_conformance.score < 3`, or `security.score < 3`. Deliver solid instrumentation so the qe-agent has nothing to flag.

--- a/skills/roles/performance-agent/SKILL.md
+++ b/skills/roles/performance-agent/SKILL.md
@@ -22,7 +22,7 @@ spawned_by: ["orchestrator"]
 
 # Performance Agent
 
-> **Pipeline position.** Spawned by `orchestrator` after contracts are authored. Reads `contract-author`'s output from `/contracts/`. Performance run results feed into qe-agent performance score. Owns: `tests/performance/`, `load-tests/`.
+> **Pipeline position.** Spawned by `orchestrator` after contracts are authored. Reads `contract-author`'s output from `/contracts/`. Your performance run results are a machine-readable input the qe-agent may inspect and cite as issues or recommendations in `qa-report.json` — there is no separate "performance" score dimension and no SLA gate. Owns: `tests/performance/`, `load-tests/`.
 
 Design and execute performance tests. You measure and report — you don't optimize application code.
 
@@ -138,4 +138,4 @@ Before reporting completion:
 - [ ] Performance test report generated in the format shown in Process §4
 - [ ] Test scripts are parameterized (BASE_URL via env var, no hardcoded URLs)
 
-The **qe-agent** validates performance results as part of the QA report. `qa-report.json` includes performance scoring — failed SLA thresholds are flagged. CRITICAL blockers or a score < 3 block the build. Do not report done until your results would pass that gate.
+The **qe-agent** may inspect your performance results when assembling the QA report. There is no "performance" score dimension and no SLA gate — `qa-report.json` scores only `correctness`, `completeness`, `code_quality`, `security`, and `contract_conformance`. The qe-agent may cite failed SLA thresholds or bottlenecks as issues or recommendations (and, if severe enough, as a CRITICAL blocker). The build gate blocks only on a CRITICAL blocker, `contract_conformance.score < 3`, or `security.score < 3`. Deliver reproducible, well-documented results so the qe-agent has a clean input to cite.

--- a/skills/roles/qe-agent/SKILL.md
+++ b/skills/roles/qe-agent/SKILL.md
@@ -116,7 +116,7 @@ When you cannot start services (no Docker, missing deps, sandboxed env), do cont
 - **Contract is ground truth** — disagreements default to "implementation is wrong"
 - **Test in dependency order** — contract conformance → integration → edge cases
 - **Be specific** — exact commands, expected vs actual, file:line references
-- **Credit what works** — the `passed` list matters
+- **Credit what works** — record what passed in each score's `notes` and in `recommendations`
 - **Schema conformance is mandatory** — `qa-report.json` must validate against `references/qa-report-schema.json`. The orchestrator parses this programmatically.
 
 ## Anti-Pattern

--- a/skills/roles/qe-agent/references/llm-judge-rubrics.md
+++ b/skills/roles/qe-agent/references/llm-judge-rubrics.md
@@ -1,6 +1,6 @@
 # LLM-as-Judge Scoring Rubrics
 
-Rubrics for the five dimensions in the QA report's `scores` section. Each dimension is scored 1–5. The QE agent uses these to self-score; the orchestrator uses them to validate.
+Rubrics for the five dimensions in the QA report's `scores` section. Each dimension is an object with a numeric `score` (1–5) and `notes`, addressed as `scores.<dimension>.score` — for example `scores.contract_conformance.score`. The QE agent uses these to self-score; the orchestrator uses them to validate.
 
 ## Correctness (Does it work?)
 
@@ -57,8 +57,8 @@ Rubrics for the five dimensions in the QA report's `scores` section. Each dimens
 The orchestrator blocks the build (`gate_decision.proceed = false`) when:
 
 - Overall `status` is `FAIL` or `BLOCKED`
-- Any blocker has `severity: CRITICAL`
-- `scores.contract_conformance < 3`
-- `scores.security < 3`
+- Any entry in `blockers` has `severity` `CRITICAL`
+- `scores.contract_conformance.score < 3`
+- `scores.security.score < 3`
 
-A score of 3 is the minimum acceptable threshold — it means "functional but needs improvement." Scores of 4-5 indicate production-ready quality.
+Only `contract_conformance` and `security` gate on score. The other three dimensions (`correctness`, `completeness`, `code_quality`) are scored and surfaced but do not auto-block. A score of 3 is the minimum acceptable threshold — it means "functional but needs improvement." Scores of 4-5 indicate production-ready quality.

--- a/skills/roles/qe-agent/references/qa-report-schema.md
+++ b/skills/roles/qe-agent/references/qa-report-schema.md
@@ -2,20 +2,38 @@
 
 The `qa-report.json` is the orchestrator's build gate. The orchestrator parses it programmatically and blocks the build on CRITICAL blockers or `contract_conformance` / `security` scores below 3. A non-conformant report is as bad as no report.
 
-The canonical machine-readable schema lives at `qa-report-schema.json` in this directory. This document explains the structure, the score model, and how to produce a conformant report.
+`qa-report-schema.json` in this directory is the authoritative schema — the single source of truth. This document explains the structure, the score model, and how to produce a conformant report; if anything here disagrees with the JSON, the JSON wins.
 
 ## File pair
 
 The QE agent writes both files at the end of Phase 4:
 
-- `qa-report.md` — human-readable narrative with findings table and summary
+- `qa-report.md` — human-readable narrative with a defect table and summary
 - `qa-report.json` — machine-readable per `qa-report-schema.json` (the gate)
 
-Both files share the same findings; the JSON exists so the orchestrator can parse without LLM calls.
+Both files describe the same defects; the JSON exists so the orchestrator can parse without LLM calls.
 
-## Schema shape (summary)
+## Top-level keys
 
-The `qa-report.json` MUST include the following top-level dimensions. Each is an object with `score` (1–5 integer) and `notes` (string explaining the score). Bare integers are non-conformant.
+The `qa-report.json` is an object with these required top-level keys (all must be present):
+
+- `schema_version` — string, const `"1.0.0"`
+- `timestamp` — RFC 3339 / ISO 8601 date-time string
+- `agent_role` — string, const `"qe"`
+- `build_session_id` — string identifying the build session
+- `status` — one of `PASS` | `FAIL` | `PARTIAL` | `BLOCKED`
+- `scores` — object of the five scored dimensions (see below)
+- `test_results` — object of test counts per suite (see below)
+- `blockers` — array of blocker objects (gate-affecting defects)
+- `issues` — array of issue objects (non-gating defects)
+- `recommendations` — array of strings
+- `gate_decision` — object with `proceed` (boolean) and `reason` (string)
+
+The orchestrator parses by name, not position — field names must match the schema exactly.
+
+## Scores
+
+The `scores` object MUST include all five dimensions. Each is an object with `score` (1–5 integer) and `notes` (string explaining the score). Bare integers are non-conformant.
 
 ```json
 {
@@ -23,13 +41,9 @@ The `qa-report.json` MUST include the following top-level dimensions. Each is an
   "completeness":         { "score": 4, "notes": "..." },
   "code_quality":         { "score": 4, "notes": "..." },
   "security":             { "score": 4, "notes": "..." },
-  "contract_conformance": { "score": 5, "notes": "..." },
-  "findings": [ ... ],
-  "passed":   [ ... ]
+  "contract_conformance": { "score": 5, "notes": "..." }
 }
 ```
-
-Refer to `qa-report-schema.json` for the full field list, required vs optional, and finding object shape.
 
 ## Dimension definitions
 
@@ -41,23 +55,36 @@ Score each 1–5 per `references/llm-judge-rubrics.md`. Use these definitions wh
 - **security** — is it safe? Input validated, no injection, CORS correct, no secrets leaked? Coordinate with security-agent if present — avoid duplicating their deeper audit.
 - **contract_conformance** — does the implementation match the spec? URLs, methods, request/response shapes, status codes, error envelope, field names.
 
-## Finding object
+## test_results
 
-Each finding in the `findings` array must include:
+The `test_results` object MUST include `unit`, `integration`, `e2e`, `contract`, and `security_scan`. Each is an object of `pass`, `fail`, and `skip` integer counts (each ≥ 0).
+
+## blockers and issues
+
+Defects are split into two arrays — there is no `findings` or `passed` array.
+
+- **`blockers`** — gate-affecting defects. Each entry has `severity` of `CRITICAL` or `HIGH`. A single `CRITICAL` blocker fails the gate.
+- **`issues`** — non-gating defects. Each entry has `severity` of `MEDIUM`, `LOW`, or `INFO`.
+
+Each blocker and issue object requires:
 
 - `id` — stable identifier (e.g., `CR-001`)
-- `severity` — `CRITICAL` | `HIGH` | `MEDIUM` | `LOW`
-- `dimension` — which scored dimension it pulls down
-- `agent` — which agent owns the fix (from the orchestrator's ownership map)
-- `summary` — one-line description
-- `evidence` — exact reproduction command or file:line reference
-- `expected` — what the contract or test required
-- `actual` — what the implementation produced
+- `severity` — `CRITICAL` | `HIGH` for blockers; `MEDIUM` | `LOW` | `INFO` for issues
+- `category` — for blockers, one of `contract_violation` | `security` | `build_failure` | `test_failure` | `other`; for issues, a free-form string
+- `description` — what is wrong, with exact reproduction command or `file:line` reference and expected vs actual
+- `suggested_fix` — how to resolve it
 
-## Passed list
+`file` (string or null) and `line` (integer or null) are optional on both.
 
-The `passed` array is not optional. Credit what works — list contract-conformance checks that succeeded, happy-path flows that ran clean, adversarial probes that did not break the system. The orchestrator uses this to calibrate the score notes.
+## recommendations and gate_decision
+
+- **`recommendations`** — array of strings. Forward-looking advice that is not itself a defect.
+- **`gate_decision`** — object with `proceed` (boolean) and `reason` (string). The QE agent fills this per the gate rules in `references/severity-thresholds.md`; the orchestrator re-derives it from `status`, `blockers`, and `scores`.
+
+## Crediting what works
+
+There is no `passed` array. Credit what works inside the `notes` of each score and in `recommendations` — call out contract-conformance checks that succeeded, happy-path flows that ran clean, and adversarial probes that did not break the system. A score must reflect what was actually tested.
 
 ## Examples
 
-See the canonical schema file and an example report under the orchestrator's reference materials. Field names must match the schema exactly — the orchestrator parses by name, not position.
+See the canonical schema file `qa-report-schema.json` and an example report under the orchestrator's reference materials. Field names must match the schema exactly — the orchestrator parses by name, not position.

--- a/skills/roles/qe-agent/references/severity-thresholds.md
+++ b/skills/roles/qe-agent/references/severity-thresholds.md
@@ -2,38 +2,42 @@
 
 The QA report is the build gate. This document defines severity assignment, score-threshold rules, and the gate decision logic the orchestrator applies to `qa-report.json`.
 
+Defects are recorded in two arrays: `blockers` (severity `CRITICAL` or `HIGH`) and `issues` (severity `MEDIUM`, `LOW`, or `INFO`). There is no `findings` array.
+
 ## Severity ladder
 
-Assign exactly one severity to each finding. Use the strictest applicable level:
+Assign exactly one severity to each defect, then place it in the right array. Use the strictest applicable level:
 
-- **CRITICAL** — blocks release. The build must not ship until this is fixed. Examples: missing required endpoint, broken auth, contract field-name mismatch on the wire, data corruption risk, exposed secrets.
-- **HIGH** — should block. Will cause user-visible failure in expected use. Examples: wrong status code, missing CORS for the contracted origin, error envelope omitted, validation gap on a documented input.
-- **MEDIUM** — fix before the next release. Edge-case failure or contract drift risk that does not yet break the happy path. Examples: shared types not imported (manual dicts that could drift), inconsistent error wording, missing rate limit on a non-critical endpoint.
-- **LOW** — nice to fix. Style, naming, or low-impact code smell.
+- **CRITICAL** — blocks release; goes in `blockers`. The build must not ship until this is fixed. Examples: missing required endpoint, broken auth, contract field-name mismatch on the wire, data corruption risk, exposed secrets.
+- **HIGH** — should block; goes in `blockers`. Will cause user-visible failure in expected use. Examples: wrong status code, missing CORS for the contracted origin, error envelope omitted, validation gap on a documented input.
+- **MEDIUM** — fix before the next release; goes in `issues`. Edge-case failure or contract drift risk that does not yet break the happy path. Examples: shared types not imported (manual dicts that could drift), inconsistent error wording, missing rate limit on a non-critical endpoint.
+- **LOW** — nice to fix; goes in `issues`. Style, naming, or low-impact code smell.
+- **INFO** — observational; goes in `issues`. Not a defect, but worth surfacing.
 
 ## Score-to-severity mapping
 
-Scores are not arbitrary — they reflect the worst finding in a dimension:
+Scores are not arbitrary — they reflect the worst defect (blocker or issue) in a dimension:
 
-| Findings present                       | Maximum score for the dimension |
+| Worst defect in the dimension          | Maximum `scores.<dim>.score`    |
 | -------------------------------------- | ------------------------------- |
 | Any CRITICAL                           | 2 (forces gate fail)            |
 | Any HIGH but no CRITICAL               | 3                               |
 | Only MEDIUM                            | 4                               |
-| Only LOW or none                       | 5                               |
+| Only LOW/INFO or none                  | 5                               |
 
-If a dimension has multiple CRITICAL findings, score it 1.
+If a dimension has multiple CRITICAL defects, score it 1.
 
 ## Gate decision logic
 
 The orchestrator blocks the build if **any** of the following hold:
 
-1. The `findings` array contains a finding with `severity == "CRITICAL"`.
-2. `contract_conformance.score < 3`.
-3. `security.score < 3`.
-4. The report is missing any of the required dimensions or is not valid against `qa-report-schema.json`.
+1. The `blockers` array contains an entry with `severity == "CRITICAL"`.
+2. `scores.contract_conformance.score < 3`.
+3. `scores.security.score < 3`.
+4. `status` is `FAIL` or `BLOCKED`.
+5. The report is missing any of the required keys or is not valid against `qa-report-schema.json`.
 
-Otherwise the build is allowed to complete. The orchestrator does not negotiate — these thresholds are hardcoded.
+Otherwise the build is allowed to complete. The orchestrator does not negotiate — these thresholds are hardcoded. Note: the other three score dimensions (`correctness`, `completeness`, `code_quality`) are scored but do **not** gate, even below 3.
 
 ## Why these specific thresholds
 
@@ -53,7 +57,7 @@ A premature `qa-report.json` with the lead unaware is worse than no report.
 
 ## Anti-patterns to avoid
 
-- Marking a dimension 5 when the `passed` list is empty. Score must reflect what was actually tested.
-- Bundling multiple problems under one finding to avoid raising the severity. One issue per finding.
+- Marking a dimension 5 without evidence in its `notes` of what was actually tested. Score must reflect what was actually tested.
+- Bundling multiple problems under one blocker or issue to avoid raising the severity. One defect per entry.
 - Lowering a CRITICAL to HIGH because "the team will fix it next sprint." Severity describes the defect, not the schedule.
 - Skipping the JSON and only writing the markdown. The orchestrator only parses JSON; markdown is for humans.

--- a/skills/workflows/setup-project-skills/references/templates/contract-format-jsonschema.md
+++ b/skills/workflows/setup-project-skills/references/templates/contract-format-jsonschema.md
@@ -12,7 +12,7 @@ This repository uses **JSON Schema** as the source of truth for integration cont
 
 When the orchestrator invokes `contract-author` in this repo, it should:
 
-1. Use the JSON Schema template at `skills/contracts/contract-author/references/templates/jsonschema-template.json`.
+1. Use the JSON Schema template at `skills/contracts/contract-author/references/json-schema-template.json`.
 2. Write to `contracts/schemas/<name>.schema.json`.
 3. Include `$id`, `$schema`, `title`, `description`, `type`, `properties`, `required`, and `additionalProperties: false` at every object level.
 

--- a/skills/workflows/setup-project-skills/references/templates/contract-format-openapi.md
+++ b/skills/workflows/setup-project-skills/references/templates/contract-format-openapi.md
@@ -12,7 +12,7 @@ This repository uses **OpenAPI** (Swagger) for integration contracts. REST endpo
 
 When the orchestrator invokes `contract-author` in this repo, it should:
 
-1. Use the OpenAPI template at `skills/contracts/contract-author/references/templates/openapi-template.yaml`.
+1. Use the OpenAPI template at `skills/contracts/contract-author/references/openapi-template.yaml`.
 2. Write to `contracts/openapi/<name>.openapi.yaml`.
 3. Include request/response schemas, error responses, and authentication declarations.
 

--- a/skills/workflows/setup-project-skills/references/templates/contract-format-pydantic.md
+++ b/skills/workflows/setup-project-skills/references/templates/contract-format-pydantic.md
@@ -12,7 +12,7 @@ This repository uses **Pydantic models** as the source of truth for integration 
 
 When the orchestrator invokes `contract-author` in this repo, it should:
 
-1. Use the Pydantic template at `skills/contracts/contract-author/references/templates/pydantic-template.py`.
+1. Use the Pydantic template at `skills/contracts/contract-author/references/pydantic-template.py`.
 2. Write to `contracts/models/<domain>_contracts.py`.
 3. Include request, response, error, and event models with full type annotations and field-level docstrings.
 

--- a/skills/workflows/setup-project-skills/references/templates/contract-format-ts.md
+++ b/skills/workflows/setup-project-skills/references/templates/contract-format-ts.md
@@ -12,7 +12,7 @@ This repository uses **TypeScript interfaces** as the source of truth for integr
 
 When the orchestrator invokes `contract-author` in this repo, it should:
 
-1. Use the TypeScript template at `skills/contracts/contract-author/references/templates/typescript-template.ts`.
+1. Use the TypeScript template at `skills/contracts/contract-author/references/typescript-template.ts`.
 2. Write to `contracts/types/<domain>.contracts.ts`.
 3. Export request, response, error, and event interfaces. Use discriminated unions for sum types. Include JSDoc on every exported type.
 


### PR DESCRIPTION
## Summary

First wave (P0) of the **reports-v2 functional audit** remediation — the four ship-stoppers. Each fix was made by a file-scoped agent, re-checked by an independent skeptic, and re-verified objectively against the canonical schema before commit.

## Changes

- **plugin.json — install manifest was 46/49.** Added `render-sanity` (the orchestrator's *hard ship gate*), `living-plan`, and `plan-intake`. A fresh `/plugin install` now yields a working ship gate. (49 unique entries, all resolve to a real `SKILL.md`.)
- **qe-agent — QA gate could silently reject a conformant report.** Reconciled the prose docs (`qa-report-schema.md`, `severity-thresholds.md`, `llm-judge-rubrics.md`, one line in `SKILL.md`) to the canonical `qa-report-schema.json`. Dropped the nonexistent `findings[]`/`passed[]` shape; documented the real top-level keys, the five `scores.<dim>.score` objects, the `blockers`/`issues` split (matching the `$defs`), `test_results`, `gate_decision`. The JSON is now declared the single source of truth.
- **observability / performance / docs agents — phantom gate scores.** Reworded so each agent's output is a *non-gating input the qe-agent may cite*, not a scored gate dimension (the schema has exactly 5 dims; no observability/performance dimension; `completeness`/`code_quality` are scored but don't gate).
- **setup-project-skills — broken contract-template path baked into consumer repos.** Fixed all four `contract-format-*.md` to point at the real `skills/contracts/contract-author/references/<x>-template.<ext>` (no `templates/` subdir; `json-schema-`, not `jsonschema-`).

## Test plan

- [x] `plugin.json` parses; 49 unique skills; the 3 added paths each resolve to a real `SKILL.md`
- [x] `findings[`/`passed[` report-shape gone from all qe-agent prose; `qa-report-schema.json` itself **unchanged**
- [x] Rewritten Blocker/Issue/TestCounts prose matches the JSON `$defs` field-for-field (id, severity+enums, category, description, suggested_fix, pass/fail/skip)
- [x] No surviving "observability/performance score" or mis-stated gating claim
- [x] Every contract-author template path in the four files resolves to a real file
- [ ] Reviewer: confirm the gate rule reads correctly (CRITICAL blocker OR `contract_conformance.score < 3` OR `security.score < 3`)

Stacked: the P1 (wiring & handoff integrity) PR will follow, based on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)