### PR TITLE
fix: Resolve P1 audit wiring, path, ownership, and namespace findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ integrations/
 # Python bytecode cache
 __pycache__/
 *.pyc
+
+node_modules/
+audit/

--- a/skills/contracts/contract-auditor/SKILL.md
+++ b/skills/contracts/contract-auditor/SKILL.md
@@ -17,7 +17,7 @@ spawned_by: ["orchestrator"]
 
 # Contract Auditor
 
-> **Pipeline position.** Runs after implementation agents complete. Reads contracts from `contract-author`. Outputs findings consumed by `qe-agent`.
+> **Pipeline position.** Runs after implementation agents complete. Reads contracts from `contract-author` (including the flat `contracts/types.<ext>`). Writes findings to `contract-audit.md` at the repo root, consumed by `qe-agent`.
 
 Audit implementations against their integration contracts. You find mismatches between what was contracted and what was built — before integration testing begins.
 
@@ -44,7 +44,7 @@ From the lead:
 - **contracts/** — the contract-author's output files. Look for:
   - `contracts/openapi.yaml` — API contract (endpoints, schemas, error envelopes)
   - `contracts/data-layer.yaml` — data layer contract (function signatures, storage semantics)
-  - `contracts/types/` — shared type definitions (TypeScript interfaces, Pydantic models, or JSON Schema)
+  - `contracts/types.<ext>` — shared type definitions, a single **flat file** (`contracts/types.ts`, `contracts/types.py`, or `contracts/types.json`), **not** a directory. This is the exact path `contract-author` writes.
   - If contracts are in a different format or location, the lead will specify.
 - **agent_ownership** — which agent owns which files, so you can attribute mismatches to the responsible agent
 - **tech_stack** — language and framework, so you know what route/handler patterns to search for
@@ -107,8 +107,8 @@ For each endpoint, compare:
 
 ### 5. Shared Types Conformance
 
-- Backend models match `contracts/types`
-- Frontend types match `contracts/types`
+- Backend models match `contracts/types.<ext>` (the flat file, e.g. `contracts/types.py`)
+- Frontend types match `contracts/types.<ext>` (the flat file, e.g. `contracts/types.ts`)
 - No camelCase vs snake_case mismatches (unless documented transform exists)
 - Enum values identical on both sides
 - **Are shared types actually imported and used?** If the contract provides Pydantic models or TypeScript interfaces as "single source of truth," verify the implementation imports them for validation and serialization rather than manually constructing dicts. Manual construction is the #1 cause of field-naming drift.
@@ -134,6 +134,8 @@ Check the contracts themselves for contradictions — this is unique value the a
 Flag contradictions to the lead — don't assume the implementation is wrong when the contract is unclear.
 
 ### 8. Generate Audit Report
+
+Write the report to **`contract-audit.md`** at the repo root — alongside `contracts/` and the qe-agent's `qa-report.md`/`qa-report.json`. This is the concrete artifact `qe-agent` consumes (it reads `contract-audit.md` before starting integration testing). If the project already pins an audit-output path in `docs/agents/contract-format.md`, use that instead.
 
 ```markdown
 # Contract Audit Report
@@ -175,5 +177,5 @@ For projects that use consumer-driven contract testing, see `references/pact-set
 - **Contract is truth** — if implementation differs, implementation is wrong
 - **Report precisely** — include file paths, line numbers, exact differences
 - **Flag ambiguities** — if the contract is ambiguous, flag it to the lead
-- **You vs. qe-agent** — you do **static** contract verification (reading code against contracts). The qe-agent does **runtime** verification (executing requests and comparing responses). You run first; your audit report feeds into QE's Phase 1. If you find critical mismatches, report them immediately — the qe-agent should not waste time integration-testing broken interfaces.
+- **You vs. qe-agent** — you do **static** contract verification (reading code against contracts). The qe-agent does **runtime** verification (executing requests and comparing responses). You run first; your `contract-audit.md` report feeds into QE's Phase 1. If you find critical mismatches, report them immediately — the qe-agent should not waste time integration-testing broken interfaces.
 - **You vs. contract-author** — the contract-author *generates* contracts; you *verify* implementations match them. If you find a gap in the contract itself (ambiguous, incomplete, or contradictory), flag it to the lead — don't assume the implementation is wrong when the contract is unclear.

--- a/skills/contracts/contract-author/SKILL.md
+++ b/skills/contracts/contract-author/SKILL.md
@@ -67,13 +67,13 @@ This extraction step prevents missing entities that only become apparent during 
 
 ### 1. Start with Shared Types
 
-Always create the shared types file first — everything else references it.
+Always create the shared types file first — everything else references it. Write it as a **single flat file** named `contracts/types.<ext>` (e.g. `contracts/types.ts`, `contracts/types.py`, `contracts/types.json`) — **not** a directory `contracts/types/`. Consumers (`contract-auditor`, `frontend-agent`) read this one flat file.
 
 Pick the format that matches the project's primary language:
 
-- TypeScript → `references/typescript-template.ts`
-- Python → `references/pydantic-template.py`
-- Multi-language → `references/json-schema-template.json`
+- TypeScript → `references/typescript-template.ts` → write to `contracts/types.ts`
+- Python → `references/pydantic-template.py` → write to `contracts/types.py`
+- Multi-language → `references/json-schema-template.json` → write to `contracts/types.json`
 
 Define every entity, enum, request shape, response shape, and the error envelope. Use the strongest type annotations available — `EmailStr` for emails, `HttpUrl` for URLs, `Decimal` for money (or integer cents with clear documentation). The richer the types, the fewer integration bugs.
 
@@ -212,7 +212,7 @@ Over-engineered contracts waste agent time implementing unnecessary complexity.
 
 Your deliverables (machine-readable formats — not markdown narratives):
 
-- `contracts/types.[ts|py|json]` — shared type definitions
+- `contracts/types.[ts|py|json]` — shared type definitions. This is a single **flat file** (`contracts/types.ts` / `contracts/types.py` / `contracts/types.json`), **never** a directory `contracts/types/`. The consumer (`contract-auditor`) and `frontend-agent` read this exact flat-file path.
 - `contracts/tsconfig.json` — REQUIRED when language is TypeScript. Must extend the workspace base tsconfig if one exists (e.g. `../../tsconfig.base.json`). Without this, `tsc --noEmit` runs with no project config and silently prints its help text instead of typechecking, which gets discovered late. (Skip this file for Python/Go/other-language projects.)
 - `contracts/openapi.yaml` — API contract (OpenAPI 3.1 spec)
 - `contracts/data-layer.yaml` — data layer interface (use `references/data-layer-template.yaml`)

--- a/skills/meta/skill-review/SKILL.md
+++ b/skills/meta/skill-review/SKILL.md
@@ -12,7 +12,7 @@ owns:
   patterns: []
   shared_read: ["skills/"]
 allowed-tools: ["Read", "Glob", "Grep", "Bash", "Write"]
-composes_with: ["skill-update", "skill-writer", "skill-creator"]
+composes_with: ["skill-update", "skill-writer", "skill-creator:skill-creator"]
 spawned_by: []
 ---
 

--- a/skills/meta/skill-update/SKILL.md
+++ b/skills/meta/skill-update/SKILL.md
@@ -7,7 +7,7 @@ requires_agent_teams: false
 requires_claude_code: true
 min_plan: starter
 owns:
-  directories: ["skills/"]
+  directories: []
   patterns: []
   shared_read: []
 allowed-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -13,14 +13,14 @@ owns:
 allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: [
   "wiki-research", "llm-wiki", "repo-deep-dive",
-  "brainstorming", "plan-builder", "writing-plans",
+  "superpowers:brainstorming", "plan-builder", "superpowers:writing-plans",
   "backend-agent", "frontend-agent", "infrastructure-agent", "qe-agent",
   "security-agent", "docs-agent", "observability-agent", "db-migration-agent", "performance-agent",
   "contract-author", "contract-auditor", "dependency-coordinator",
   "context-manager", "deployment-checklist", "code-review-agent", "project-profiler",
   "mermaid-charts", "playwright",
-  "claude-design-brief", "ui-brief", "frontend-design", "ui-ux-pro-max", "ux-review", "render-sanity",
-  "nano-banana", "claude-api", "feature-dev",
+  "claude-design-brief", "ui-brief", "frontend-design:frontend-design", "ui-ux-pro-max", "ux-review", "render-sanity",
+  "nano-banana", "claude-api", "feature-dev:feature-dev",
   "git-commit", "git-pr", "git-pr-feedback", "git-post-merge-cleanup",
   "claude-mem:mem-search", "claude-mem:timeline-report", "claude-mem:knowledge-agent",
   "skill-writer", "skill-review", "skill-update",
@@ -48,7 +48,8 @@ For single-agent or ad-hoc work, this skill is not the right tool.
 The orchestrator is the conductor — not the only player. It composes with three groups of skills:
 
 - **INVOKES at the right phase:** `nano-banana` (seed imagery), `ui-ux-pro-max` + `frontend-design` (UI quality), `ux-review` + `render-sanity` (post-build validation), `repo-deep-dive` (reference research), `llm-wiki` (project knowledge base), `mermaid-charts` (architecture diagrams), `deployment-checklist` (ship readiness).
-- **DISPATCHES role-agents in parallel:** `backend-agent`, `frontend-agent`, `infrastructure-agent`, `db-migration-agent`, `security-agent`, `observability-agent`, `performance-agent`, `docs-agent`, `qe-agent`, `code-review-agent`.
+- **DISPATCHES role-agents in parallel:** `backend-agent`, `frontend-agent`, `infrastructure-agent`, `db-migration-agent`, `security-agent`, `observability-agent`, `performance-agent`, `docs-agent`, `qe-agent`.
+- **DELEGATES diff/code review to the external `/code-review` CLI:** during a build, the Phase 4 diff review pass is the external `/code-review` CLI, NOT a spawned `code-review-agent`. The in-repo `code-review-agent` skill is not a default build phase — invoke it only deliberately for a standalone, repo-aware review. See `references/mission-interpretation.md`.
 - **DOES NOT preempt:** `brainstorming`, `plan-builder`, `writing-plans`, `claude-design-brief`, `ui-brief`, `feature-dev`, `claude-mem:*`. If any of these belong before the build starts, let them run first — orchestrator picks up from the artifacts they produce.
 
 <what-to-do>

--- a/skills/orchestrator/references/file-ownership.md
+++ b/skills/orchestrator/references/file-ownership.md
@@ -1,15 +1,68 @@
 # File Ownership Map
 
-Directory ownership takes precedence over pattern ownership. Subdirectory carve-outs are explicit (e.g., performance-agent owns `tests/performance/` carved out from qe-agent's `tests/`). This table is the canonical ownership map — when in doubt, this overrides any individual role skill.
+This table is the **canonical** ownership map for the whole Skill-Madness toolkit — it enumerates **every** skill that declares exclusive ownership of a directory or pattern, not just the build-time role agents. When in doubt, this overrides any individual skill's frontmatter.
+
+**Precedence rules:**
+
+1. **Directory ownership takes precedence over pattern ownership.** If a pattern (e.g. `docs/adr/**`) would land inside a directory owned by another skill, the more specific directory owner wins.
+2. **Subdirectory carve-outs are explicit.** A deeper-nested directory can be carved out of a broader owner (e.g. `performance-agent` owns `tests/performance/` carved out of qe-agent's `tests/`; `setup-project-skills` owns `docs/agents/` and `maintain-context` owns `docs/adr/`, both carved out of docs-agent's `docs/`).
+3. **No path has two owners.** Every owned directory/pattern below resolves to exactly one skill. Skills not listed here own nothing — their write capability (if any) comes from `allowed-tools`, not ownership.
+
+## Build-time role agents
+
+These are spawned by the orchestrator during a multi-agent build. File ownership between them is exclusive and resolved before any agent is spawned.
 
 | Agent Role | Owns (Exclusive) | Shared Read | Never Touches |
 |------------|-----------------|-------------|---------------|
 | orchestrator | `.gitignore` | `contracts/`, `.claude/handoffs/`, `*` | `src/` |
-| backend | `src/api/`, `src/services/`, `src/models/`, `src/middleware/`, `src/utils/` | `contracts/`, `shared/`, `src/types/` | `src/components/`, `src/pages/` |
-| frontend | `src/components/`, `src/pages/`, `src/hooks/`, `src/styles/`, `public/` | `contracts/`, `shared/`, `src/types/` | `src/api/`, `src/services/` |
-| infrastructure | `.github/workflows/`, `nginx/`, `k8s/`, `terraform/`, `scripts/deploy/`, `Dockerfile*`, `docker-compose*` | All (read-only) | `src/` |
-| qe | `tests/` *(excl. `tests/performance/`)*, `e2e/`, `__tests__/`, `*.test.*`, `*.spec.*` | All (read-only) | `src/` (test files in `src/` owned by directory's agent) |
-| performance | `tests/performance/`, `load-tests/` | All (read-only) | `src/` |
+| backend-agent | `src/api/`, `src/services/`, `src/models/`, `src/middleware/`, `src/utils/` | `contracts/`, `shared/`, `src/types/` | `src/components/`, `src/pages/`, `.env.example` |
+| frontend-agent | `src/components/`, `src/pages/`, `src/hooks/`, `src/styles/`, `public/`, `*.tsx`, `*.jsx`, `*.vue`, `*.svelte`, `*.css` | `contracts/`, `shared/`, `src/types/`, `assets/` | `src/api/`, `src/services/` |
+| infrastructure-agent | `.github/workflows/`, `nginx/`, `k8s/`, `terraform/`, `scripts/deploy/`, `Dockerfile*`, `docker-compose*`, `Makefile`, `justfile`, **`.env.example`** | All (read-only) | `src/` |
+| qe-agent | `tests/` *(excl. `tests/performance/`)*, `e2e/`, `__tests__/`, `*.test.*`, `*.spec.*`, `qa-report.md`, `qa-report.json` | All (read-only) | `src/` (test files in `src/` owned by the directory's agent) |
+| performance-agent | `tests/performance/`, `load-tests/` | All (read-only) | `src/` |
+| security-agent | `.github/security/`, `SECURITY.md` | All (read-only) | `src/` |
+| db-migration-agent | `migrations/`, `seeds/`, `prisma/`, `alembic/`, `knex/migrations/` | `src/models/` | `src/` (non-migration) |
+| observability-agent | `src/telemetry/`, `src/logging/`, `monitoring/`, `alerts/` | `src/` | other agents' `src/` |
+| docs-agent | `docs/` *(excl. `docs/agents/` and `docs/adr/`)*, `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md` | All (read-only) | `src/`, config files, test files, `docs/agents/`, `docs/adr/` |
+| code-review-agent | *(nothing — review only)* | All (read-only) | everything (read-only role) |
+| contract-author | `contracts/`, `schemas/`, `openapi.yaml`, `asyncapi.yaml` | `*` | `src/` |
+| contract-auditor | *(nothing — audit only)* | `contracts/`, `src/`, `backend/`, `frontend/`, `docs/` | everything (read-only role) |
+
+## Workflow & meta skills that own paths
+
+These skills run outside (or alongside) a build but still claim exclusive ownership of specific paths. They are part of the canonical map so their paths never collide with a role agent's.
+
+| Skill | Owns (Exclusive) | Notes |
+|-------|-----------------|-------|
+| setup-project-skills | `docs/agents/` | **Carve-out** from docs-agent's `docs/`. Writes the per-repo config (`domain-docs.md`, `contract-format.md`, `work-item-tracker.md`). |
+| maintain-context | `docs/adr/`, `CONTEXT.md` | **Carve-out** from docs-agent's `docs/`. `docs/adr/` is a directory (precedence over patterns); `CONTEXT.md` is the domain glossary. |
+| context-manager | `.claude/handoffs/` | Session-handoff files. Orchestrator shares-read this directory. |
+| project-profiler | `CLAUDE.md`, `.claude/profile.yaml` | Generated project profile + machine-readable profile. |
+| llm-wiki | `index.md`, `wiki/log.md`, `wiki/overview.md` | Root knowledge-base index + `wiki/` log/overview pages (canonical layout: root `index.md` entry, `wiki/` articles). |
+| settings-consolidator | `settings.local.json` | Claude Code permission files (merged into the global one). |
+| work-item-brief | `briefs/**/*.md` | Generated work-item brief documents. |
+| railway-deploy | `railway.toml` | Railway deployment config. (No directory ownership; pattern-only.) |
+| sync-skills | `skills/workflows/sync-skills/` | Owns only its own subtree — the toolkit's `skills/` tree is otherwise un-owned. |
+
+**Skills that own nothing:** `skill-update`, `skill-writer`, `skill-review`, `skill-explorer`, `deployment-checklist`, `claude-design-brief`, `architecture-rescue`, `ui-brief`, `diagnose-loop`, `wiki-research`, `plan-builder`, `playwright`, `render-sanity`, `living-plan`, `zoom-out`, `repo-deep-dive`, `dependency-coordinator`, `mermaid-charts`, `plan-intake`, `caveman`, `grill-me`, `nano-banana`, and the git skills (`git-commit`, `git-pr`, `git-pr-feedback`, `git-post-merge-cleanup`). Their `owns` blocks are empty by design; any write capability comes from `allowed-tools`. In particular `skill-update` owns nothing — it edits skills via `allowed-tools`, exactly like its sibling meta skills, so it does not swallow the `skills/` tree (which would otherwise collide with `sync-skills`).
+
+## The three explicit carve-outs under `docs/`
+
+`docs-agent` owns `docs/` broadly, but two subtrees are owned by other skills and **must not** be written by docs-agent:
+
+| Path | Exclusive owner | Carved out of |
+|------|-----------------|---------------|
+| `docs/agents/` | `setup-project-skills` | `docs/` (docs-agent) |
+| `docs/adr/` | `maintain-context` | `docs/` (docs-agent) |
+| `docs/` (everything else) | `docs-agent` | — |
+
+Without these carve-outs, docs-agent's `docs/` directory ownership would silently swallow both subtrees (directory ownership beats pattern ownership), so each carve-out is declared as a directory in the owning skill's frontmatter and called out here.
+
+## The `.env.example` resolution
+
+`.env.example` is owned by **infrastructure-agent only**. backend-agent does **not** own or create it: backend defines the variable names and safe local-dev defaults its services need and hands them to infrastructure-agent (via the lead), who writes the committed `.env.example`. The gitignored `.env` (real local values) remains backend-agent's concern. See `team-sizing.md` for the shared-infrastructure file assignment table.
+
+## Conflict resolution
 
 **Rule**: If two roles would touch the same file, resolve the conflict by assigning that file to exactly one role before spawning. Unresolvable conflicts → human decision.
 

--- a/skills/orchestrator/references/handoff-protocol.md
+++ b/skills/orchestrator/references/handoff-protocol.md
@@ -5,8 +5,9 @@ When an agent approaches context limits (~80% usage), it writes a structured han
 ## Roles
 
 - **Agent** — detects context usage approaching ~80%, drafts the handoff file content
-- **Context-manager** — owns `.claude/handoffs/`, validates handoff quality, assists with compaction strategy
-- **Orchestrator** — reads completed handoff files, spawns continuation agents with the handoff as context
+- **Orchestrator** — owns the build-loop handoff: it validates handoff quality against the checklist below, reads completed handoff files from `.claude/handoffs/`, and spawns continuation agents with the handoff as context. This protocol document is the single canonical home for that validation logic.
+
+The orchestrator does NOT spawn `context-manager` as a build-phase validator. `context-manager` is a **user-invocable compaction helper** — a person reaches for it directly ("compact this", "hand off this conversation") to compress a long session or write a session-handoff. It is not part of the orchestrator's automated build loop; the handoff validation in this document is the orchestrator's own responsibility.
 
 Signaling varies by runtime: in Agent Teams, signal via inbox/TeammateTool. In subagent mode, the agent exits and the orchestrator reads the handoff file from `.claude/handoffs/`. In sequential mode, the user relays.
 

--- a/skills/orchestrator/references/mission-interpretation.md
+++ b/skills/orchestrator/references/mission-interpretation.md
@@ -114,7 +114,7 @@ they earn their keep. This table maps "build situation" → "skill to invoke".
 | Mid-build feature addition with codebase understanding required | `feature-dev` | Phase 3, after core scaffolding |
 | Any project that ships code | `qe-agent` (mandatory), `security-agent` | Phase 3 |
 | Need to validate every implementation against its contract | `contract-auditor` | Phase 4 |
-| Diff review pass | `code-review` (or `/code-review:code-review`) | Phase 4 |
+| Diff review pass | external `/code-review` CLI (see note below) | Phase 4 |
 | Security-only diff pass | `security-review` (or `/security-review`) | Phase 4 |
 | Find dead code, premature abstractions, duplicated logic | `simplify` | Phase 4 |
 | E2E happy-path validation with a real browser | `playwright` | Phase 4 |
@@ -130,6 +130,25 @@ they earn their keep. This table maps "build situation" → "skill to invoke".
 | Search persistent memory for prior solutions before designing | `claude-mem:mem-search` | Phase 0 or wherever a "have we solved this?" question lands |
 | Post-build skill ecosystem audit | `skill-review`, `skill-update`, `skill-writer` | Phase 7 |
 | Stale worktrees and branches | `git-post-merge-cleanup`, `sync-skills` | Phase 8 |
+
+## Diff/code review during a build → external `/code-review` CLI
+
+Diff and code review during a build is handled by the **external `/code-review`
+CLI**, not by spawning the in-repo `code-review-agent` skill. The orchestrator
+does **not** add a build phase that spawns `code-review-agent` by default —
+Phase 4's diff review pass runs the `/code-review` CLI against the build's diff.
+
+When to choose which:
+
+- **`/code-review` CLI (default)** — fast, diff-scoped correctness + cleanup
+  pass over the working tree or PR during an active build. This is the Phase 4
+  default. Use it for every build's review pass.
+- **`code-review-agent` skill (opt-in only)** — reach for it only when you
+  explicitly need the skill's structured, repo-aware role behavior (e.g. a
+  standalone, non-build review where you want the agent's full checklist and
+  reference files rather than a diff-scoped CLI pass). It is not spawned as
+  part of the default build loop; invoke it deliberately when that behavior is
+  what you want.
 
 ## When the user explicitly names a skill
 

--- a/skills/orchestrator/references/team-sizing.md
+++ b/skills/orchestrator/references/team-sizing.md
@@ -44,7 +44,8 @@ Every file in the repo has exactly one owner. No exceptions.
 | File | Usually Owned By | Rationale |
 |------|-----------------|-----------|
 | Root `package.json` | Frontend (if JS monorepo root) or Backend | Whoever runs `npm install` more often |
-| `.env` / `.env.example` | Backend | Backend defines ports, DB URLs, API keys |
+| `.env.example` | Infrastructure | Infrastructure owns the committed template; backend supplies the variable names/defaults its services read |
+| `.env` (gitignored, real local values) | Backend | Backend defines ports, DB URLs, API keys |
 | `docker-compose.yml` | Backend or Infrastructure | Defines service topology |
 | `tsconfig.json` (root) | Frontend | Frontend build tooling more sensitive to TS config |
 | `.gitignore` | Lead (pre-created) | Rarely changes |

--- a/skills/roles/backend-agent/SKILL.md
+++ b/skills/roles/backend-agent/SKILL.md
@@ -16,7 +16,7 @@ owns:
   patterns: []
   shared_read: ["contracts/", "shared/", "src/types/"]
 allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
-composes_with: ["frontend-agent", "qe-agent", "infrastructure-agent", "contract-author", "db-migration-agent", "observability-agent"]
+composes_with: ["frontend-agent", "qe-agent", "infrastructure-agent", "contract-author", "db-migration-agent", "observability-agent", "wiki-research"]
 spawned_by: ["orchestrator"]
 ---
 
@@ -57,7 +57,8 @@ You receive from the lead:
 ## Your Ownership
 
 - **Own:** `src/api/`, `src/services/`, `src/models/`, `src/middleware/`, `src/utils/` (directory names adapt to project conventions — frontmatter `owns.directories` is canonical)
-- **Conditionally own:** `.env`, `.env.example`, `requirements.txt` / `package.json` (confirm with lead if not already assigned)
+- **Conditionally own:** `.env`, `requirements.txt` / `package.json` (confirm with lead if not already assigned)
+- **NOT yours:** `.env.example` is owned exclusively by infrastructure-agent. Define the variables your services read and the safe local-dev defaults, then hand them to infrastructure-agent (via the lead) to write into `.env.example`. Do not create or edit `.env.example` yourself.
 - **Read-only:** `contracts/`, `shared/`, `src/types/`
 - **Off-limits:** `src/components/`, `src/pages/` (frontend), `src/telemetry/`, `src/logging/` (observability), `migrations/` (db-migration), `Dockerfile*`, `docker-compose*` (infrastructure), all other agents' directories
 
@@ -134,7 +135,7 @@ The #1 "works in dev, breaks in integration" issue. Set up immediately:
 
 ### 8. Environment Configuration
 
-`.env.example` committed with placeholders, `.env` gitignored with real values. Every config from env vars.
+Every config comes from env vars; `.env` is gitignored and holds real local values. The committed `.env.example` (placeholders, safe defaults) is owned by infrastructure-agent — supply the variable names and defaults your services read and hand them off via the lead rather than writing `.env.example` yourself.
 
 ## Coordination Rules
 

--- a/skills/roles/code-review-agent/SKILL.md
+++ b/skills/roles/code-review-agent/SKILL.md
@@ -2,7 +2,7 @@
 name: code-review-agent
 version: 1.3.0
 disable-model-invocation: true
-description: "Orchestrator-dispatched only. Reviews code for quality, correctness, security, and adherence to project conventions in multi-agent builds. Composed by orchestrator during multi-agent builds. Not user-invocable."
+description: "Explicitly-invoked read-only code review for quality, correctness, security, and adherence to project conventions. Run on request for a thorough standalone review of a set of files; not auto-triggered and not an automatic build phase. During an orchestrated build, build-time diff review is handled by the external /code-review CLI, not this skill."
 compatibility: "Claude Code"
 metadata:
   author: hive-ecosystem
@@ -17,24 +17,26 @@ owns:
   shared_read: ["*"]
 allowed-tools: ["Read", "Write", "Grep", "Glob"]
 composes_with: ["wiki-research", "qe-agent", "security-agent", "backend-agent", "frontend-agent"]
-spawned_by: ["orchestrator"]
+spawned_by: []
 ---
 
 # Code Review Agent
 
-> **Pipeline position.** Spawned by `orchestrator` after contracts are authored. Reads `contract-author`'s output from `/contracts/`. Review report feeds into qe-agent correctness/code_quality/contract_conformance scores. Owns: none (read-only review across all source).
+> **Invocation.** Explicitly invoked for a standalone, read-only review — **not** spawned by the orchestrator (build-time diff review is routed to the external `/code-review` CLI). Reads source and any contracts under `/contracts/` when present. Produces a structured review report. Owns: none (read-only review across all source).
 
 Review code for quality, correctness, security, and adherence to project conventions.
 
 ## When this skill applies
 
-This skill assumes a contract-first multi-agent build model:
+Use this skill for an explicitly-requested, thorough read-only review. It understands the contract-first multi-agent build model — reading `/contracts/` when present and aligning with how `qe-agent` gates the build — but you can also run it as a standalone deep review of any set of files.
 
-- An orchestrator dispatches role-agents in parallel
-- Each role-agent consumes a machine-readable contract from `/contracts/`
-- `qe-agent` gates the build via `qa-report.json`
+It is not auto-triggered and is not a build phase. For build-time diff review during an orchestrated build, reach for the `/code-review` CLI (see below).
 
-For single-agent or ad-hoc work, this skill is not the right tool.
+## When this skill vs the /code-review CLI
+
+During an orchestrated build, build-time diff review is **not** handled by this skill — the orchestrator routes it to the external `/code-review` CLI. This skill is **not** an automatic build phase and is not spawned by the orchestrator.
+
+Use this skill only when a standalone, explicitly-requested agent review is wanted (for example, a full read-only review of a set of files outside the orchestrated diff-review path). For build-time diff review, reach for the `/code-review` CLI instead.
 
 ## Role
 

--- a/skills/roles/docs-agent/SKILL.md
+++ b/skills/roles/docs-agent/SKILL.md
@@ -22,7 +22,7 @@ spawned_by: ["orchestrator"]
 
 # Docs Agent
 
-> **Pipeline position.** Spawned by `orchestrator` after contracts are authored. Reads `contract-author`'s output from `/contracts/`. Your generated docs are an input the qe-agent may weigh in its `completeness` and `code_quality` scores — but neither of those dimensions gates the build (only `contract_conformance`, `security`, and CRITICAL blockers do). Owns: `docs/`.
+> **Pipeline position.** Spawned by `orchestrator` after contracts are authored. Reads `contract-author`'s output from `/contracts/`. Your generated docs are an input the qe-agent may weigh in its `completeness` and `code_quality` scores — but neither of those dimensions gates the build (only `contract_conformance`, `security`, and CRITICAL blockers do). Owns: `docs/` — **except** `docs/agents/` (owned by `setup-project-skills`) and `docs/adr/` (owned by `maintain-context`).
 
 Generate and maintain project documentation. You read the code and contracts — you don't write application code.
 
@@ -52,8 +52,9 @@ From the lead:
 ## Your Ownership
 
 - **Own:** `docs/`, `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`
+- **Carve-outs (NOT yours, even though they live under `docs/`):** `docs/agents/` is owned exclusively by `setup-project-skills`; `docs/adr/` is owned exclusively by `maintain-context`. Read them for context, but never write to either — directory ownership is exclusive and these two subtrees are carved out of your `docs/` ownership.
 - **Read-only:** Everything else
-- **Off-limits:** `src/`, config files, test files
+- **Off-limits:** `src/`, config files, test files, `docs/agents/`, `docs/adr/`
 
 ## Process
 

--- a/skills/roles/frontend-agent/SKILL.md
+++ b/skills/roles/frontend-agent/SKILL.md
@@ -16,7 +16,7 @@ owns:
   patterns: ["*.tsx", "*.jsx", "*.vue", "*.svelte", "*.css"]
   shared_read: ["contracts/", "shared/", "src/types/", "assets/"]
 allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
-composes_with: ["backend-agent", "qe-agent", "infrastructure-agent", "contract-author", "frontend-design", "ui-ux-pro-max", "ui-brief", "nano-banana"]
+composes_with: ["backend-agent", "qe-agent", "infrastructure-agent", "contract-author", "frontend-design:frontend-design", "ui-ux-pro-max", "ui-brief", "nano-banana"]
 spawned_by: ["orchestrator"]
 ---
 
@@ -48,7 +48,7 @@ You receive from the lead:
 
 - **plan_excerpt** — UI, routing, and state management sections
 - **api_contract** — versioned API contract (URLs, methods, request/response shapes, error envelope, SSE format)
-- **shared_types** — shared type definitions (import or mirror from `contracts/types.[ts|py|json]`)
+- **shared_types** — shared type definitions, a single flat file written by `contract-author` (import or mirror from `contracts/types.<ext>`, e.g. `contracts/types.ts` / `contracts/types.py` / `contracts/types.json` — not a `contracts/types/` directory)
 - **ownership** — your files/directories and off-limits boundaries
 - **tech_stack** — framework, UI library, package manager
 
@@ -165,7 +165,7 @@ Focus indicators, labels on inputs, descriptive button text, alt text, keyboard 
 | Trailing slash mismatch | Copy URLs from contract |
 | Fetch without error handling | Every fetch checks res.ok |
 | Missing loading/empty states | Handle for every async op |
-| Types diverge from contract | Mirror contracts/types |
+| Types diverge from contract | Mirror the flat `contracts/types.<ext>` file (e.g. `contracts/types.ts`) |
 | Using innerHTML for rendering | Use createElement + textContent to prevent XSS |
 | Over-engineering vanilla JS | No build tools, no frameworks for simple projects |
 | Inline `style=` on elements for layout | Class + stylesheet rule — inline styles can't be overridden by media queries without `!important` |

--- a/skills/roles/infrastructure-agent/SKILL.md
+++ b/skills/roles/infrastructure-agent/SKILL.md
@@ -13,7 +13,7 @@ requires_claude_code: true
 min_plan: starter
 owns:
   directories: [".github/workflows/", "nginx/", "k8s/", "terraform/", "scripts/deploy/"]
-  patterns: ["Dockerfile*", "docker-compose*", "Makefile", "justfile"]
+  patterns: ["Dockerfile*", "docker-compose*", "Makefile", "justfile", ".env.example"]
   shared_read: ["*"]
 allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: ["backend-agent", "frontend-agent", "qe-agent", "deployment-checklist", "observability-agent"]
@@ -52,8 +52,9 @@ From the lead:
 
 ## Your Ownership
 
-- **Own:** `.github/workflows/`, `nginx/`, `k8s/`, `terraform/`, `scripts/deploy/`, `Dockerfile*`, `docker-compose*`, `Makefile`, `justfile`
-- **May create:** `.env.example`, `.dockerignore`
+- **Own:** `.github/workflows/`, `nginx/`, `k8s/`, `terraform/`, `scripts/deploy/`, `Dockerfile*`, `docker-compose*`, `Makefile`, `justfile`, `.env.example`
+- **`.env.example` is yours exclusively** — the canonical map assigns `.env.example` to infrastructure-agent only. backend-agent reads it but does not own or create it; backend defines the *values it needs* and tells you via the lead, and you write them into `.env.example`.
+- **May create:** `.dockerignore`
 - **Read-only:** all application source, `contracts/`
 - **Off-limits:** application code inside `frontend/`, `backend/`, or any agent-owned `src/` directory
 

--- a/skills/workflows/context-manager/SKILL.md
+++ b/skills/workflows/context-manager/SKILL.md
@@ -12,40 +12,43 @@ owns:
   shared_read: ["*"]
 allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob"]
 composes_with: ["orchestrator"]
-spawned_by: ["orchestrator"]
+spawned_by: []
 ---
 
 # Context Manager
 
 Manage context window usage, compaction strategy, and session handoffs for long-running builds.
 
+This is a **user-invocable** helper. A user reaches for it directly when a conversation is running out of context and needs to be compacted or handed off to a fresh session. It is **not** spawned by the orchestrator during a build.
+
+> **During an orchestrated build, handoff validation is governed by `orchestrator/references/handoff-protocol.md`** (the protocol the orchestrator actually runs). This skill is for user-driven compaction/handoff outside that loop.
+
 ## Role
 
-You help agents and the orchestrator manage their context window efficiently. When agents approach context limits (~80% usage), you help them produce structured handoff files so a continuation agent can pick up seamlessly. You also **validate handoff quality** — ensuring handoff files contain actionable continuation context before the orchestrator spawns a continuation agent.
+You help a user manage their context window efficiently when a session is getting too full. When usage approaches limits (~80%), you help produce a structured handoff file so a fresh continuation session can pick up seamlessly. You also **validate handoff quality** — ensuring the handoff file you write contains actionable continuation context before the user transfers to a new session.
 
 ## Your Ownership
 
 - **You own (exclusive):** `.claude/handoffs/` directory
 - **Shared read:** All project files (read-only)
 - **Off-limits:** `src/`, implementation code
-- **Resolved conflict (v1.1):** `.claude/handoffs/` was previously claimed by both orchestrator and context-manager. Context-manager is the definitive owner — you write and validate handoffs. The orchestrator reads handoff files to spawn continuation agents.
+- **Resolved conflict (v1.1):** `.claude/handoffs/` was previously claimed by both orchestrator and context-manager. Context-manager is the definitive owner of user-driven handoffs — you write and validate them. (Build-loop handoffs during an orchestrated build are governed separately by `orchestrator/references/handoff-protocol.md`.)
 
 ## Inputs
 
-- **Agent context signal** — an agent reports it's approaching ~80% context usage, or the orchestrator detects it
-- **Handoff draft (optional)** — an agent may produce a draft handoff file for you to validate and improve
-- **Compaction request (optional)** — an agent asks for help compacting its context before resorting to a full handoff
+- **Context signal** — the current session is approaching ~80% context usage
+- **Handoff draft (optional)** — the user may provide a draft handoff file for you to validate and improve
+- **Compaction request (optional)** — the user asks for help compacting the session before resorting to a full handoff
 
 ## When to Act
 
-- Agent context usage approaches 80%
-- Complex build requires multiple sessions
-- Orchestrator needs to hand off coordination
-- An agent reports it's running low on context
+- Session context usage approaches 80%
+- A long-running task needs to continue across multiple sessions
+- The user wants to transfer the conversation to a fresh session
 
 ## Handoff Protocol
 
-When an agent needs to hand off, it writes a structured YAML file to `.claude/handoffs/`. See `references/compaction-guide.md` for the full specification.
+When the session needs to hand off, write a structured YAML file to `.claude/handoffs/`. See `references/compaction-guide.md` for the full specification.
 
 ### Handoff File Structure
 
@@ -80,17 +83,15 @@ continuation_context: |
 suggested_first_action: [exact next step]
 ```
 
-### Orchestrator Behavior on Handoff
+### Continuation in a Fresh Session
 
-1. Read the handoff file
-2. Spawn a continuation agent with the handoff as first message context
-3. Tag the task as `in_progress_handoff` in the shared task list
-4. The continuation agent reads files_modified and files_created to understand current state
-5. The continuation agent starts with suggested_first_action
+After the handoff file is written, the user starts a fresh session and points it at the latest file in `.claude/handoffs/`. The continuation session reads `files_modified` and `files_created` to understand current state, then begins with `suggested_first_action`.
+
+> **Inside an orchestrated build, the read/validate/spawn behavior on a handoff is governed by `orchestrator/references/handoff-protocol.md` — not this skill.** This skill covers writing and quality-checking the user-driven handoff file; it does not duplicate the orchestrator's build-loop validation.
 
 ## Context Efficiency Tips
 
-For agents approaching context limits:
+For a session approaching its context limit:
 
 - Avoid re-reading files already in context
 - Summarize long outputs before storing in context
@@ -100,7 +101,5 @@ For agents approaching context limits:
 ## Coordination
 
 - Handoff files are append-only — never modify a previous handoff
-- Each handoff gets a unique filename: `{agent-role}-{timestamp}.yaml`
-- The orchestrator is the only one that spawns continuation agents
-- **Quality gate:** Before the orchestrator acts on a handoff, validate that `continuation_context` is specific and actionable (not vague), `suggested_first_action` is an exact next step, and `completion_pct` is an honest estimate. Reject vague handoffs back to the originating agent.
-- **Orchestrator boundary:** You own `.claude/handoffs/` and validate quality. The orchestrator reads handoffs and spawns continuations — it does not write to this directory.
+- Each handoff gets a unique filename: `{role-or-session}-{timestamp}.yaml`
+- **Quality gate (your job):** Before declaring a handoff ready, validate that `continuation_context` is specific and actionable (not vague), `suggested_first_action` is an exact next step, and `completion_pct` is an honest estimate. Reject and rewrite vague handoffs.

--- a/skills/workflows/llm-wiki/SKILL.md
+++ b/skills/workflows/llm-wiki/SKILL.md
@@ -8,7 +8,7 @@ requires_claude_code: false
 min_plan: starter
 owns:
   directories: []
-  patterns: ["wiki/index.md", "wiki/log.md", "wiki/overview.md"]
+  patterns: ["index.md", "wiki/log.md", "wiki/overview.md"]
   shared_read: ["raw/", "wiki/"]
 allowed-tools: ["Read", "Write", "Edit", "Glob", "Grep"]
 composes_with: ["wiki-research", "repo-deep-dive", "project-profiler", "mermaid-charts"]
@@ -57,10 +57,10 @@ If the user's initial message already answers some of these, don't re-ask. Bias 
 ```
 <wiki-root>/
 ├── CLAUDE.md          ← the wiki schema (LLM operating manual)
+├── index.md           ← entry-point content catalog (root; updated on every ingest)
 ├── raw/               ← immutable source documents (user adds, LLM reads only)
 │   └── assets/        ← downloaded images and attachments
-├── wiki/              ← LLM-generated and LLM-maintained markdown pages
-│   ├── index.md       ← content catalog (updated on every ingest)
+├── wiki/              ← LLM-generated and LLM-maintained article pages
 │   ├── log.md         ← append-only operation history
 │   ├── overview.md    ← evolving synthesis / thesis (created after first ingest)
 │   └── sources/       ← one summary page per ingested source
@@ -68,7 +68,7 @@ If the user's initial message already answers some of these, don't re-ask. Bias 
 └── .gitignore         ← ignore nothing by default (wiki is just markdown)
 ```
 
-Create these directories and files. The `wiki/sources/` directory holds one page per ingested source. Additional subdirectories (`wiki/entities/`, `wiki/concepts/`, etc.) are created as needed during ingest.
+Create these directories and files. The root `index.md` is the entry point; `wiki/` holds the article pages. The `wiki/sources/` directory holds one page per ingested source. Additional subdirectories (`wiki/entities/`, `wiki/concepts/`, etc.) are created as needed during ingest.
 
 ### Step 3: Write the wiki CLAUDE.md
 
@@ -82,7 +82,7 @@ Write the filled template to `<wiki-root>/CLAUDE.md`.
 
 ### Step 4: Initialize index.md and log.md
 
-**`wiki/index.md`:**
+**`index.md`** (root entry point):
 ```markdown
 # Index
 
@@ -137,7 +137,7 @@ Read `references/operations.md` § Ingest for the full workflow. Summary:
 2. **Discuss** — briefly surface the 2–3 most interesting takeaways; invite the user to guide emphasis
 3. **Write a source summary page** to `wiki/sources/<slug>.md`
 4. **Update or create entity and concept pages** — identify named things (people, orgs, tools, papers) and concepts that warrant their own pages; update cross-references
-5. **Update `wiki/index.md`** — add the source entry, update page counts
+5. **Update `index.md`** (root entry point) — add the source entry, update page counts
 6. **Append to `wiki/log.md`** — one entry: `## [DATE] ingest | <title>`
 7. **Update `wiki/overview.md`** — revise the synthesis to incorporate the new source; note if it confirms, contradicts, or extends prior claims
 
@@ -151,7 +151,7 @@ Answer questions using the wiki as the knowledge base.
 
 Read `references/operations.md` § Query for the full workflow. Summary:
 
-1. Read `wiki/index.md` first to find relevant pages
+1. Read the root `index.md` first to find relevant pages
 2. Read the relevant pages
 3. Synthesize an answer with wiki citations (link to the wiki pages, not raw sources)
 4. Offer to file the answer as a new wiki page if it represents valuable synthesis (comparisons, analyses, discovered connections)
@@ -180,7 +180,7 @@ Produce a lint report and offer to fix issues automatically or suggest new sourc
 The user reads; the LLM writes. Some principles:
 
 - **Never modify files in `raw/`** — they are the immutable source of truth
-- **Always update `index.md` and `log.md`** on every ingest — these are how the LLM navigates at scale
+- **Always update the root `index.md` and `wiki/log.md`** on every ingest — these are how the LLM navigates at scale
 - **Cross-references are the point** — a page with no links to other wiki pages is a missed opportunity
 - **File good answers back** — if a query produces a valuable synthesis, create a wiki page for it
 - **Note contradictions explicitly** — when new sources conflict with existing claims, update the relevant pages to flag the tension rather than silently overwriting

--- a/skills/workflows/llm-wiki/references/operations.md
+++ b/skills/workflows/llm-wiki/references/operations.md
@@ -91,7 +91,7 @@ Keep `overview.md` readable as a standalone document. It should represent your b
 
 ### Step 7: Update index.md
 
-Add a row to the Sources table. Update the header counts (Sources: N, Pages: N).
+Update the root `index.md` (the entry point). Add a row to the Sources table. Update the header counts (Sources: N, Pages: N).
 
 If you created new entity or concept pages, add entries to those sections.
 
@@ -134,7 +134,7 @@ Answer questions using the wiki as the knowledge base.
 
 ### Step 1: Read the index
 
-Always start with `wiki/index.md`. Identify which pages are likely relevant.
+Always start with the root `index.md`. Identify which pages are likely relevant.
 
 For simple factual questions: the index alone often shows where to look.
 For synthesis questions: you may need to read multiple pages.
@@ -177,7 +177,7 @@ Health-check the wiki and surface maintenance work.
 
 ### Step 1: Read the full wiki
 
-Read `wiki/index.md` and then all pages listed in it.
+Read the root `index.md` and then all pages listed in it.
 
 For large wikis: do a targeted scan — read page headers and first paragraphs, drilling to full content only when a specific issue is suspected.
 

--- a/skills/workflows/llm-wiki/references/wiki-schema-template.md
+++ b/skills/workflows/llm-wiki/references/wiki-schema-template.md
@@ -31,10 +31,10 @@ in `raw/` and are never modified.
 ```
 {{WIKI_ROOT}}/
 ├── CLAUDE.md          ← this file (the schema)
+├── index.md           ← entry-point content catalog (root) — read this first before every query
 ├── raw/               ← immutable source documents (human adds, LLM reads only)
 │   └── assets/        ← downloaded images and attachments
-└── wiki/              ← everything the LLM writes and maintains
-    ├── index.md       ← content catalog — read this first before every query
+└── wiki/              ← article pages the LLM writes and maintains
     ├── log.md         ← append-only operation history
     ├── overview.md    ← evolving synthesis / thesis across all sources
     ├── sources/       ← one summary page per ingested source
@@ -58,7 +58,7 @@ When the human adds a new source or pastes content:
    - Same pattern: update or create `wiki/concepts/<slug>.md`
 6. Update `wiki/overview.md` — revise the synthesis to incorporate this source; explicitly
    note if it confirms, contradicts, or extends prior claims
-7. Update `wiki/index.md` — add the source entry, update counts in the header
+7. Update the root `index.md` (the entry point) — add the source entry, update counts in the header
 8. Append to `wiki/log.md`: `## [YYYY-MM-DD] ingest | <source title>`
 
 A single ingest typically touches 5–15 wiki pages. Work through all of them.
@@ -67,7 +67,7 @@ A single ingest typically touches 5–15 wiki pages. Work through all of them.
 
 When the human asks a question:
 
-1. Read `wiki/index.md` to identify relevant pages
+1. Read the root `index.md` to identify relevant pages
 2. Read those pages
 3. Synthesize an answer with citations linking to wiki pages (e.g., `[[entities/openai]]`)
 4. If the answer is a valuable synthesis (comparison, analysis, discovered connection),
@@ -77,7 +77,7 @@ When the human asks a question:
 
 When the human asks for a health check:
 
-1. Read `wiki/index.md` and all pages
+1. Read the root `index.md` and all pages
 2. Flag: contradictions between pages, orphan pages, missing cross-references, important
    concepts mentioned but lacking pages, data gaps a web search could fill
 3. Produce a lint report with specific fixes
@@ -182,7 +182,7 @@ tags: []
 
 ### Index conventions
 
-`wiki/index.md` has this structure:
+The root `index.md` (the entry point) has this structure:
 
 ```markdown
 # Index
@@ -192,16 +192,16 @@ tags: []
 ## Sources
 | Title | Slug | Date | Type |
 |-------|------|------|------|
-| [Source Title](sources/slug.md) | slug | YYYY-MM-DD | article |
+| [Source Title](wiki/sources/slug.md) | slug | YYYY-MM-DD | article |
 
 ## Entities
-- [Entity Name](entities/slug.md) — one-line description
+- [Entity Name](wiki/entities/slug.md) — one-line description
 
 ## Concepts
-- [Concept Name](concepts/slug.md) — one-line description
+- [Concept Name](wiki/concepts/slug.md) — one-line description
 
 ## Syntheses and analyses
-- [Page Title](path/to/page.md) — one-line description
+- [Page Title](wiki/path/to/page.md) — one-line description
 ```
 
 Update the header counts and add rows/entries on every ingest.
@@ -226,7 +226,7 @@ Always link entity and concept names on first mention within a page.
 ### Working rules
 
 1. Never modify anything in `raw/` — it is the immutable source of truth
-2. Always update `index.md` and `log.md` on every ingest
+2. Always update the root `index.md` and `wiki/log.md` on every ingest
 3. Cross-references are the point — a page with no links is a missed opportunity
 4. File good answers back — if a query produces a valuable synthesis, create a wiki page
 5. Note contradictions explicitly — don't silently overwrite; flag the tension

--- a/skills/workflows/maintain-context/SKILL.md
+++ b/skills/workflows/maintain-context/SKILL.md
@@ -7,8 +7,8 @@ requires_agent_teams: false
 requires_claude_code: true
 min_plan: starter
 owns:
-  directories: []
-  patterns: ["CONTEXT.md", "docs/adr/**"]
+  directories: ["docs/adr/"]
+  patterns: ["CONTEXT.md"]
   shared_read: []
 allowed-tools: ["Read", "Write", "Edit", "Grep", "Glob"]
 composes_with: ["grill-me", "architecture-rescue", "setup-project-skills"]
@@ -18,6 +18,8 @@ spawned_by: []
 # maintain-context
 
 Incrementally maintain two artifacts as conversations happen: `CONTEXT.md` (the project's domain glossary) and `docs/adr/` (decision records). Both compound in value only if you keep them honest, narrow, and rare.
+
+> **Ownership.** This skill owns `docs/adr/` exclusively (as a directory, so it takes precedence over pattern ownership) plus the `CONTEXT.md` glossary file. `docs/adr/` is an explicit carve-out from `docs-agent`'s broader `docs/` ownership — without it, `docs/` would silently swallow the ADR subtree. `docs-agent` reads `docs/adr/` for context but never writes there. See the canonical map in the orchestrator's `references/file-ownership.md`.
 
 ## The three-condition ADR gate
 

--- a/skills/workflows/project-profiler/SKILL.md
+++ b/skills/workflows/project-profiler/SKILL.md
@@ -12,12 +12,14 @@ owns:
   shared_read: ["*"]
 allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
 composes_with: ["skill-writer", "contract-author", "orchestrator"]
-spawned_by: ["orchestrator"]
+spawned_by: []
 ---
 
 # Project Profiler
 
 Analyze a codebase and generate a project profile that agents can consume. You produce two files: `CLAUDE.md` (human-readable, ≤200 lines) and `.claude/profile.yaml` (machine-readable).
+
+**Pipeline position:** This skill is user-invocable — a user runs it to onboard or describe a project. It is not spawned by the orchestrator. Its output is *consumed by* downstream skills: the orchestrator reads `CLAUDE.md` for project context, deployment-checklist reads it for environment-specific commands and URLs, and dependency-coordinator reads `.claude/profile.yaml` for the tech-stack profile. Think consumed-by, not spawned-by.
 
 ## Role
 
@@ -101,7 +103,7 @@ Follow the schema in `references/profile-schema.yaml`. Fill in every field that 
 
 ### 7. Generate CLAUDE.md
 
-Structure per the spec (≤200 lines):
+Structure as follows (≤200 lines):
 
 - What This Is (1-2 sentences)
 - Tech Stack (bullet list)
@@ -115,7 +117,7 @@ Structure per the spec (≤200 lines):
 
 ## Quality Checklist
 
-- [ ] profile.yaml passes schema validation
+- [ ] profile.yaml conforms to the structure in `references/profile-schema.yaml`
 - [ ] CLAUDE.md is ≤200 lines
 - [ ] All "How to Run" commands are verified to work
 - [ ] Directory map matches actual structure

--- a/skills/workflows/render-sanity/SKILL.md
+++ b/skills/workflows/render-sanity/SKILL.md
@@ -29,8 +29,8 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-composes_with: ["superpowers:ux-review", "qe-agent", "orchestrator", "frontend-agent", "feature-dev:feature-dev", "playwright"]
-spawned_by: ["orchestrator", "superpowers:ux-review", "qe-agent"]
+composes_with: ["superpowers:ux-review", "orchestrator", "frontend-agent", "feature-dev:feature-dev", "playwright"]
+spawned_by: ["orchestrator", "superpowers:ux-review"]
 ---
 
 # Render Sanity
@@ -158,7 +158,6 @@ This skill catches one specific failure mode: **the app renders, but renders bro
 
 - **`orchestrator`** is the primary invoker. It calls render-sanity at Phase 12 (post-build verification) BEFORE `superpowers:ux-review` — render-sanity catches broken-content failures; ux-review then assesses polish on a known-good shell. A render-sanity FAIL blocks the build's Definition of Done.
 - **`superpowers:ux-review`** MAY invoke render-sanity as a precondition. When it does, the render-sanity report becomes the "Critical Issues" section of the ux-review report.
-- **`qe-agent`** SHOULD invoke render-sanity when its plan includes E2E or "UI reflects backend state after mutations" acceptance criteria. The signed-out/signed-in matrices catch bugs contract conformance cannot.
 - **`feature-dev:feature-dev`** SHOULD invoke render-sanity after a feature is wired end-to-end, before declaring "the feature works."
 - **The user** can invoke this skill directly any time they want a fast objective answer to "is the UI actually working" — typically after a build claims done, after a refactor, after auth was added, or after seeing a screenshot with `?` / `Couldn't load` / dead links.
 

--- a/skills/workflows/repo-deep-dive/references/vault-integration.md
+++ b/skills/workflows/repo-deep-dive/references/vault-integration.md
@@ -13,12 +13,12 @@ A directory is a **knowledge vault** if it shows the markers below. Search likel
 ```bash
 # Strong signals (any one is a good indicator; two+ is near-certain):
 #   .obsidian/        → an Obsidian vault
-#   index.md + log.md at root, plus a wiki/ dir
+#   a root index.md entry point, plus a wiki/ dir of article pages (incl. wiki/log.md)
 #   a CLAUDE.md (or similar) that self-describes as a wiki/knowledge base
 # Existing convention: sibling dirs ending in _deepdive (the established naming)
 find <search-root> -maxdepth 2 -type d -name '.obsidian' 2>/dev/null
 find <search-root> -maxdepth 3 -type d -name '*_deepdive' 2>/dev/null | head
-ls <candidate>/index.md <candidate>/log.md <candidate>/CLAUDE.md 2>/dev/null
+ls <candidate>/index.md <candidate>/CLAUDE.md 2>/dev/null
 ls -d <candidate>/wiki/{entities,concepts,comparisons,sources} 2>/dev/null
 ```
 
@@ -40,8 +40,8 @@ Run this **only when the output target is a detected vault**, and only *after* t
 2. **Entity pages** — create/update `wiki/entities/<project>.md` and a page for any major named subsystem worth its own node (e.g. a security scanner, a notable engine). Synthesis, not a dump.
 3. **Concept pages** — create/update `wiki/concepts/<idea>.md` for any cross-cutting pattern the deep dive surfaced that spans multiple projects (e.g. a learning loop, a merge strategy). Link which systems implement it and how they differ.
 4. **Comparison page** — `wiki/comparisons/<project>-vs-<reference>.md` distilling the Phase 4 comparison + the build list.
-5. **Update the catalog** — add entries for every new page to `index.md` in its correct section (Entities / Concepts / Comparisons / Sources).
-6. **Append the log** — add one append-only entry to `log.md` in the vault's format (commonly `## [YYYY-MM-DD] deep-dive | <Title>`) noting sources, outputs, wiki pages touched, and key findings.
+5. **Update the catalog** — add entries for every new page to the root `index.md` (the entry point) in its correct section (Entities / Concepts / Comparisons / Sources).
+6. **Append the log** — add one append-only entry to `wiki/log.md` in the vault's format (commonly `## [YYYY-MM-DD] deep-dive | <Title>`) noting sources, outputs, wiki pages touched, and key findings.
 
 ### Page format (typical Obsidian vault)
 

--- a/skills/workflows/setup-project-skills/SKILL.md
+++ b/skills/workflows/setup-project-skills/SKILL.md
@@ -22,6 +22,8 @@ Explicit-invocation only. Run once per repository.
 
 > **What this writes:** a `docs/agents/` directory containing three config files (`domain-docs.md`, `contract-format.md`, `work-item-tracker.md`) plus an `## Agent skills` block appended to either `CLAUDE.md` or `AGENTS.md`. Never both. Never overwrites an existing `## Agent skills` block without explicit confirmation.
 
+> **Ownership:** this skill owns `docs/agents/` exclusively. It is carved out of `docs-agent`'s broader `docs/` ownership — `docs-agent` reads `docs/agents/` for context but never writes there. See the canonical map in the orchestrator's `references/file-ownership.md`.
+
 This skill bootstraps the per-repo configuration that the rest of the Skill-Madness toolkit reads at runtime. Downstream skills like `maintain-context`, `contract-author`, and the orchestrator look in `docs/agents/` for these files and fail loud if they are missing.
 
 ## The three questions

--- a/skills/workflows/wiki-research/SKILL.md
+++ b/skills/workflows/wiki-research/SKILL.md
@@ -12,7 +12,7 @@ owns:
   shared_read: ["wiki/", "index.md"]
 allowed-tools: ["Read", "Glob", "Grep"]
 composes_with: ["repo-deep-dive", "llm-wiki", "project-profiler"]
-spawned_by: ["orchestrator", "code-review-agent", "repo-deep-dive", "project-profiler", "backend-agent", "frontend-agent", "security-agent", "plan-builder"]
+spawned_by: ["orchestrator", "code-review-agent"]
 ---
 
 # Wiki-First Research Protocol

--- a/skills/workflows/zoom-out/SKILL.md
+++ b/skills/workflows/zoom-out/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: zoom-out
 version: 1.1.0
-description: "Step back from the current code and give a higher-level perspective: which modules are involved, how do they connect, what is this change touching that isn't obvious? Reads the project's CONTEXT.md / domain glossary when available. Explicit invocation only — does not auto-fire. Use when feeling stuck in detail, when a change feels bigger than expected, or before making a structural decision."
+description: "User-invoked only, via /zoom-out — never auto-fires. Steps back from the current code to give a higher-level perspective: which modules are involved, how do they connect, what is this change touching that isn't obvious? Reads the project's CONTEXT.md / domain glossary when available. Invoke it deliberately when you feel stuck in detail, when a change feels bigger than expected, or before making a structural decision and you want a map first."
 disable-model-invocation: true
 requires_agent_teams: false
 requires_claude_code: true


### PR DESCRIPTION
## Summary

Second wave (**P1 — wiring & handoff integrity**) of the reports-v2 functional audit. Goal: make the dependency graph *truthful* and every producer/consumer handoff *resolve*. 11 file-disjoint agents, each re-checked by an independent skeptic; the cross-task seams the skeptics caught were reconciled by hand.

**Stacked on [#15](https://github.com/ivy00johns/Skill-Madness/pull/15)** — merge P0 first. (Also carries one `chore: ignore node_modules and audit artifacts` commit.)

## Changes

**Dead spawn edges — trimmed per the chosen dispositions**
- `context-manager` → drop orchestrator spawn edge; reframed user-only, validation logic deduped into `handoff-protocol.md` (the protocol that actually runs).
- `code-review-agent` → **cede** build-time diff review to the external `/code-review` CLI; reframed as *explicit-invoke-only* so it stays reachable instead of becoming an orphan (it's `disable-model-invocation: true`, so trimming the edge alone would have made it dead — the skeptic caught this).
- `project-profiler` → drop false orchestrator spawn edge; reframed consumed-by.
- `wiki-research` → `spawned_by` trimmed to `[orchestrator, code-review-agent]` (the only real invokers).
- `render-sanity` → drop the non-reciprocated `qe-agent` edge (kept orchestrator); reconciled the prose that claimed qe-agent invokes it.

**Producer/consumer paths**
- Contract shared types standardized on the flat file `contracts/types.<ext>` (author writes it; auditor + frontend-agent read it). contract-auditor now states a concrete report output path.
- Wiki layout canonicalized to **root `index.md` + `wiki/` articles** across `llm-wiki`, `wiki-research`, and `repo-deep-dive`'s vault example.

**Ownership** — rebuilt `file-ownership.md` as genuinely canonical (every owner + the three `docs/` carve-outs explicit). `skill-update` owns `[]`; `.env.example` → infrastructure-agent only; `docs/agents/` → setup-project-skills; `docs/adr/` → maintain-context. **No two skills own the same path.**

**Namespace** — prefixed the confidently-known plugin refs (`superpowers:`, `frontend-design:`, `feature-dev:`, `skill-creator:`). No in-repo skill was wrongly prefixed.

## Needs a human call (left bare on purpose)
Five external refs in `orchestrator`/`frontend-agent` couldn't be prefixed with certainty: **`ux-review`, `ui-ux-pro-max`, `claude-api`, `loop`, `schedule`**. Signal that they likely want `superpowers:`: render-sanity already uses `superpowers:ux-review`, and the frontmatter-spec uses `superpowers:ui-ux-pro-max` as an example. Confirm and I'll apply in a follow-up.

## Deferred to P2 (noted in the audit, intentionally not touched here)
code-review-agent `Write`-vs-read-only + report output path · render-sanity "Phase 12 vs 13" label · contract format-decision-tree symmetry · skill-review `docs/architecture.md` coverage-gap.

## Test plan

- [x] No two skills own the same path (frontmatter-level extraction across all 49)
- [x] `skill-update` owns `[]`; `.env.example` resolves to infrastructure-agent only; `docs/agents` + `docs/adr` single-owner each
- [x] `context-manager`/`project-profiler`/`code-review-agent` `spawned_by: []`; `wiki-research` = `[orchestrator, code-review-agent]`; render-sanity dropped qe-agent
- [x] No `wiki/index.md` entry-point remains; all three wiki skills agree on root `index.md`; ownership map matches
- [x] contract-auditor reads the flat `contracts/types.<ext>` (no dir form)
- [x] No in-repo skill given a plugin prefix; YAML frontmatter valid across all changed files
- [x] code-review-agent no longer self-contradicts (no "Not user-invocable" / "Spawned by orchestrator" remnants) and is reachable via explicit invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)