### PR TITLE
fix: Correct external skill namespaces (close FA6)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -27,7 +27,7 @@ Skill-Madness is a mature **50-skill** library — a contract-first multi-agent 
 - ✅ **M2 — Ecosystem audit + fixes** (2026-05-20): 48 per-skill reports; all C1–C4 critical findings resolved.
 - ✅ **M3 — Runtime + install layer** (2026-05-24, PR #8): hooks, installer discipline, telemetry, scanner, PSFS standard.
 - 🟡 **M4 — Doc-polish (IMPROVEMENT_PLAN Phases 2–4)**: reference files + thinking-move docs shipped (RF1–RF5, TM1–TM3). 3 items left in the ledger (PR1 verify + CL1/CL2 cleanup). **Nearly done.**
-- 🟡 **M5 — Functional audit (reports-v2) + remediation** (audit 2026-05-28; remediation 2026-05-30/31): P0 blockers (PR #15) and P1 wiring/ownership/namespace (PR #16) **both merged**; plan ledger reconciled (PR #17). P2 fidelity backlog filed (FA1–FA5), plus 2 open design decisions (FA7–FA8) and the namespace confirm (FA6). **Remediation landed; P2 backlog open.**
+- 🟡 **M5 — Functional audit (reports-v2) + remediation** (audit 2026-05-28; remediation 2026-05-30/31): P0 blockers (PR #15) and P1 wiring/ownership/namespace (PR #16) **both merged**; plan ledger reconciled (PR #17). P2 fidelity backlog filed (FA1–FA5); FA6 namespaces resolved (2026-06-01); 2 open design decisions remain (FA7–FA8). **Remediation landed; P2 + 2 decisions open.**
 
 ## Closure log
 
@@ -49,6 +49,7 @@ Items move here on ship. Format: `<ref> (date) — <one-line summary>`.
 - **FA-P1 — wiring & integrity** (2026-05-30, PR #16, merged 2026-05-31) — 6 dead `spawned_by` edges trimmed; contract types standardized on flat `contracts/types.<ext>`; wiki layout canonicalized to root `index.md` + `wiki/`; `file-ownership.md` rebuilt canonical (no path owned twice; `.env.example`→infra; `docs/agents`→setup-project-skills; `docs/adr`→maintain-context); known plugin refs namespaced (5 left pending human confirm → FA6); `audit/` + `node_modules/` gitignored.
 - **Living-plan reconciliation** (2026-05-31, PR #17) — re-synced PLAN / START-HERE / REMAINING-WORK / FUTURE / CLAUDE to reality (count 47→49), intaken the reports-v2 functional audit as ledger entries FA1–FA8, and untracked the 96 superseded v1 audit reports.
 - **website-walkthrough-video skill** (2026-05-31) — added the 50th skill: a smooth full-site scrolling walkthrough-video generator (Playwright full-page capture + ffmpeg pan/render → desktop + mobile mp4s). Catalog 49→50.
+- **FA6 — external namespace correctness** (2026-06-01) — corrected refs wrongly prefixed `superpowers:` on non-superpowers skills (`superpowers:ux-review`→`ux-review`, `superpowers:ui-ux-pro-max`→`ui-ux-pro-max`, `superpowers:frontend-design`→`frontend-design:frontend-design`) in render-sanity / ui-brief / claude-design-brief / frontmatter-spec; added a known-bare-externals whitelist to `lint-skills.sh`. The 5 "bare" refs the audit flagged were already correct (built-in commands + a global skill, not superpowers).
 
 ---
 

--- a/docs/REMAINING-WORK.md
+++ b/docs/REMAINING-WORK.md
@@ -99,9 +99,9 @@ Add boundary clauses where trigger contexts overlap: ui-brief, plan-builder↔li
 **P3 · Cosmetic · open · Owner: —** · Source: [FAUDIT] §10 P2.13
 caveman exit phrase, claude-design-brief count, render-sanity Phase label (12 vs 13), interactive-doc `conversation_search` + metadata stub, frontmatter field ordering.
 
-### FA6 — Confirm + apply 5 bare external namespace refs
-**P1 · Namespaces · open (needs human confirm) · Owner: —** · Source: [FAUDIT] §10 P1.8 (carryover from #16)
-P1 namespaced the known plugin refs but left 5 bare pending confirmation of the correct prefix: `ux-review`, `ui-ux-pro-max`, `claude-api`, `loop`, `schedule` in orchestrator + frontend-agent (likely `superpowers:` / plugin prefixes). Confirm each target, then apply + add the lint that FAILs on bare known-plugin names.
+### FA6 — External skill namespace correctness
+**P1 · Namespaces · closed (2026-06-01) · Owner: —** · Source: [FAUDIT] §10 P1.8 (carryover from #16)
+RESOLVED. Investigation (against the live catalog) showed the 5 "bare" refs were already correct and are **not** superpowers: `ux-review` is a bare global `~/.claude/skills/` skill; `ui-ux-pro-max` is a bare-invoked plugin skill; `claude-api` / `loop` / `schedule` are Claude Code built-in commands. The real bugs were the *opposite* — wrong `superpowers:` prefixes on non-superpowers skills (`superpowers:ux-review`, `superpowers:ui-ux-pro-max`, `superpowers:frontend-design`) in render-sanity, ui-brief, claude-design-brief, and the frontmatter-spec example/convention. Fixed: corrected those to `ux-review` / `ui-ux-pro-max` / `frontend-design:frontend-design`; added a known-bare-externals whitelist to `scripts/lint-skills.sh` (so legit global/built-in refs stop warning); corrected the frontmatter-spec convention text. The 6 valid `superpowers:` refs (brainstorming, systematic-debugging, tdd, using-git-worktrees, verification-before-completion, writing-plans) were left untouched.
 
 ### FA7 — DECISION: `metadata` block — backfill all 49 or drop
 **P3 · Decision · open · Owner: —** · Source: [FAUDIT] §10 Human Decisions

--- a/scripts/lint-skills.sh
+++ b/scripts/lint-skills.sh
@@ -497,12 +497,20 @@ cross_validate() {
   local all_names
   all_names="$(awk -F'\t' '{print $1}' "$name_map_file" | sort)"
 
+  # Known bare external refs: skills that live outside this collection (a global
+  # ~/.claude/skills/ skill, or a bare-invoked plugin skill) or Claude Code
+  # built-in slash commands. Bare is their invocable form, so they are legitimate
+  # and must not flag as "unknown". Only add genuinely-verified externals. See FA6.
+  local known_external=" ux-review ui-ux-pro-max claude-api loop schedule "
+
   for f in "${files[@]}"; do
     while IFS= read -r ref_name; do
       [[ -z "$ref_name" ]] && continue
       # Plugin-namespaced refs (plugin:name) are external by definition — out of
       # scope for in-collection resolution, so they are never flagged.
       [[ "$ref_name" == *:* ]] && continue
+      # Known bare externals (global skills / built-in commands) are also fine.
+      [[ "$known_external" == *" $ref_name "* ]] && continue
       if ! printf '%s\n' "$all_names" | grep -qxF "$ref_name"; then
         emit_issue WARN "$f" "" "composes_with references unknown skill '$ref_name'"
       fi
@@ -511,6 +519,7 @@ cross_validate() {
     while IFS= read -r ref_name; do
       [[ -z "$ref_name" ]] && continue
       [[ "$ref_name" == *:* ]] && continue
+      [[ "$known_external" == *" $ref_name "* ]] && continue
       if ! printf '%s\n' "$all_names" | grep -qxF "$ref_name"; then
         emit_issue WARN "$f" "" "spawned_by references unknown skill '$ref_name'"
       fi

--- a/skills/meta/skill-writer/references/frontmatter-spec.md
+++ b/skills/meta/skill-writer/references/frontmatter-spec.md
@@ -183,14 +183,15 @@ This repo's extensions for orchestrated builds. Not part of Anthropic's spec; pa
 
 When a skill's `composes_with` or `spawned_by` references a skill from another plugin pack (rather than this repo), prefix the skill name with the plugin namespace:
 
-- `superpowers:brainstorming` (skill lives in `superpowers` plugin)
-- `superpowers:ui-ux-pro-max` (plugin)
+- `superpowers:brainstorming` (skill lives in the `superpowers` plugin)
+- `frontend-design:frontend-design` (skill in the `frontend-design` plugin)
 - `claude-mem:mem-search` (claude-mem plugin)
+- `ux-review`, `ui-ux-pro-max`, `loop` (bare — a global `~/.claude/skills/` skill, a bare-invoked plugin skill, or a Claude Code built-in command; no plugin namespace applies)
 - `bare-name` (in-repo skill — no prefix)
 
-This makes the audit pass: in-repo references can be verified against `skills/`; plugin-namespaced refs are treated as external dependencies.
+This makes the audit pass: in-repo references verify against `skills/`; `plugin:skill` refs are external dependencies; and a curated whitelist of known bare externals in `scripts/lint-skills.sh` keeps legitimate global/built-in refs from flagging as unknown.
 
-In-repo skills using this convention: `orchestrator` (claude-mem:*), `ui-brief`, `render-sanity`, `claude-design-brief`, `frontend-agent` (all using `superpowers:` prefix).
+**Only prefix a ref with a plugin namespace if the skill actually lives in that plugin — verify against the live catalog, do not assume `superpowers:`.** (FA6 corrected several refs wrongly prefixed `superpowers:`: `ux-review` and `ui-ux-pro-max` are bare; `frontend-design` is `frontend-design:frontend-design`.)
 
 ## Forbidden in Frontmatter
 

--- a/skills/workflows/claude-design-brief/SKILL.md
+++ b/skills/workflows/claude-design-brief/SKILL.md
@@ -11,7 +11,7 @@ owns:
   patterns: []
   shared_read: ["*"]
 allowed-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]
-composes_with: ["ui-brief", "superpowers:ui-ux-pro-max", "superpowers:frontend-design", "superpowers:brainstorming"]
+composes_with: ["ui-brief", "ui-ux-pro-max", "frontend-design:frontend-design", "superpowers:brainstorming"]
 spawned_by: []
 ---
 

--- a/skills/workflows/render-sanity/SKILL.md
+++ b/skills/workflows/render-sanity/SKILL.md
@@ -29,15 +29,15 @@ owns:
   directories: []
   patterns: []
   shared_read: ["*"]
-composes_with: ["superpowers:ux-review", "orchestrator", "frontend-agent", "feature-dev:feature-dev", "playwright"]
-spawned_by: ["orchestrator", "superpowers:ux-review"]
+composes_with: ["ux-review", "orchestrator", "frontend-agent", "feature-dev:feature-dev", "playwright"]
+spawned_by: ["orchestrator", "ux-review"]
 ---
 
 # Render Sanity
 
 > **Why this exists:** "Tests pass, dev server boots, console is clean" is a process bar. It's not the same as "the app works." This skill is the missing semantic check between those two — it catches failure modes that render plausibly but are quietly broken.
 
-This skill is **not** subjective. It does not evaluate visual hierarchy, typography, or polish — those are `superpowers:ux-review`'s job. It hunts four specific, objectively-verifiable failure modes that ship past every other gate.
+This skill is **not** subjective. It does not evaluate visual hierarchy, typography, or polish — those are `ux-review`'s job. It hunts four specific, objectively-verifiable failure modes that ship past every other gate.
 
 **Announce at start:** "Using render-sanity to click through [N routes] and check for stale data, placeholder text, dead links, and auth dead-ends."
 
@@ -146,8 +146,8 @@ A FAIL is a gate, not a recommendation. The orchestrator's Definition of Done de
 
 ## What this skill is NOT
 
-- **Not visual review.** "The spacing feels off" / "the gradient is harsh" — those belong to `superpowers:ux-review`. This skill has no opinion about aesthetics.
-- **Not accessibility audit.** Heading hierarchy, ARIA labels, keyboard nav — `superpowers:ux-review` or a11y tooling.
+- **Not visual review.** "The spacing feels off" / "the gradient is harsh" — those belong to `ux-review`. This skill has no opinion about aesthetics.
+- **Not accessibility audit.** Heading hierarchy, ARIA labels, keyboard nav — `ux-review` or a11y tooling.
 - **Not performance.** Bundle size, LCP, hydration — `performance-agent`.
 - **Not contract conformance.** Whether the API matches the OpenAPI spec — `qe-agent` / `contract-auditor`.
 - **Not test coverage.** Whether the unit tests cover this code — `qe-agent`.
@@ -156,8 +156,8 @@ This skill catches one specific failure mode: **the app renders, but renders bro
 
 ## When invoked by other skills
 
-- **`orchestrator`** is the primary invoker. It calls render-sanity at Phase 12 (post-build verification) BEFORE `superpowers:ux-review` — render-sanity catches broken-content failures; ux-review then assesses polish on a known-good shell. A render-sanity FAIL blocks the build's Definition of Done.
-- **`superpowers:ux-review`** MAY invoke render-sanity as a precondition. When it does, the render-sanity report becomes the "Critical Issues" section of the ux-review report.
+- **`orchestrator`** is the primary invoker. It calls render-sanity at Phase 12 (post-build verification) BEFORE `ux-review` — render-sanity catches broken-content failures; ux-review then assesses polish on a known-good shell. A render-sanity FAIL blocks the build's Definition of Done.
+- **`ux-review`** MAY invoke render-sanity as a precondition. When it does, the render-sanity report becomes the "Critical Issues" section of the ux-review report.
 - **`feature-dev:feature-dev`** SHOULD invoke render-sanity after a feature is wired end-to-end, before declaring "the feature works."
 - **The user** can invoke this skill directly any time they want a fast objective answer to "is the UI actually working" — typically after a build claims done, after a refactor, after auth was added, or after seeing a screenshot with `?` / `Couldn't load` / dead links.
 

--- a/skills/workflows/ui-brief/SKILL.md
+++ b/skills/workflows/ui-brief/SKILL.md
@@ -11,7 +11,7 @@ owns:
   patterns: []
   shared_read: ["*"]
 allowed-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash"]
-composes_with: ["superpowers:ui-ux-pro-max", "superpowers:frontend-design", "superpowers:brainstorming", "superpowers:ux-review", "frontend-agent", "orchestrator", "playwright"]
+composes_with: ["ui-ux-pro-max", "frontend-design:frontend-design", "superpowers:brainstorming", "ux-review", "frontend-agent", "orchestrator", "playwright"]
 spawned_by: []
 ---
 


### PR DESCRIPTION
## Summary

Resolves **FA6**. Investigating the 5 "bare" refs the reports-v2 audit flagged (`ux-review`, `ui-ux-pro-max`, `claude-api`, `loop`, `schedule`) showed they were **already correct** — they're Claude Code built-in commands or a bare global `~/.claude/skills/` skill, **not** superpowers. The real bug was the *opposite*: several skills wrongly prefixed **non-superpowers** skills with `superpowers:`.

## Changes

- **`superpowers:ux-review` → `ux-review`** (it's a bare global skill, not in superpowers) — render-sanity (×7), ui-brief.
- **`superpowers:ui-ux-pro-max` → `ui-ux-pro-max`** (bare-invoked plugin skill) — claude-design-brief, ui-brief, frontmatter-spec example.
- **`superpowers:frontend-design` → `frontend-design:frontend-design`** (it's the `frontend-design` plugin) — ui-brief, claude-design-brief.
- **`frontmatter-spec.md`**: corrected the convention text + the wrong example; added the rule *"only prefix if the skill actually lives in that plugin — verify against the live catalog, don't assume `superpowers:`."*
- **`scripts/lint-skills.sh`**: added a curated **known-bare-externals whitelist** (`ux-review ui-ux-pro-max claude-api loop schedule`) so legitimate global/built-in refs stop warning as `unknown skill` (6 → 0).
- Closed FA6 in `docs/REMAINING-WORK.md` + added the `PLAN.md` closure-log entry.

The 6 **valid** `superpowers:` refs (brainstorming, systematic-debugging, test-driven-development, using-git-worktrees, verification-before-completion, writing-plans) were left untouched.

## Test plan

- [ ] `scripts/lint-skills.sh` → 0 errors, **0 `unknown skill` warnings** (verified locally).
- [ ] No `superpowers:<non-superpowers-skill>` refs remain (verified: grep clean).
- [ ] CI green (Lint Skills, PSFS, Catalog, Skill Scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)