### PR TITLE
feat: Add Workflow mode (ultracode) to the orchestrator

### DIFF
--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: orchestrator
-version: 1.9.0
+version: 1.10.0
 description: |
-  Coordinate multi-agent Claude Code builds end-to-end: read the plan/mission, design integration contracts, dispatch role-agents in parallel, gate on QA, ship. Use when the user mentions agent teams, parallel builds, swarm builds, multi-agent work, a MISSION.md file, executing a multi-phase mission, or wants to split work across Claude sessions. Triggers on "agent team", "parallel build", "team build", "multi-agent", "swarm build", "build X with agents", "coordinate the build", "run the mission". Composes with brainstorming, plan-builder, writing-plans, contract-author, role-agents (backend/frontend/infra/qe/security/observability/performance/docs/db), render-sanity, ux-review, deployment-checklist, frontend-design, ui-ux-pro-max, nano-banana, repo-deep-dive, llm-wiki, mermaid-charts, claude-mem. Does NOT preempt brainstorming, planning, design-brief, or feature-dev — it picks up after those produce artifacts.
+  Coordinate multi-agent Claude Code builds end-to-end: read the plan/mission, design integration contracts, dispatch role-agents in parallel, gate on QA, ship. Under ultracode (standing opt-in) or an explicit "workflow"/"workflows" ask, it drives the implement + verify phases with the Workflow tool — fanning out the role-agents (`agent({agentType})`) against the contracts and adversarially verifying — instead of hand-spawning agents one message at a time. Use when the user mentions agent teams, parallel/swarm builds, multi-agent work, a MISSION.md file, a multi-phase mission, splitting work across Claude sessions, "workflow"/"dynamic workflow", or ultracode mode. Triggers on "agent team", "parallel build", "team build", "multi-agent", "swarm build", "build X with agents", "coordinate the build", "run the mission", "workflow", "dynamic workflows", "ultracode build", "orchestrate with workflows". Does NOT preempt brainstorming, planning, design-brief, or feature-dev — it picks up after those produce artifacts.
 requires_agent_teams: false
 requires_claude_code: true
 min_plan: starter
@@ -10,7 +10,7 @@ owns:
   directories: []
   patterns: [".gitignore"]
   shared_read: ["contracts/", ".claude/handoffs/"]
-allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "Agent", "Workflow"]
 composes_with: [
   "wiki-research", "llm-wiki", "repo-deep-dive",
   "superpowers:brainstorming", "plan-builder", "superpowers:writing-plans",
@@ -117,16 +117,49 @@ For the full 14-phase playbook, read `references/phase-guide.md`. For mission-in
 ## Runtime Detection
 
 ```text
-Is CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS set?
-  YES → Native Agent Teams (tmux, TeammateTool, inbox, shared task list)
-  NO → Is bash tool available?
-    YES → Subagents via Task/Agent tool (parallel, no TeammateTool)
-    NO → Sequential mode (work through roles one at a time, user coordinates)
+Is ultracode on (a system-reminder says so) OR did the user say "workflow"/"workflows"/"dynamic workflow"?
+  YES → Workflow mode (PREFERRED): drive the implement + verify phases with the Workflow tool —
+        deterministic JS that fans out the role-agents and adversarially verifies the result.
+        Design/contracts stay inline. See "Dynamic Workflows" below + references/workflow-orchestration.md.
+  NO → Is CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS set?
+    YES → Native Agent Teams (tmux, TeammateTool, inbox, shared task list)
+    NO → Is the Agent/Task tool available?
+      YES → Subagents via Task/Agent tool (parallel, no TeammateTool)
+      NO → Sequential mode (work through roles one at a time, user coordinates)
 ```
 
-Each agent role skill works standalone regardless of runtime. Only this orchestrator skill needs the full decision tree.
+Workflow mode is gated on those opt-in signals on purpose: the Workflow tool can spawn dozens of
+agents, so absent ultracode or an explicit "workflow" ask, don't reach for it — the other runtimes
+stay the default and behave exactly as before. Each agent role skill works standalone regardless of
+runtime; only this orchestrator skill needs the full decision tree.
 
 **Sequential mode**: When neither Agent Teams nor subagent spawning is available, work through each role one at a time within a single session. Apply the relevant role skill as your own instructions for that phase. The user may need to coordinate context resets between roles. Contracts and validation still apply — only the parallelism changes.
+
+## Dynamic Workflows (ultracode)
+
+When Workflow mode is selected, the **execution substrate** changes but the contract-first
+philosophy does not. You still spend 50% on design and contracts — and that work stays **inline,
+in the main loop**, because it's the human-in-the-loop architecture phase. What moves onto the
+Workflow tool is the parallel-implement and verify phases: instead of hand-spawning agents and
+shepherding replies message by message, you author a Workflow script that launches them with real
+control flow — fan-out, barriers, loop-until-green, adversarial verification.
+
+The "WITH our madness" part: a workflow `agent()` becomes one of your role-agents by invoking that
+role's skill from inside the agent's prompt (the portable path — every role skill runs standalone),
+or via `agent({agentType})` when the role is a registered subagent type. The brief is the same
+distilled template from `references/agent-spawning.md`; the contracts in `contracts/` stay the
+integration layer; file ownership, the wave gate, and the QA gate rules all still apply unchanged.
+
+Work it **one workflow per phase, in sequence** — an implement workflow, then (after you run the
+wave gate and read the structured reports) a verify workflow — so you stay at every gate instead of
+burying them in one mega-script. Keep HITL phases inline: a workflow agent runs to completion once,
+so anything needing a mid-flight human stays out of the script. And the QA gate is still law — the
+verify workflow informs you, it never overrides `gate_decision`; fix and re-run.
+
+**Read `references/workflow-orchestration.md` before authoring** — it has the phase→workflow map,
+the implement/verify script skeletons (with schemas for structured agent reports and the QA gate),
+the adversarial-verify pattern, and the caveats that bite (pure-literal `meta`, one-level nesting,
+worktree isolation cost, budget scaling, no silent caps).
 
 ## File Ownership
 
@@ -200,6 +233,10 @@ When agents approach context limits, follow the handoff protocol in `references/
 | **Treating "ux-review invoked" as the post-build gate** | Process-level checks ("did the skill run?") let visible bugs ship — stale mock IDs leaking into "live" pages, lone `?` / generic-fallback placeholder text where real data should be, lists rendering plausibly but linking to dead targets, "Couldn't load X · Unauthorized" dead-end shells on auth-gated routes. These render with 0 console errors and pass every test-suite-based gate. The outcome-level gate is `render-sanity`: its four objective checks (smell scan, click-through every list, signed-out matrix, signed-in matrix) must return PASS. A "ux-review invoked" line in MISSION_SKILLS.md without a render-sanity PASS is the bug v1.7's process rigor was masking. |
 | **Skipping `render-sanity` when the dev stack isn't up** | Don't invoke validation against a dead port and call it green. Either bring up the stack first (the workspace already has a one-command `dev` script per workspace-bootstrap rules) or report "Cannot run — dev server not responding." Silent skips are how broken builds get declared done. |
 | **Spawning an agent without AFK/HITL classification** | Every agent dispatch must declare whether it can finish unattended (AFK) or needs a human in the loop (HITL). Undeclared dispatches stall builds the moment a prompt fires with no one watching. |
+| **Hand-spawning agents one message at a time under ultracode / Workflow mode** | When the opt-in signals are present, deterministic fan-out is the whole point — author a Workflow script (`references/workflow-orchestration.md`) for the implement + verify phases instead of dispatching and babysitting replies manually. |
+| **Putting the contract/design phase inside a workflow** | Design and contracts are interactive, human-in-the-loop architecture — the 50% that can't be delegated. Keep them inline; workflows execute implement + verify, not the decisions that shape them. |
+| **Cramming the whole build into one mega-workflow** | One workflow per phase, run in sequence, so the wave gate and QA gate stay real checkpoints you read between. A single script that implements-and-ships hides the gates that keep multi-agent builds safe. |
+| **Letting a workflow silently cap coverage** | If a script bounds work (top-N findings, sampled routes, no retry), `log()` what was dropped — same audit ethos as the mission-skills manifest. Silent truncation reads as "covered everything." |
 
 ## Definition of Done
 
@@ -227,6 +264,7 @@ ALL must be true:
 ## Reference Documents
 
 - **`references/mission-interpretation.md`** — how to read a multi-phase mission/plan as a script you EXECUTE, including the skill-trigger heuristic (when each composable skill earns its keep) and the `MISSION_SKILLS.md` template.
+- **`references/workflow-orchestration.md`** — Workflow mode (ultracode / "workflow"): the phase→workflow map, role-agents-as-workflow-agents, implement + verify script skeletons with schemas, adversarial QA verification, and the caveats that bite. Read before authoring any Workflow script.
 - **`references/phase-guide.md`** — the full 14-phase build playbook (Phase 0 external-services audit through Phase 13 handoff).
 - **`references/team-sizing.md`** — how to size the agent team to the work; thresholds and starter formulas.
 - **`references/file-ownership.md`** — canonical agent-to-directory ownership map and contract-first architecture overview.

--- a/skills/orchestrator/references/workflow-orchestration.md
+++ b/skills/orchestrator/references/workflow-orchestration.md
@@ -1,0 +1,206 @@
+# Workflow-driven orchestration (ultracode)
+
+How to run the contract-first madness build on the **Workflow tool** — deterministic JS
+that fans out subagents — instead of hand-spawning agents one message at a time. Read this
+when ultracode is on, when the user said "workflow", or when a build is large enough that
+message-by-message dispatch would lose the thread.
+
+## Table of contents
+- [The model](#the-model)
+- [When NOT to use a workflow](#when-not-to-use-a-workflow)
+- [Phase → workflow mapping](#phase--workflow-mapping)
+- [Role-agents as workflow agents](#role-agents-as-workflow-agents)
+- [Skeleton: the implement workflow](#skeleton-the-implement-workflow)
+- [Skeleton: the verify workflow](#skeleton-the-verify-workflow)
+- [Caveats that bite](#caveats-that-bite)
+
+## The model
+
+Nothing about the philosophy changes. Design and contracts are still 50% of the effort and
+still happen **inline, in the main loop** — that's the human-in-the-loop architecture work.
+What changes is the *execution substrate* for the parallel-implement and verify phases:
+instead of you spawning agents and shepherding replies by hand, you author a Workflow script
+that spawns them deterministically with real control flow (fan-out, barriers, loop-until-green,
+adversarial verification).
+
+The Workflow tool runs the script in the background and hands you back structured results.
+The contracts in `contracts/` remain the integration layer — workflow agents share the same
+working tree, so they read the same contracts and write to their owned directories exactly as
+a hand-spawned agent would. File ownership (`references/file-ownership.md`), the QA gate rules,
+and the wave gate all still apply; the workflow is just how the agents get launched.
+
+**One workflow per phase, run in sequence.** Ultracode's guidance is to author a workflow per
+phase (implement → verify → ...) and read each result before launching the next. That keeps you
+in the loop at every gate — you inspect the implement workflow's summaries, run/confirm the wave
+gate, then launch verify. Don't try to cram the whole build into one mega-script; you lose the
+gates that make multi-agent builds safe.
+
+## When NOT to use a workflow
+
+- **The design/contract phase.** It's interactive architecture work with you and (often) the
+  user. Keep it inline. Putting contract authoring inside a workflow buries the most important
+  decisions in a subagent.
+- **HITL phases.** A workflow agent runs to completion and returns once — there's no pausing
+  mid-agent for a human. Any phase classified HITL (see `references/agent-spawning.md`) stays
+  inline. Workflow agents are inherently AFK; only dispatch AFK work into them.
+- **Trivial builds.** One or two agents with no verification loop is faster dispatched directly.
+
+## Phase → workflow mapping
+
+| Build phase | Substrate | Why |
+|---|---|---|
+| 0–4: external audit, plan read, skills manifest, **contracts** | Inline (main loop) | Architecture + HITL; the 50% that can't be delegated |
+| Pre-build creative (`nano-banana`, design briefs, `repo-deep-dive`) | Inline or its own workflow | These produce artifacts agents consume; run before implement |
+| **Implement** (role-agents, by wave) | **Workflow** | Deterministic fan-out is exactly what `parallel`/`pipeline` are for |
+| Wave gate (install + typecheck + test) | Inline barrier between implement waves | You must see failures and route them; see `references/wave-gate.md` |
+| **Verify** (qe-agent, render-sanity, ux-review, code/security review) | **Workflow** | Find → adversarially verify is the canonical review pattern |
+| Mission completion check, end-state report | Inline | Audit + human handoff |
+
+## Role-agents as workflow agents
+
+This is the "WITH our madness" part. A workflow `agent()` becomes one of your role-agents by
+**invoking the role skill from inside the agent's prompt** — the portable path, since every
+role skill is built to "work standalone regardless of runtime":
+
+```js
+agent(
+  `You are the backend agent for this build. Begin by invoking the \`backend-agent\` skill
+   (Skill tool) to load your role instructions, then execute the brief below against the
+   contracts in contracts/.
+
+   ${distilledBrief}`,                       // the agent-spawning.md template, filled in
+  { label: 'backend', phase: 'Implement', schema: AGENT_REPORT }
+)
+```
+
+The brief is the **same distilled template** from `references/agent-spawning.md` (ownership,
+plan excerpt, contracts produced/consumed, domain rules, before-reporting-done). Don't paste the
+whole plan — distillation matters more here, not less, because you're spawning many at once.
+
+If a role happens to be registered as a custom subagent type, `agent(prompt, {agentType:
+'backend-agent'})` is a shortcut — but the skill-invocation-in-prompt approach above always works
+and is the default. Either way, return a structured report via `schema` so the gate logic is data,
+not prose:
+
+```js
+const AGENT_REPORT = {
+  type: 'object',
+  required: ['role', 'status', 'filesTouched', 'validation'],
+  properties: {
+    role: { type: 'string' },
+    status: { enum: ['done', 'blocked', 'partial'] },
+    filesTouched: { type: 'array', items: { type: 'string' } },
+    validation: { type: 'string', description: 'commands run + results' },
+    blockers: { type: 'array', items: { type: 'string' } },
+  },
+};
+```
+
+## Skeleton: the implement workflow
+
+One wave of role-agents in parallel (they own disjoint directories, so no write conflicts), each
+loading its role skill and building against the contracts. `parallel` is the right call here
+because the wave gate downstream needs *all* agents done before it runs.
+
+```js
+export const meta = {
+  name: 'madness-implement',
+  description: 'Fan out role-agents for one implementation wave against the contracts',
+  phases: [{ title: 'Implement' }],
+};
+
+const AGENT_REPORT = { /* as above */ };
+
+// `args` carries the per-role briefs you distilled inline (pass them in the Workflow call).
+const briefs = args.briefs;   // [{ role: 'backend', prompt: '...' }, ...]
+
+const reports = await parallel(
+  briefs.map((b) => () =>
+    agent(b.prompt, { label: b.role, phase: 'Implement', schema: AGENT_REPORT })
+  )
+);
+
+return reports.filter(Boolean);
+```
+
+You then read `reports` inline, run the wave gate (`references/wave-gate.md`), and route any
+`status: 'blocked'` back to that role in the next wave. For a dependency-ordered build (backend
+before frontend-that-calls-it), use `pipeline` so each item flows through stages without a global
+barrier — but most waves are a flat `parallel`.
+
+When agents would touch overlapping paths and ownership can't fully partition them, add
+`isolation: 'worktree'` to those `agent()` calls so they build on isolated copies — but it's
+expensive (per-agent worktree setup), so reserve it for genuine conflicts; clean directory
+ownership avoids needing it.
+
+## Skeleton: the verify workflow
+
+Find → adversarially verify. The qe-agent produces the real `qa-report.json` (gate it per the
+main skill's QA Gate Rules); the review/sanity agents surface findings, and each finding is
+checked by an independent skeptic so plausible-but-wrong issues don't stall the build.
+
+```js
+export const meta = {
+  name: 'madness-verify',
+  description: 'QE gate + render-sanity + reviews, with adversarial verification of findings',
+  phases: [{ title: 'QA' }, { title: 'Review' }, { title: 'Verify' }],
+};
+
+const QA_REPORT = { /* mirror roles/qe-agent/references/qa-report-schema.json */ };
+const FINDINGS = { type: 'object', required: ['findings'],
+  properties: { findings: { type: 'array', items: {
+    type: 'object', required: ['title', 'severity', 'file'],
+    properties: { title: {type:'string'}, severity: {type:'string'}, file: {type:'string'} } } } } };
+const VERDICT = { type: 'object', required: ['real'],
+  properties: { real: {type:'boolean'}, reason: {type:'string'} } };
+
+// QE gate first — its report is authoritative and you do NOT override it.
+const qa = await agent(
+  `Invoke the \`qe-agent\` skill, write + run tests against the contracts, and emit qa-report.json.`,
+  { label: 'qe', phase: 'QA', schema: QA_REPORT }
+);
+
+// Review dimensions in parallel; each finding gets independently verified as it lands.
+const LENSES = [
+  { key: 'render-sanity', prompt: 'Invoke `render-sanity`; run all four checks on the live app.' },
+  { key: 'ux',            prompt: 'Invoke `ux-review`; walk the routes at desktop + mobile.' },
+  { key: 'code',          prompt: 'Run `code-review` on the diff.' },
+  { key: 'security',      prompt: 'Run `security-review` on the diff.' },
+];
+
+const verified = await pipeline(
+  LENSES,
+  (l) => agent(l.prompt, { label: l.key, phase: 'Review', schema: FINDINGS }),
+  (review, l) => parallel((review?.findings ?? []).map((f) => () =>
+    agent(`Adversarially verify this ${l.key} finding — try to REFUTE it. Default real=false if unsure: ${f.title} (${f.file})`,
+          { label: `verify:${f.file}`, phase: 'Verify', schema: VERDICT })
+      .then((v) => ({ ...f, real: v?.real }))))
+);
+
+const confirmed = verified.flat().filter(Boolean).filter((f) => f.real);
+return { qa, confirmed };
+```
+
+Read `qa` against the QA Gate Rules and act on `confirmed`. If the gate fails or criticals
+remain, fix and re-run verify — a **loop-until-green** with a hard cap (e.g. 3 rounds, matching the
+circuit breaker) so a stubborn failure surfaces to the human instead of spinning.
+
+## Caveats that bite
+
+- **`meta` is a pure literal** — no variables, function calls, or template strings in it. Use the
+  same phase titles in `meta.phases` as in your `phase()`/`{phase: ...}` calls.
+- **Nesting is one level.** The orchestrator (main loop) launches the workflow; a role-agent
+  *inside* a workflow cannot call the Workflow tool again. Don't write briefs that tell an agent
+  to "run a workflow."
+- **Permissions.** Run the build in a write-permissive mode (acceptEdits/auto) so workflow agents
+  don't burn context on permission prompts — same rule as hand-spawned agents.
+- **Pipeline by default; barrier only when a stage needs all prior results.** Implement waves and
+  QA-finding dedup are genuine barriers (`parallel`); most else pipelines.
+- **No silent caps.** If you bound coverage (top-N findings, sampled routes, no retry), `log()`
+  what you dropped. Silent truncation reads as "covered everything" — the same audit ethos as the
+  mission-skills manifest.
+- **Scale to budget under ultracode.** If a token target is set, size the fleet and the
+  verify-round count to `budget` rather than a fixed number; with no target, use sensible defaults
+  (one agent per owned domain, 1 verifier per finding).
+- **The QA gate is still law.** The verify workflow informs you; it doesn't get to override
+  `gate_decision`. Fix and re-run.


### PR DESCRIPTION
## Summary

Restores + finishes the orchestrator's **Workflow mode** feature (was WIP in a stash). When **ultracode** is on or the user explicitly asks for a **"workflow"**, the orchestrator now drives the *implement + verify* phases with the **Workflow tool** — authoring deterministic scripts that fan out the role-agents (`agent({agentType})`) against the contracts and adversarially verify — instead of hand-spawning agents one message at a time. Design + contracts stay **inline** (the human-in-the-loop architecture phase); one workflow per phase keeps the wave gate and QA gate as real checkpoints.

## Changes

- **`orchestrator/SKILL.md` → v1.10.0**: `allowed-tools` += `Agent`, `Workflow`; a Workflow-mode branch in *Runtime Detection*; a new **Dynamic Workflows (ultracode)** section; 4 new anti-patterns (hand-spawning under ultracode, design-in-a-workflow, mega-workflow, silent coverage caps); a *Reference Documents* entry. Description trimmed to **1022 chars** (PSFS ≤1024).
- **new `references/workflow-orchestration.md`** (206 lines): the phase→workflow map, implement/verify script skeletons with structured-report + QA-gate schemas, the adversarial-verify pattern, and the caveats that bite (pure-literal `meta`, one-level nesting, worktree cost, budget scaling, no silent caps).

## Test plan

- [ ] CI green (Lint Skills / PSFS, Catalog, Skill Scan).
- [ ] `composes_with`/ownership unchanged from #16 (this only adds Workflow-mode behavior).

Note: restored onto current `main` via a clean 3-way merge — #16's namespace corrections are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)