### PR TITLE
fix: Return 0 from sync-skills status functions

### DIFF
--- a/skills/workflows/sync-skills/scripts/sync-skills.sh
+++ b/skills/workflows/sync-skills/scripts/sync-skills.sh
@@ -216,6 +216,7 @@ check_status_claude() {
   done
 
   [[ $broken -gt 0 ]] && echo "  ($broken broken symlink(s) — run --clean to remove)"
+  return 0
 }
 
 # Status for Cursor (category-level)
@@ -268,6 +269,7 @@ check_status_cursor() {
   done
 
   [[ $broken -gt 0 ]] && echo "  ($broken broken symlink(s) — run --clean to remove)"
+  return 0
 }
 
 if [[ "$STATUS_MODE" == "yes" ]]; then


### PR DESCRIPTION
## Summary

`check_status_claude` / `check_status_cursor` in `sync-skills.sh` ended on a `[[ $broken -gt 0 ]]` test. With **zero broken symlinks** that test is false, so the function returned **exit 1** — which can trip callers running under `set -e` and make a clean status look like a failure. Added an explicit `return 0` to both.

## Test plan

- [ ] `sync-skills.sh --status` exits 0 when there are no broken symlinks.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)