### PR TITLE
feat: Make the skill catalog self-maintaining (single source of truth)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/ivy00johns"
   },
   "metadata": {
-    "description": "All the skills, all the agents, all the chaos — a contract-first multi-agent orchestrator and the 50-skill library it draws from.",
+    "description": "All the skills, all the agents, all the chaos — a contract-first multi-agent orchestrator and the 51-skill library it draws from.",
     "version": "0.1.0",
     "homepage": "https://github.com/ivy00johns/Skill-Madness",
     "license": "MIT"
@@ -15,7 +15,7 @@
     {
       "name": "skill-madness",
       "source": "./",
-      "description": "Install all 50 Skill-Madness skills: the 14-phase orchestrator, 9 role agents with exclusive file ownership, 3 contract skills (OpenAPI/AsyncAPI/Pydantic/TS/JSON Schema), 5 git workflow skills, 9 meta/skill-management skills, 13 cross-cutting workflows (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …), and the interactive-doc workflow.",
+      "description": "Install all 51 Skill-Madness skills: the 14-phase orchestrator, 9 role agents with exclusive file ownership, 3 contract skills (OpenAPI/AsyncAPI/Pydantic/TS/JSON Schema), 5 git workflow skills, 9 meta/skill-management skills, 13 cross-cutting workflows (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …), and the interactive-doc workflow.",
       "version": "0.1.0",
       "author": {
         "name": "ivy00johns"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-madness",
-  "description": "Contract-first multi-agent orchestrator with 50 skills: a 14-phase orchestrator that authors machine-readable contracts before code, dispatches 10 role agents in parallel with exclusive file ownership, and blocks the merge on a structured QA report. Plus meta-skills, git conventions, and cross-cutting workflow tools (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …).",
+  "description": "Contract-first multi-agent orchestrator with 51 skills: a 14-phase orchestrator that authors machine-readable contracts before code, dispatches 10 role agents in parallel with exclusive file ownership, and blocks the merge on a structured QA report. Plus meta-skills, git conventions, and cross-cutting workflow tools (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …).",
   "version": "0.1.0",
   "author": {
     "name": "ivy00johns",
@@ -46,6 +46,7 @@
     "./skills/meta/skill-review",
     "./skills/meta/skill-update",
     "./skills/meta/skill-explorer",
+    "./skills/meta/skill-catalog",
 
     "./skills/workflows/plan-builder",
     "./skills/workflows/living-plan",
@@ -67,7 +68,6 @@
     "./skills/workflows/repo-deep-dive",
     "./skills/workflows/llm-wiki",
     "./skills/workflows/railway-deploy",
-
     "./skills/workflows/architecture-rescue",
     "./skills/workflows/caveman",
     "./skills/workflows/diagnose-loop",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A multi-agent orchestration toolkit for Claude Code — 50 OSS-publishable skills in `skills/`. Skills are symlinked to `~/.claude/skills/` for global availability.
+A multi-agent orchestration toolkit for Claude Code — 51 OSS-publishable skills in `skills/`. Skills are symlinked to `~/.claude/skills/` for global availability.
 
 The toolkit targets Claude Code as the primary host but the SKILL.md format is platform-agnostic — Claude.ai, Copilot CLI, Codex, and Gemini CLI all consume it. Skills should describe work in terms of capabilities ("read the file", "run the command") rather than Claude-Code-specific tool names where reasonable, so the same skill body works across hosts.
 
@@ -40,7 +40,7 @@ All SKILL.md files use the frontmatter convention defined in `skills/meta/skill-
 - **`skills/orchestrator/`** (1) — Entry point. 14-phase build playbook, runtime detection, contract-first coordination. References: phase-guide, team-sizing, circuit-breaker, handoff-protocol.
 - **`skills/roles/`** (10) — Implementation agents (backend, frontend, infrastructure, qe, security, performance, observability, docs, db-migration, code-review). Each has a SKILL.md + reference files with validation checklists.
 - **`skills/contracts/`** (2) — contract-author (generates contracts from templates) and contract-auditor (verifies implementations match). Templates: OpenAPI, AsyncAPI, Pydantic, TypeScript, JSON Schema.
-- **`skills/meta/`** (4) — skill-writer, skill-review, skill-update, skill-explorer.
+- **`skills/meta/`** (5) — skill-writer, skill-review, skill-update, skill-explorer, skill-catalog.
 - **`skills/git/`** (4) — Git workflow conventions: git-commit, git-pr, git-pr-feedback, git-post-merge-cleanup.
 - **`skills/workflows/`** (29) — plan-builder, plan-intake, living-plan, context-manager, deployment-checklist, dependency-coordinator, project-profiler, wiki-research, interactive-doc, settings-consolidator, sync-skills, ui-brief, claude-design-brief, mermaid-charts, nano-banana, playwright, render-sanity, repo-deep-dive, llm-wiki, railway-deploy, architecture-rescue, caveman, diagnose-loop, grill-me, maintain-context, zoom-out, setup-project-skills, work-item-brief, website-walkthrough-video.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -12,7 +12,7 @@
 
 ## Where we are
 
-Skill-Madness is a mature **50-skill** library — a contract-first multi-agent orchestrator (14 phases), 10 role agents with exclusive file ownership, contract/meta/git/workflow skills — with a runtime + install layer on top. Two large efforts and two audits have landed; the latest audit's P0+P1 remediation has now merged, with a P2 fidelity backlog filed:
+Skill-Madness is a mature **51-skill** library — a contract-first multi-agent orchestrator (14 phases), 10 role agents with exclusive file ownership, contract/meta/git/workflow skills — with a runtime + install layer on top. Two large efforts and two audits have landed; the latest audit's P0+P1 remediation has now merged, with a P2 fidelity backlog filed:
 
 1. **Skill curation** (from `DeepResearch/skills-comparative_deepdive/PLAN-skill-creator.md`): authored 8 new skills, migrated 6, merged 3 pairs into 3 unified skills, and applied 8 categories of bulk in-place edits. Fully executed.
 2. **Ecosystem audit — surface pass** (`audit/MASTER_AUDIT_PLAN.md`, 7-dimension rubric, avg 4.49/5): all critical findings closed — 5 broken `composes_with` cross-references fixed, 7 oversized descriptions trimmed under the 1024-char ceiling, 2 missing frontmatter blocks restored. This was the *style / compliance / cross-ref* layer; its per-skill reports now live in `audit/reports-v1-sufrace/`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://github.com/ivy00johns/Skill-Madness/actions/workflows/lint-skills.yml"><img src="https://github.com/ivy00johns/Skill-Madness/actions/workflows/lint-skills.yml/badge.svg" alt="Skill Lint" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
-  <img src="https://img.shields.io/badge/skills-50-success.svg" alt="50 skills" />
+  <img src="https://img.shields.io/badge/skills-51-success.svg" alt="51 skills" />
   <img src="https://img.shields.io/badge/role%20agents-10-blueviolet.svg" alt="10 role agents" />
   <img src="https://img.shields.io/badge/orchestrator-14%20phases-success.svg" alt="14-phase orchestrator" />
   <img src="https://img.shields.io/badge/hosts-11-orange.svg" alt="11 hosts" />
@@ -42,13 +42,13 @@ Every AI coding tool ships the same trap: one agent, one context window, one set
 - 📜 **Contract-first** — `contract-author` writes OpenAPI / AsyncAPI / Pydantic / TypeScript / JSON Schema *before* a line of implementation. `contract-auditor` verifies every shipped module against the spec. Agents can't drift; the contract is the truth.
 - 🤖 **Ten role agents, exclusive ownership** — backend, frontend, infrastructure, QE, security, docs, observability, db-migration, performance, code-review. Each declares `owns.directories` / `owns.files` in its frontmatter. No two agents touch the same path. Conflicts get resolved before spawn, not after.
 - 🛡️ **QA gate that blocks** — `qe-agent` emits a `qa-report.json` with critical / high / medium / low findings plus contract-conformance and security scores. The orchestrator gates the merge on the report. Agents can't self-declare "done."
-- 🪜 **Progressive disclosure** — frontmatter (~100 tokens) always loaded, body loaded on trigger, references loaded on demand. A 50-skill library stays cheap to host.
+- 🪜 **Progressive disclosure** — frontmatter (~100 tokens) always loaded, body loaded on trigger, references loaded on demand. A 51-skill library stays cheap to host.
 - 🔁 **Two-runtime degradation** — Agent Teams (parallel tmux) → subagents (Task tool) → sequential. The orchestrator picks the highest mode the host supports; role skills work standalone in any of them.
-- 🧰 **50 skills, six categories, all CI-linted** — orchestrator, roles, contracts, meta-skills (skill-writer, skill-explorer, skill-review, skill-update), git workflow conventions, and 26 cross-cutting workflow skills (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, diagnose-loop, grill-me, …). Frontmatter, body length, and cross-skill ownership all gated on every push.
+- 🧰 **51 skills, six categories, all CI-linted** — orchestrator, roles, contracts, meta-skills (skill-writer, skill-explorer, skill-review, skill-update), git workflow conventions, and 26 cross-cutting workflow skills (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, diagnose-loop, grill-me, …). Frontmatter, body length, and cross-skill ownership all gated on every push.
 - 🌐 **Portable across eleven hosts** — `SKILL.md` is the canonical source; converters emit Claude Code, Copilot, Cursor, Aider, Windsurf, OpenCode, Qwen, OpenClaw, Gemini CLI, Antigravity, and Kimi formats. The orchestrator's parallel-dispatch metadata is Claude-Code-specific, but everything else (role definitions, contracts, workflows, git conventions, meta-skills) ports cleanly. See [Also works on ten other hosts](#-also-works-on-ten-other-hosts).
 
 > **Status — read before you pitch this to anyone:**
-> - **The orchestrator + 50-skill library is the mature part.** All bodies under 500 lines, zero ownership conflicts, zero broken cross-references, full Ubuntu + macOS lint matrix on every push.
+> - **The orchestrator + 51-skill library is the mature part.** All bodies under 500 lines, zero ownership conflicts, zero broken cross-references, full Ubuntu + macOS lint matrix on every push.
 > - **Claude Code is the end-to-end-verified host.** Multi-agent dispatch with file-ownership exclusivity and the `qa-report.json` gate runs live on Claude Code today. The other ten hosts receive skill *content* but don't run the orchestrator's parallel dispatch.
 > - **Lossy conversion is announced.** When a skill is converted to a non-Claude-Code host, orchestration-only fields (`allowed_tools`, `owns`, `composes_with`, `spawned_by`, `requires_agent_teams`) are stripped with a stderr line per skill. Skills marked `requires_claude_code: true` are skipped entirely for those targets. See `contracts/installer/per-tool-output-spec.md`.
 
@@ -79,7 +79,7 @@ From inside Claude Code:
 /plugin install skill-madness@skill-madness
 ```
 
-That installs all 50 skills into Claude Code's plugin storage. No clone, no symlink, no edits-to-the-repo workflow. Use this if you just want the skills.
+That installs all 51 skills into Claude Code's plugin storage. No clone, no symlink, no edits-to-the-repo workflow. Use this if you just want the skills.
 
 To update later: `/plugin update skill-madness`.
 
@@ -160,7 +160,7 @@ flowchart TB
         cra[code-review]
     end
 
-    subgraph meta["🧠 meta/ — 4 skills"]
+    subgraph meta["🧠 meta/ — 5 skills"]
         direction TB
         sw[skill-writer]
         sx[skill-explorer]
@@ -251,7 +251,7 @@ flowchart TB
 
 ## 🧰 Skill catalog
 
-50 skills organized into six categories. All bodies under 500 lines, all frontmatter validated, zero ownership conflicts, zero broken cross-references.
+51 skills organized into six categories. All bodies under 500 lines, all frontmatter validated, zero ownership conflicts, zero broken cross-references.
 
 <details>
 <summary><b>📚 Full skill table</b> (click to expand)</summary>
@@ -521,7 +521,7 @@ Almost always a `pyyaml` version skew. CI installs `pyyaml` explicitly on macOS 
 </details>
 
 <details>
-<summary><b>"My non-Claude-Code host doesn't see all 50 skills"</b></summary>
+<summary><b>"My non-Claude-Code host doesn't see all 51 skills"</b></summary>
 
 Expected. Skills with `requires_claude_code: true` (notably the `orchestrator` and most of `roles/`) are skipped for hosts that can't execute multi-agent dispatch. Run `./scripts/convert.sh --verbose` to see the skip list per host.
 </details>
@@ -548,7 +548,7 @@ Set the override env var documented in `scripts/README.md` (e.g. `CURSOR_RULES_D
 
 ## 🗺️  Roadmap
 
-- [x] **Skill library** — 50 skills, six categories, all linted
+- [x] **Skill library** — 51 skills, six categories, all linted
 - [x] **Multi-tool installer** — convert / install / lint, eleven host adapters
 - [x] **CI matrix** — Ubuntu + macOS lint on every push
 - [x] **Contract-first specs** — OpenAPI / AsyncAPI / Pydantic / TypeScript / JSON Schema templates

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -5,7 +5,7 @@
 
 ## Status at a glance
 
-A mature library of **50 skills** (contracts · git · meta · orchestrator · roles · workflows), all PSFS-validated, full Ubuntu + macOS lint matrix on every push.
+A mature library of **51 skills** (contracts · git · meta · orchestrator · roles · workflows), all PSFS-validated, full Ubuntu + macOS lint matrix on every push.
 
 | Effort | State |
 |--------|-------|

--- a/contracts/installer/catalog-invariant.md
+++ b/contracts/installer/catalog-invariant.md
@@ -1,6 +1,6 @@
 # Contract: Catalog-as-CI-Invariant (P1-A)
 
-**Version:** 1.0.0
+**Version:** 1.1.0
 **Status:** ACTIVE — orchestrator, AllTheSkills P1
 **Source plan:** `DeepResearch/The-Hive/ecc_deepdive/source-material/14-alltheskills-frontier.md` (P1)
 **Models:** ECC's `scripts/ci/catalog.js` (counts asserted vs disk, build fails on drift, `--sync`).
@@ -11,7 +11,7 @@ The repo's advertised skill counts have **already drifted**: `README.md` says "4
 
 The authoritative inventory is computed from disk:
 
-- **A skill** = a directory under `skills/` containing a `SKILL.md`, **excluding** anything under `skills/archive/` and `skills/in-progress/`.
+- **A skill** = a directory directly under a category (`skills/<category>/<skill>/SKILL.md`) or the top-level `skills/orchestrator/SKILL.md`, **excluding** anything under `skills/archive/`, `skills/in-progress/`, or `node_modules/` — and anything nested deeper than a skill root (e.g. a bundled `node_modules` `SKILL.md`). The `find` scan is depth-bounded (`-maxdepth 3`) to enforce this.
 - **Category** = the immediate subdirectory of `skills/` a skill lives in (`orchestrator`, `roles`, `contracts`, `meta`, `git`, `workflows`). `orchestrator/SKILL.md` at the category root counts as category `orchestrator` (count 1).
 - Counts: total active skills + per-category counts.
 
@@ -22,8 +22,11 @@ The authoritative inventory is computed from disk:
 ```
 scripts/catalog.sh [--check | --sync | --text] [--help]
   --check   (default) compute counts from disk, compare to the asserted counts in
-            README.md + plugin.json + marketplace.json; exit 1 on any mismatch, 0 if clean.
-  --sync    rewrite the asserted counts in those files to match disk; exit 0.
+            README.md + plugin.json + marketplace.json + CLAUDE.md + PLAN.md +
+            START-HERE.md, AND verify the plugin.json `skills` array lists exactly
+            the on-disk skills; exit 1 on any mismatch, 0 if clean.
+  --sync    rewrite the asserted counts in those files + reconcile the plugin.json
+            `skills` array (register missing, drop stale) to match disk; exit 0.
   --text    print the computed catalog (total + per-category table) to stdout; exit 0.
 ```
 
@@ -32,14 +35,21 @@ scripts/catalog.sh [--check | --sync | --text] [--help]
 The check must compare disk truth against every place a count is hard-coded:
 
 - `README.md`: the shields badge (`badge/skills-<N>-…`), the "**N skills, six categories**" line, the "installs all N skills" line, the "N skills organized into six categories" line, the "doesn't see all N skills" line, the "Skill library — N skills" line, and the mermaid per-category subgraph labels (`contracts/ — N skills`, `roles/ — N agents`, `meta/ — N skills`, `git/ — N skills`, `workflows/ — N skills`).
-- `.claude-plugin/plugin.json`: the "<N> skills" phrase in `description`. (Do not try to reconcile the `skills` array here — that's verified separately by existing tooling; this check only owns the human-readable count.)
+- `.claude-plugin/plugin.json`: the "<N> skills" phrase in `description`, AND the `skills` array itself — every on-disk skill registered, no entry pointing at a skill that no longer exists. Array reconciliation is delegated to `scripts/sync-catalog-skills.py`, which preserves the existing curated order and appends new skills to their category group. *(v1.0.0 deliberately left the array alone, assuming "existing tooling" verified it; nothing did — that is the drift this version closes.)*
 - `.claude-plugin/marketplace.json`: any "<N> skills" phrase.
+- `CLAUDE.md`: the "N OSS-publishable skills" line.
+- `PLAN.md`: the "**N-skill** library" line.
+- `START-HERE.md`: the "library of **N skills**" line.
+
+Across every file, only **live** current-count phrasings are targeted; historical notes ("catalog reshaped to 47 skills", "across 49 skills") use distinct wording and are deliberately left untouched. A file that does not exist is a no-op.
 
 Detect counts by regex (`[0-9]+ skills`, `skills-[0-9]+`, `— [0-9]+ (skills|agents)`); `--sync` rewrites the number in place without touching surrounding text. Per-category labels are synced from the per-category disk counts.
 
 ## CI
 
-A new job/step (orchestrator wires it into `.github/workflows/lint-skills.yml` — **do not edit the workflow yourself**) runs `scripts/catalog.sh --check` and fails the build on drift.
+A new job/step (orchestrator wires it into `.github/workflows/lint-skills.yml` — **do not edit the workflow yourself**) runs `scripts/catalog.sh --check` and the `tests/catalog/` bats suite, failing the build on drift.
+
+**Local enforcement.** A `catalog-sync` lifecycle hook (`hooks/scripts/catalog-sync.sh`, registered in `hooks/hooks.manifest.json`, `PreToolUse` on `git commit`) checks the catalog before a commit lands; on real drift it runs `--sync` and **re-stages** the corrected files so the commit is self-consistent. It acts only on drift and never blocks. The `skill-catalog` skill documents the whole single-source-of-truth model for humans and agents.
 
 ## Tests (`tests/catalog/`, bats, bash-3.2)
 
@@ -51,12 +61,13 @@ A new job/step (orchestrator wires it into `.github/workflows/lint-skills.yml` �
 
 ## Ownership (P1-A agent)
 
-OWNS exclusively: `scripts/catalog.sh`, `tests/catalog/`, and the asserted-count regions of `README.md`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (via `--sync`).
-MUST NOT touch: `.github/workflows/` (orchestrator wires CI), `scripts/install*.sh`, `scripts/convert.sh`, `scripts/README.md` (P1-B owns), `hooks/`, `skills/workflows/repo-deep-dive/`, or any P1-B file.
+OWNS exclusively: `scripts/catalog.sh`, `scripts/sync-catalog-skills.py`, `hooks/scripts/catalog-sync.sh` (+ its `hooks.manifest.json` entry), `skills/meta/skill-catalog/`, `tests/catalog/`, and the asserted-count regions of `README.md`, `CLAUDE.md`, `PLAN.md`, `START-HERE.md`, `.claude-plugin/plugin.json` (the count phrase **and** the `skills` array), and `.claude-plugin/marketplace.json` (via `--sync`).
+MUST NOT touch: `.github/workflows/` (orchestrator wires CI), `scripts/install*.sh`, `scripts/convert.sh`.
 
 ## DoD
 
 `catalog.sh --check` reflects true disk counts; running `--sync` then `--check` is clean and leaves README + plugin.json + marketplace.json internally consistent (the existing 46/47 drift resolved to the real disk number). `bash -n` clean. bats pass. **No git operations.**
 
 ## Changelog
+- 1.1.0 — extend count coverage to `CLAUDE.md` / `PLAN.md` / `START-HERE.md` (live phrasings only); reconcile the `plugin.json` `skills` array from disk via `scripts/sync-catalog-skills.py` (register missing, drop stale); exclude `node_modules` via `-maxdepth 3`; add the `catalog-sync` pre-commit hook (auto-fix + re-stage) and the `skill-catalog` skill. `sed_replace` treats a missing file as a no-op.
 - 1.0.0 — initial (orchestrator, P1-A).

--- a/hooks/hooks.manifest.json
+++ b/hooks/hooks.manifest.json
@@ -35,6 +35,14 @@
       "description": "On a Bash 'git commit', run lint-skills.sh if skills changed; warn only, never blocks the commit."
     },
     {
+      "id": "catalog-sync",
+      "event": "PreToolUse",
+      "script": "scripts/catalog-sync.sh",
+      "profiles": ["standard", "strict"],
+      "blocking": false,
+      "description": "On a Bash 'git commit', if the skill catalog (counts across README/CLAUDE/PLAN/START-HERE/plugin.json/marketplace.json + the plugin.json skills array) has drifted from disk, run catalog.sh --sync and re-stage the corrected files so the commit stays self-consistent; acts only on real drift, never blocks."
+    },
+    {
       "id": "skill-usage",
       "event": "PostToolUse",
       "script": "scripts/skill-usage.sh",

--- a/hooks/scripts/catalog-sync.sh
+++ b/hooks/scripts/catalog-sync.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# catalog-sync.sh — PreToolUse(Bash) hook, scoped to `git commit`.
+#
+# The filesystem is the single source of truth for the skill catalog. When a
+# commit is about to run, this checks whether the derived artifacts (skill
+# counts across README/CLAUDE/PLAN/START-HERE/plugin.json/marketplace.json, and
+# the plugin.json `skills` array) still agree with disk. If they've drifted —
+# typically because a skill directory was just added or removed — it runs
+# `scripts/catalog.sh --sync` and re-stages the corrected files so the commit
+# carries them. You never have to remember to update counts again.
+#
+# It only acts when there is REAL drift (a no-op otherwise), so ordinary commits
+# are untouched. Never blocks — worst case it does nothing.
+#
+# Exit: always 0.
+
+set -euo pipefail
+
+HOOK_SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+for cand in \
+  "$HOOK_SCRIPTS_DIR/../../scripts/lib/term.sh" \
+  "$HOOK_SCRIPTS_DIR/../lib/term.sh"; do
+  [[ -f "$cand" ]] && { . "$cand"; break; }
+done
+type ats_warn >/dev/null 2>&1 || ats_warn() { printf '[!!]  %s\n' "$*"; }
+type ats_ok   >/dev/null 2>&1 || ats_ok()   { printf '[OK]  %s\n' "$*"; }
+type ats_info >/dev/null 2>&1 || ats_info() { printf '[--]  %s\n' "$*"; }
+
+PAYLOAD="$(cat 2>/dev/null || true)"
+
+# Pull the command string out of the PreToolUse payload (tool_input.command).
+cmd=""
+if [[ -n "$PAYLOAD" ]]; then
+  cmd="$(printf '%s' "$PAYLOAD" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+ti = d.get("tool_input") or {}
+print(ti.get("command") or d.get("command") or "")
+' 2>/dev/null || true)"
+fi
+
+# Only act on a git commit invocation.
+case "$cmd" in
+  *"git commit"*) : ;;
+  *) exit 0 ;;
+esac
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+CATALOG="$PROJECT_DIR/scripts/catalog.sh"
+[[ -f "$CATALOG" ]] || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+( cd "$PROJECT_DIR" 2>/dev/null && git rev-parse --is-inside-work-tree ) >/dev/null 2>&1 || exit 0
+
+# Cheap check first — if the catalog already matches disk, do nothing.
+if ( cd "$PROJECT_DIR" && bash "$CATALOG" --check ) >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Drift detected: reconcile and re-stage the derived files so the commit is
+# self-consistent.
+( cd "$PROJECT_DIR" && bash "$CATALOG" --sync ) >/dev/null 2>&1 || {
+  ats_warn "catalog-sync: catalog drift detected but --sync failed (commit NOT blocked); run scripts/catalog.sh --sync"
+  exit 0
+}
+
+CATALOG_FILES=(
+  "README.md"
+  "CLAUDE.md"
+  "PLAN.md"
+  "START-HERE.md"
+  ".claude-plugin/plugin.json"
+  ".claude-plugin/marketplace.json"
+)
+restaged=""
+for f in "${CATALOG_FILES[@]}"; do
+  if ( cd "$PROJECT_DIR" && ! git diff --quiet -- "$f" 2>/dev/null ); then
+    ( cd "$PROJECT_DIR" && git add -- "$f" ) 2>/dev/null && restaged="$restaged $f"
+  fi
+done
+
+if [[ -n "$restaged" ]]; then
+  ats_ok "catalog-sync: reconciled skill counts + plugin listing to disk and re-staged:$restaged"
+else
+  ats_info "catalog-sync: catalog reconciled (no tracked files needed restaging)"
+fi
+exit 0

--- a/scripts/catalog.sh
+++ b/scripts/catalog.sh
@@ -2,27 +2,33 @@
 #
 # catalog.sh — Catalog-as-CI-invariant for Skill Madness.
 #
-# The filesystem is the single source of truth for the advertised skill counts.
-# This script computes the true inventory from disk and either checks the
-# hard-coded counts in README.md + plugin.json + marketplace.json against it
-# (--check), rewrites those counts to match (--sync), or prints the table
-# (--text).
+# The filesystem is the single source of truth for the skill catalog. This
+# script computes the true inventory from disk and either checks every derived
+# assertion against it (--check), rewrites them to match (--sync), or prints the
+# table (--text). It covers:
+#   - the count phrases in README.md, plugin.json, marketplace.json,
+#     CLAUDE.md, PLAN.md, and START-HERE.md (live phrasings only — historical
+#     "47 skills" notes are left alone);
+#   - the plugin.json `skills` array itself (every on-disk skill registered,
+#     no stale entries) — delegated to scripts/sync-catalog-skills.py.
 #
-# Contract: contracts/installer/catalog-invariant.md v1.0.0
+# Contract: contracts/installer/catalog-invariant.md v1.1.0
 #
 # Usage:
 #   scripts/catalog.sh [--check | --sync | --text] [--help]
 #
 # Options:
-#   --check   (default) compare asserted counts to disk; exit 1 on any mismatch.
-#   --sync    rewrite asserted counts in README/plugin.json/marketplace.json.
+#   --check   (default) compare every asserted count + the plugin listing to
+#             disk; exit 1 on any mismatch.
+#   --sync    rewrite all counts + reconcile the plugin.json skills array.
 #   --text    print total + per-category table to stdout.
 #   --help    print this and exit.
 #
-# A skill = a directory under skills/ containing a SKILL.md, EXCLUDING anything
-# under skills/archive/ and skills/in-progress/. Category = the immediate
-# subdirectory of skills/ the skill lives in (orchestrator/SKILL.md at the
-# category root counts as category 'orchestrator').
+# A skill = a directory directly under a category (skills/<cat>/<skill>/SKILL.md)
+# or the top-level orchestrator (skills/orchestrator/SKILL.md). Anything under
+# skills/archive/, skills/in-progress/, or node_modules/ — or nested deeper than
+# a skill root (a bundled node_modules SKILL.md) — is NOT a skill; the -maxdepth
+# scan and the python reconciler both enforce that.
 #
 # Exit codes: 0 ok / clean, 1 drift detected (--check), 2 argument failure.
 #
@@ -41,9 +47,16 @@ SKILLS_ROOT="$REPO_ROOT/skills"
 README="$REPO_ROOT/README.md"
 PLUGIN_JSON="$REPO_ROOT/.claude-plugin/plugin.json"
 MARKETPLACE_JSON="$REPO_ROOT/.claude-plugin/marketplace.json"
+CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
+PLAN_MD="$REPO_ROOT/PLAN.md"
+START_HERE="$REPO_ROOT/START-HERE.md"
 
-# The six known categories, fixed order for stable output.
-CATEGORIES="orchestrator roles contracts meta git workflows"
+# Companion that reconciles the plugin.json `skills` array with disk (registers
+# new skills, drops stale entries). Delegated to from --check / --sync.
+SKILLS_SYNC="$SCRIPT_DIR/sync-catalog-skills.py"
+
+# The six known categories, fixed order for stable output (matches plugin.json).
+CATEGORIES="orchestrator roles contracts git meta workflows"
 
 # ---------------------------------------------------------------------------
 # Disk inventory
@@ -65,7 +78,7 @@ category_of() {
 # count_total <skills_root>  — total active skills.
 count_total() {
   local root="$1"
-  find "$root" -name SKILL.md -type f 2>/dev/null \
+  find "$root" -maxdepth 3 -name SKILL.md -type f 2>/dev/null \
     | grep -v "$root/archive/" \
     | grep -v "$root/in-progress/" \
     | wc -l \
@@ -79,7 +92,7 @@ count_category() {
     [[ -z "$f" ]] && continue
     c="$(category_of "$f")"
     [[ "$c" == "$cat" ]] && n=$(( n + 1 ))
-  done < <(find "$root" -name SKILL.md -type f 2>/dev/null \
+  done < <(find "$root" -maxdepth 3 -name SKILL.md -type f 2>/dev/null \
              | grep -v "$root/archive/" \
              | grep -v "$root/in-progress/")
   echo "$n"
@@ -116,8 +129,11 @@ cmd_text() {
 # ---------------------------------------------------------------------------
 
 # sed_replace <file> <sed-expr...> — apply one or more -e exprs portably.
+# A missing target is a no-op: not every repo (or test fixture) carries every
+# asserted-count file, and a count that isn't present simply can't drift.
 sed_replace() {
   local file="$1"; shift
+  [[ -f "$file" ]] || return 0
   local tmp
   tmp="$(mktemp "${TMPDIR:-/tmp}/ats-catalog.XXXXXX")"
   sed "$@" "$file" > "$tmp"
@@ -247,6 +263,29 @@ for_each_assertion() {
     'Install all [0-9]+ Skill-Madness skills' "$total" \
     's/.*Install all ([0-9]+) Skill-Madness skills.*/\1/' \
     "s/(Install all )[0-9]+( Skill-Madness skills)/\1${total}\2/g"
+
+  # --- CLAUDE.md / PLAN.md / START-HERE.md live total counts -----------------
+  # Only the LIVE current-count phrasings are targeted. Historical mentions
+  # ("47 skills across 6 categories", "validating all 47 skills clean",
+  # "across 49 skills") use different wording and are deliberately left alone.
+
+  # CLAUDE.md "What This Is": "— N OSS-publishable skills in `skills/`".
+  "$cb" "$CLAUDE_MD" "CLAUDE.md (N OSS-publishable skills)" \
+    '[0-9]+ OSS-publishable skills' "$total" \
+    's/.*[^0-9]([0-9]+) OSS-publishable skills.*/\1/' \
+    "s/[0-9]+( OSS-publishable skills)/${total}\1/g"
+
+  # PLAN.md "Where we are": "a mature **N-skill** library".
+  "$cb" "$PLAN_MD" "PLAN.md (N-skill library)" \
+    '\*\*[0-9]+-skill\*\* library' "$total" \
+    's/.*\*\*([0-9]+)-skill\*\* library.*/\1/' \
+    "s/(\*\*)[0-9]+(-skill\*\* library)/\1${total}\2/g"
+
+  # START-HERE.md "Status at a glance": "A mature library of **N skills**".
+  "$cb" "$START_HERE" "START-HERE.md (library of N skills)" \
+    'library of \*\*[0-9]+ skills\*\*' "$total" \
+    's/.*library of \*\*([0-9]+) skills\*\*.*/\1/' \
+    "s/(library of \*\*)[0-9]+( skills\*\*)/\1${total}\2/g"
 }
 
 # ---------------------------------------------------------------------------
@@ -261,7 +300,7 @@ cmd_check() {
   MISMATCHES=()
   for_each_assertion _check_cb
 
-  local total
+  local total rc=0
   total="$(count_total "$SKILLS_ROOT")"
 
   if (( ${#MISMATCHES[@]} > 0 )); then
@@ -270,10 +309,20 @@ cmd_check() {
     for m in "${MISMATCHES[@]}"; do
       ats_warn "$m"
     done
+    rc=1
+  fi
+
+  # plugin.json `skills` array registration — delegated to the reconciler, which
+  # prints its own drift lines. Missing python3 degrades to count-only checking.
+  if [[ -f "$SKILLS_SYNC" ]] && command -v python3 >/dev/null 2>&1; then
+    python3 "$SKILLS_SYNC" --check || rc=1
+  fi
+
+  if (( rc != 0 )); then
     ats_info "run 'scripts/catalog.sh --sync' to reconcile"
     return 1
   fi
-  ats_ok "catalog clean: all asserted counts match disk (total = $total)"
+  ats_ok "catalog clean: counts + plugin.json listing all match disk (total = $total)"
   return 0
 }
 
@@ -288,9 +337,13 @@ _sync_cb() {
 
 cmd_sync() {
   for_each_assertion _sync_cb
+  # Reconcile the plugin.json `skills` array (register new, drop stale).
+  if [[ -f "$SKILLS_SYNC" ]] && command -v python3 >/dev/null 2>&1; then
+    python3 "$SKILLS_SYNC" --sync
+  fi
   local total
   total="$(count_total "$SKILLS_ROOT")"
-  ats_ok "synced asserted counts to disk (total = $total)"
+  ats_ok "synced counts + plugin.json listing to disk (total = $total)"
   return 0
 }
 

--- a/scripts/sync-catalog-skills.py
+++ b/scripts/sync-catalog-skills.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""sync-catalog-skills.py — reconcile plugin.json's `skills` array with disk.
+
+The filesystem is the single source of truth for which skills exist. This
+script keeps the published manifest (`.claude-plugin/plugin.json` `skills`
+array) in agreement with it:
+
+  --check   exit 1 if any on-disk skill is missing from the array, or any
+            array entry points at a skill that no longer exists. Prints the
+            drift. (CI / pre-commit use this.)
+  --sync    rewrite the array to match disk: register missing skills, drop
+            stale entries, keep existing order, group by category. (Idempotent.)
+
+A skill is a directory directly under a category (skills/<category>/<skill>/
+SKILL.md) or the top-level orchestrator (skills/orchestrator/SKILL.md).
+Anything under archive/, in-progress/, or node_modules/ — or nested deeper
+than that (e.g. a bundled node_modules SKILL.md) — is NOT a skill.
+
+Reconciliation preserves the existing curated order: entries already in the
+array stay where they are; newly-discovered skills are appended to the end of
+their category's group (sorted); entries whose directory is gone are removed.
+So adding a skill directory + running --sync produces a one-line diff.
+
+Exit codes: 0 clean / synced, 1 drift (--check), 2 usage / parse error.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SKILLS = REPO / "skills"
+PLUGIN_JSON = REPO / ".claude-plugin" / "plugin.json"
+
+# Fixed category order — matches the manifest's existing grouping so a clean
+# repo round-trips with a zero-line diff.
+CATEGORIES = ["orchestrator", "roles", "contracts", "git", "meta", "workflows"]
+EXCLUDED = {"archive", "in-progress", "node_modules"}
+
+
+def discover_by_category():
+    """Return {category: [./skills/<...> , ...]} of real skills found on disk."""
+    by_cat = {c: [] for c in CATEGORIES}
+    if not SKILLS.is_dir():
+        return by_cat
+    for skill_md in SKILLS.rglob("SKILL.md"):
+        parts = skill_md.relative_to(SKILLS).parts  # (...,'SKILL.md')
+        if any(p in EXCLUDED for p in parts):
+            continue
+        if len(parts) == 2:          # skills/<cat>/SKILL.md  (orchestrator)
+            cat, rel = parts[0], parts[0]
+        elif len(parts) == 3:        # skills/<cat>/<skill>/SKILL.md
+            cat, rel = parts[0], f"{parts[0]}/{parts[1]}"
+        else:                        # deeper than a skill root => not a skill
+            continue
+        if cat in by_cat:
+            by_cat[cat].append(f"./skills/{rel}")
+    return by_cat
+
+
+def load_existing():
+    """Return (full_text, list_of_entries) from plugin.json."""
+    text = PLUGIN_JSON.read_text()
+    data = json.loads(text)
+    return text, list(data.get("skills", []))
+
+
+def category_of(entry):
+    """'./skills/<cat>/<skill>' -> '<cat>'; './skills/orchestrator' -> 'orchestrator'."""
+    segs = entry.strip("./").split("/")  # ['skills','<cat>', ...]
+    return segs[1] if len(segs) > 1 else None
+
+
+def reconcile(existing, by_cat_disk):
+    """Preserve existing order; append new (sorted) per category; drop stale.
+
+    Returns {category: [entries]} ready to emit, grouped in CATEGORIES order.
+    """
+    disk_all = {e for entries in by_cat_disk.values() for e in entries}
+    out = {c: [] for c in CATEGORIES}
+    seen = set()
+    # 1. keep existing entries that still exist on disk, in their current order
+    for e in existing:
+        key = e.rstrip("/")
+        if key in disk_all and key not in seen:
+            cat = category_of(key)
+            if cat in out:
+                out[cat].append(key)
+                seen.add(key)
+    # 2. append skills present on disk but not yet listed, sorted, to their group
+    for cat in CATEGORIES:
+        for e in sorted(by_cat_disk.get(cat, [])):
+            if e not in seen:
+                out[cat].append(e)
+                seen.add(e)
+    return out
+
+
+def emit_array(out_by_cat):
+    """Render the JSON `skills` array text, category groups separated by a blank
+    line, 4-space indented entries, to match the manifest's house style."""
+    groups = []
+    for cat in CATEGORIES:
+        entries = out_by_cat.get(cat, [])
+        if entries:
+            groups.append(",\n".join(f'    "{e}"' for e in entries))
+    return "[\n" + ",\n\n".join(groups) + "\n  ]"
+
+
+def write_array(text, array_text):
+    """Replace the `skills` array block in plugin.json text, preserving the rest.
+
+    The array contains only string entries (no nested brackets), so a non-greedy
+    match from `"skills": [` to the first `]` is exact.
+    """
+    new_text, n = re.subn(
+        r'"skills"\s*:\s*\[.*?\]',
+        '"skills": ' + array_text,
+        text,
+        count=1,
+        flags=re.DOTALL,
+    )
+    if n != 1:
+        raise SystemExit("could not locate the `skills` array in plugin.json")
+    return new_text
+
+
+def main(argv):
+    mode = argv[1] if len(argv) > 1 else "--check"
+    if mode not in ("--check", "--sync"):
+        print("usage: sync-catalog-skills.py [--check | --sync]", file=sys.stderr)
+        return 2
+
+    by_cat = discover_by_category()
+    disk_set = {e for entries in by_cat.values() for e in entries}
+    text, existing = load_existing()
+    existing_set = {e.rstrip("/") for e in existing}
+
+    missing = sorted(disk_set - existing_set)   # on disk, not registered
+    stale = sorted(existing_set - disk_set)      # registered, gone from disk
+
+    if mode == "--check":
+        if missing or stale:
+            print("[ERR] plugin.json skills array out of sync with disk:")
+            for m in missing:
+                print(f"  [!!]  not registered (add): {m}")
+            for s in stale:
+                print(f"  [!!]  stale entry (remove):  {s}")
+            print("  [--]  run 'scripts/catalog.sh --sync' to reconcile")
+            return 1
+        print(f"[OK]  plugin.json skills array matches disk ({len(disk_set)} skills)")
+        return 0
+
+    # --sync
+    reconciled = reconcile(existing, by_cat)
+    new_text = write_array(text, emit_array(reconciled))
+    if new_text != text:
+        PLUGIN_JSON.write_text(new_text)
+        added = ", ".join(missing) if missing else "none"
+        removed = ", ".join(stale) if stale else "none"
+        print(f"[OK]  synced plugin.json skills array (added: {added}; removed: {removed})")
+    else:
+        print(f"[OK]  plugin.json skills array already in sync ({len(disk_set)} skills)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/skills/meta/skill-catalog/SKILL.md
+++ b/skills/meta/skill-catalog/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: skill-catalog
+version: 1.0.0
+description: |
+  Keep the Skill-Madness catalog in sync with the filesystem. The published
+  plugin.json `skills` array and every advertised skill count (README, CLAUDE.md,
+  PLAN.md, START-HERE.md, marketplace.json) are DERIVED from disk by one command,
+  so they never drift. Use this whenever you add, remove, or rename a skill,
+  register a skill in plugin.json, notice mismatched skill counts ("47 vs 49"),
+  hit a CI "catalog drift" failure, ask "how many skills are there", or need
+  skills symlinked into ~/.claude for global use. The filesystem is the single
+  source of truth: run `scripts/catalog.sh --sync` (a pre-commit hook also
+  auto-fixes drift on commit), then `sync-skills` for the global symlinks. Never
+  hand-edit the counts or the plugin.json array — let the tooling regenerate them.
+compatibility: Claude Code
+metadata:
+  author: hive-ecosystem
+  category: meta
+  tags: [catalog, plugin-manifest, skill-counts, single-source-of-truth, sync, ci-invariant]
+requires_claude_code: true
+requires_agent_teams: false
+min_plan: starter
+allowed-tools: ["Read", "Bash", "Edit", "Glob", "Grep"]
+owns:
+  directories: []
+  patterns: []
+  shared_read: ["*"]
+composes_with: ["sync-skills", "skill-writer", "skill-update", "skill-review"]
+---
+
+# Skill Catalog
+
+> **One rule:** the filesystem under `skills/` is the single source of truth for
+> what skills exist and how many there are. Everything else — the `plugin.json`
+> manifest, the README badge, the counts in `CLAUDE.md` / `PLAN.md` /
+> `START-HERE.md` / `marketplace.json` — is *derived* from it. You never edit
+> those by hand; you run one command and they regenerate.
+
+This skill exists because the alternative — hand-maintaining a skill count in
+six files plus a manifest array — drifts every single time. A skill gets added,
+the array isn't updated, three of the six counts get bumped and three don't, and
+now the repo disagrees with itself. The fix is to stop treating those numbers as
+facts to maintain and start treating them as *outputs* to generate.
+
+## The one command
+
+```bash
+scripts/catalog.sh --sync     # make every derived count + the plugin array match disk
+scripts/catalog.sh --check    # verify they match (exit 1 + a drift report if not); CI runs this
+scripts/catalog.sh --text     # print the per-category table (disk truth)
+```
+
+`--sync` is **idempotent** — run it as often as you like; if nothing drifted it
+changes nothing. It is safe to run any time.
+
+## What it keeps in sync
+
+| Artifact | What's reconciled |
+|---|---|
+| `.claude-plugin/plugin.json` `skills` array | every on-disk skill is registered; stale entries (deleted skills) are removed; your curated order is preserved and new skills are appended to their category group |
+| `.claude-plugin/plugin.json` description | the "with N skills" count |
+| `README.md` | badge, all prose counts, the per-category mermaid labels |
+| `CLAUDE.md` | the "N OSS-publishable skills" line |
+| `PLAN.md` | the "**N-skill** library" line |
+| `START-HERE.md` | the "library of **N skills**" line |
+| `.claude-plugin/marketplace.json` | the two "N-skill" / "all N" phrases |
+
+Only the **live** count phrasings are touched. Historical notes — `PLAN.md`'s
+"catalog reshaped to 47 skills", "across 49 skills", etc. — use different wording
+on purpose and are left exactly as written. They're a record of what was true
+then, not an assertion about now.
+
+## What counts as a skill
+
+A directory directly under a category (`skills/<category>/<skill>/SKILL.md`) or
+the top-level `skills/orchestrator/SKILL.md`. **Not** a skill: anything under
+`archive/`, `in-progress/`, or `node_modules/` — including the `SKILL.md`
+scaffolds that some bundled npm packages (e.g. `playwright-core`) ship deep
+inside a skill's `scripts/node_modules/`. The scan is depth-bounded so those
+never inflate the count. (This is why the count used to read "52" locally after
+an `npm install` but "50" in CI — that bug is gone.)
+
+## You usually don't run it at all
+
+A `catalog-sync` pre-commit hook (`hooks/scripts/catalog-sync.sh`, registered in
+`hooks/hooks.manifest.json`) intercepts `git commit`. If — and only if — the
+catalog has drifted from disk, it runs `--sync` and **re-stages** the corrected
+files so the commit is self-consistent. On an in-sync repo it does nothing. So
+in practice: add your skill directory, commit, and the counts + manifest are
+already correct in that commit. The drift can't land.
+
+CI is the backstop: the "Installer + Catalog" job runs `catalog.sh --check`, so
+even a commit made outside Claude Code (a terminal commit with the hook profile
+off) is caught before merge.
+
+## Workflows
+
+### Add a skill
+
+1. Create `skills/<category>/<new-skill>/SKILL.md` (use the `skill-writer` skill
+   to scaffold it correctly).
+2. Commit. The hook reconciles the manifest + counts into your commit. (Or run
+   `scripts/catalog.sh --sync` first if you want to see the changes before
+   committing.)
+3. Run `sync-skills` to symlink it into `~/.claude/skills/` so it's available
+   globally — see "Global availability" below.
+
+### Remove or rename a skill
+
+Delete or rename the directory, then commit (or `--sync`). The reconciler drops
+the stale `plugin.json` entry and registers the new path; the counts fall or hold
+automatically. A rename is just a remove + add.
+
+### "The counts are wrong" / a CI catalog failure
+
+Run `scripts/catalog.sh --check` to see exactly which files disagree and by how
+much, then `scripts/catalog.sh --sync` to fix all of them at once, and commit.
+Don't open the files and edit numbers — that's how the drift started.
+
+## Global availability (symlinks) — `sync-skills`
+
+Catalog sync is about the *repo's* internal consistency. Making the skills
+actually loadable by Claude Code / Cursor is a separate axis: symlinking the
+skill directories into `~/.claude/skills/` (and `~/.cursor/skills-cursor/`). That
+is the `sync-skills` skill's job. The two compose into one "I added a skill"
+story:
+
+```bash
+scripts/catalog.sh --sync     # repo agrees with itself (counts + manifest)
+# … then, via the sync-skills skill:
+/sync-skills                  # the skill is linked into the global dirs
+```
+
+Run catalog sync first (so the manifest is right), then `sync-skills` (so the
+filesystem links are right). `sync-skills` also has a `--status` mode to answer
+"are my skills linked?" the same way `catalog.sh --check` answers "are my counts
+right?".
+
+## Anti-patterns
+
+- **Hand-editing a skill count anywhere.** The moment you type a number into
+  `CLAUDE.md` or `plugin.json`, you've created a second source of truth that will
+  drift. Run `--sync` instead.
+- **Hand-adding a `plugin.json` `skills` entry.** Same problem, and easy to
+  forget (that's the bug where a freshly-added skill silently never publishes).
+  The reconciler registers it from disk.
+- **Committing with `--no-verify` or the hook profile off, then wondering why
+  CI fails on "catalog drift."** The check is there to catch exactly that. Run
+  `--sync` and recommit.
+- **Bumping the total but not the per-category breakdown** (the curated
+  `skills/workflows/ (N) — name, name, …` list in `CLAUDE.md`). The *counts*
+  sync automatically; that one enumerated prose list is still curated by hand —
+  update it when you add a workflow skill, or the number and the names will
+  disagree.
+
+## Reference
+
+- `scripts/catalog.sh` — the count + invariant engine (bash; the CI gate).
+- `scripts/sync-catalog-skills.py` — the `plugin.json` `skills` array reconciler.
+- `hooks/scripts/catalog-sync.sh` — the auto-fix-on-commit hook.
+- `contracts/installer/catalog-invariant.md` — the catalog-as-CI-invariant contract.

--- a/tests/catalog/07-catalog-invariant.bats
+++ b/tests/catalog/07-catalog-invariant.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 # 07-catalog-invariant.bats — Validate scripts/catalog.sh.
 #
-# Contract: contracts/installer/catalog-invariant.md v1.0.0
+# Contract: contracts/installer/catalog-invariant.md v1.1.0
 #
 # Builds a self-contained fake repo in a temp dir (scripts/catalog.sh + libs,
 # a skills/ tree, README.md, plugin.json, marketplace.json) so the count
@@ -199,4 +199,88 @@ EOF
   run env NO_COLOR=1 bash "$FCATALOG" --sync
   [ "$status" -eq 0 ]
   grep -qF '| 47 | `railway-deploy`' "$FAKE/README.md"
+}
+
+# ---------------------------------------------------------------------------
+# node_modules SKILL.md scaffolds (bundled npm deps) must NOT be counted.
+# ---------------------------------------------------------------------------
+@test "catalog ignores node_modules SKILL.md scaffolds" {
+  mkdir -p "$FAKE/skills/workflows/plan-builder/scripts/node_modules/dep/inner"
+  printf -- '---\nname: dep\n---\n' \
+    > "$FAKE/skills/workflows/plan-builder/scripts/node_modules/dep/inner/SKILL.md"
+  run env NO_COLOR=1 bash "$FCATALOG" --text
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qE 'TOTAL[[:space:]]+5'        # still 5, not 6
+  ! echo "$output" | grep -qE 'TOTAL[[:space:]]+6'
+}
+
+# ---------------------------------------------------------------------------
+# CLAUDE.md / PLAN.md / START-HERE.md live counts are checked + synced; a
+# missing file is a no-op (not every fixture carries them).
+# ---------------------------------------------------------------------------
+@test "catalog checks + syncs CLAUDE.md / PLAN.md / START-HERE.md live counts" {
+  printf -- '— 6 OSS-publishable skills in `skills/`.\n'        > "$FAKE/CLAUDE.md"
+  printf -- 'a mature **6-skill** library — stuff.\n'           > "$FAKE/PLAN.md"
+  printf -- 'A mature library of **6 skills** (contracts).\n'   > "$FAKE/START-HERE.md"
+
+  run env NO_COLOR=1 bash "$FCATALOG" --check
+  [ "$status" -eq 1 ]
+
+  run env NO_COLOR=1 bash "$FCATALOG" --sync
+  [ "$status" -eq 0 ]
+  grep -q '5 OSS-publishable skills'   "$FAKE/CLAUDE.md"
+  grep -q '\*\*5-skill\*\* library'    "$FAKE/PLAN.md"
+  grep -q 'library of \*\*5 skills\*\*' "$FAKE/START-HERE.md"
+
+  run env NO_COLOR=1 bash "$FCATALOG" --check
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Historical count phrasings ("reshaped to 47 skills", "across 49 skills") must
+# survive --sync untouched — only the live phrasing is reconciled.
+# ---------------------------------------------------------------------------
+@test "catalog --sync leaves historical count notes untouched" {
+  printf -- '— 6 OSS-publishable skills now.\nHistory: reshaped to 47 skills; across 49 skills.\n' \
+    > "$FAKE/CLAUDE.md"
+  run env NO_COLOR=1 bash "$FCATALOG" --sync
+  [ "$status" -eq 0 ]
+  grep -q '5 OSS-publishable skills' "$FAKE/CLAUDE.md"   # live count reconciled
+  grep -q 'reshaped to 47 skills'    "$FAKE/CLAUDE.md"   # history preserved
+  grep -q 'across 49 skills'         "$FAKE/CLAUDE.md"
+}
+
+# ---------------------------------------------------------------------------
+# plugin.json `skills` array is reconciled with disk (register missing, drop
+# stale). Requires python3 + the reconciler copied into the fixture.
+# ---------------------------------------------------------------------------
+@test "catalog registers on-disk skills missing from the plugin.json array" {
+  command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+  cp "$REPO_ROOT/scripts/sync-catalog-skills.py" "$FAKE/scripts/sync-catalog-skills.py"
+  # Fixture plugin.json registers only orchestrator; disk has 5 skills.
+  run env NO_COLOR=1 bash "$FCATALOG" --check
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -qi "not registered"
+
+  run env NO_COLOR=1 bash "$FCATALOG" --sync
+  [ "$status" -eq 0 ]
+  grep -q 'backend-agent'  "$FAKE/.claude-plugin/plugin.json"
+  grep -q 'mermaid-charts' "$FAKE/.claude-plugin/plugin.json"
+
+  run env NO_COLOR=1 bash "$FCATALOG" --check
+  [ "$status" -eq 0 ]
+}
+
+@test "catalog drops a stale plugin.json array entry" {
+  command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+  cp "$REPO_ROOT/scripts/sync-catalog-skills.py" "$FAKE/scripts/sync-catalog-skills.py"
+  printf '{\n  "description": "x with 5 skills",\n  "skills": ["./skills/orchestrator", "./skills/workflows/ghost"]\n}\n' \
+    > "$FAKE/.claude-plugin/plugin.json"
+  run env NO_COLOR=1 bash "$FCATALOG" --check
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -qi "stale entry"
+
+  run env NO_COLOR=1 bash "$FCATALOG" --sync
+  [ "$status" -eq 0 ]
+  ! grep -q 'ghost' "$FAKE/.claude-plugin/plugin.json"
 }


### PR DESCRIPTION
## Summary

This kills the recurring **skill-count drift** for good. The count was bouncing 47→49→50→51 across `plugin.json`, `README.md`, `CLAUDE.md`, `marketplace.json`, `PLAN.md`, and `START-HERE.md` and getting hand-reconciled every time, because the filesystem was only *partly* the source of truth. Four gaps, all closed:

| Gap | Before | After |
|---|---|---|
| plugin.json **`skills` array** | hand-maintained; a new skill silently never registered | reconciled from disk (`sync-catalog-skills.py`) — register new, drop stale, keep curated order |
| **CLAUDE.md / PLAN.md / START-HERE.md** counts | not covered → drifted independently | covered by `catalog.sh` (live phrasings only) |
| **node_modules** SKILL.md scaffolds | inflated the count (52 vs 50 locally) | excluded via `-maxdepth 3` |
| **Enforcement** | CI-only | `catalog-sync` pre-commit hook auto-fixes + re-stages on commit |

## Changes

- **`scripts/catalog.sh`** — depth-bounded scan; new live-count assertions for CLAUDE.md/PLAN.md/START-HERE.md (carefully targets only current phrasings — the historical "47 skills" / "across 49 skills" notes are left untouched); delegates the array to the reconciler; missing file = no-op.
- **`scripts/sync-catalog-skills.py`** (new) — the `plugin.json` `skills`-array reconciler (`--check` / `--sync`), order-preserving and idempotent.
- **`hooks/scripts/catalog-sync.sh`** (new) + manifest entry — `PreToolUse(git commit)`: on **real** drift only, runs `--sync` and re-stages the corrected files. Never blocks. (Auto-fix & re-stage, per the chosen behavior.)
- **`skills/meta/skill-catalog/`** (new) — the discoverable skill: documents the single-source-of-truth model and folds in the `sync-skills` symlink workflow ("counted right *and* linked").
- **`tests/catalog/`** — +5 bats (now 13): node_modules immunity, the 3 new files, historical-note safety, array register + drop.
- **Contract** `catalog-invariant.md` → **v1.1.0** (the array was explicitly out of scope in v1.0.0 — "verified separately by existing tooling"; nothing did, which is the drift this closes).
- The catalog **self-reconciled to 51** — adding `skill-catalog` registered itself + bumped every count.

## Test plan

- [x] `catalog.sh --check` clean; drift across all 6 files + the array is detected, `--sync` fixes it, idempotent.
- [x] Historical "47/49 skills" notes survive `--sync` untouched (test 11).
- [x] `node_modules` SKILL.md scaffolds don't count (test 9).
- [x] `lint-skills`, `lint-hooks`, all **13 bats** pass; `bash -n` + `py_compile` clean.
- [ ] CI: Lint Skills / PSFS, **Installer + Catalog** (runs `--check` + the bats suite), Skill Scan.

## Notes

- One deliberate non-goal: the **per-category enumerated name lists** in CLAUDE.md (`workflows/ (N) — name, name, …`) stay human-curated. The *total* + the plugin array auto-sync; that one prose breakdown is documented in `skill-catalog` as hand-maintained (a clean follow-up if you want it generated too).
- Built in an isolated worktree off `main`, so it does not touch the `design-token-guard` WIP on the other branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)