### PR TITLE
feat: Add design-token-guard and use-freellmapi skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/ivy00johns"
   },
   "metadata": {
-    "description": "All the skills, all the agents, all the chaos — a contract-first multi-agent orchestrator and the 51-skill library it draws from.",
+    "description": "All the skills, all the agents, all the chaos — a contract-first multi-agent orchestrator and the 53-skill library it draws from.",
     "version": "0.1.0",
     "homepage": "https://github.com/ivy00johns/Skill-Madness",
     "license": "MIT"
@@ -15,7 +15,7 @@
     {
       "name": "skill-madness",
       "source": "./",
-      "description": "Install all 51 Skill-Madness skills: the 14-phase orchestrator, 9 role agents with exclusive file ownership, 3 contract skills (OpenAPI/AsyncAPI/Pydantic/TS/JSON Schema), 5 git workflow skills, 9 meta/skill-management skills, 13 cross-cutting workflows (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …), and the interactive-doc workflow.",
+      "description": "Install all 53 Skill-Madness skills: the 14-phase orchestrator, 9 role agents with exclusive file ownership, 3 contract skills (OpenAPI/AsyncAPI/Pydantic/TS/JSON Schema), 5 git workflow skills, 9 meta/skill-management skills, 13 cross-cutting workflows (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …), and the interactive-doc workflow.",
       "version": "0.1.0",
       "author": {
         "name": "ivy00johns"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-madness",
-  "description": "Contract-first multi-agent orchestrator with 51 skills: a 14-phase orchestrator that authors machine-readable contracts before code, dispatches 10 role agents in parallel with exclusive file ownership, and blocks the merge on a structured QA report. Plus meta-skills, git conventions, and cross-cutting workflow tools (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …).",
+  "description": "Contract-first multi-agent orchestrator with 53 skills: a 14-phase orchestrator that authors machine-readable contracts before code, dispatches 10 role agents in parallel with exclusive file ownership, and blocks the merge on a structured QA report. Plus meta-skills, git conventions, and cross-cutting workflow tools (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …).",
   "version": "0.1.0",
   "author": {
     "name": "ivy00johns",
@@ -76,6 +76,8 @@
     "./skills/workflows/zoom-out",
     "./skills/workflows/setup-project-skills",
     "./skills/workflows/work-item-brief",
-    "./skills/workflows/website-walkthrough-video"
+    "./skills/workflows/website-walkthrough-video",
+    "./skills/workflows/design-token-guard",
+    "./skills/workflows/use-freellmapi"
   ]
 }

--- a/.scan-skills-ignore
+++ b/.scan-skills-ignore
@@ -1,0 +1,11 @@
+# scan-skills false-positive suppressions — "path:rule", path relative to repo root.
+# Only for KNOWN-safe documentation examples, never to hide a real secret.
+#
+# use-freellmapi: its curl smoke tests and per-framework recipes show where a key
+# goes using the placeholder unified key `freellmapi-xxxx` and idiomatic env-var
+# reads like `apiKey: process.env.OPENAI_API_KEY`. The secret-generic heuristic
+# can't distinguish a placeholder / env-var reference from a real literal, so the
+# suppression is scoped to these two docs-only files. The skill ships no real
+# credentials (verified: every "key" is a placeholder or an env lookup).
+skills/workflows/use-freellmapi/SKILL.md:secret-generic
+skills/workflows/use-freellmapi/references/recipes.md:secret-generic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A multi-agent orchestration toolkit for Claude Code — 51 OSS-publishable skills in `skills/`. Skills are symlinked to `~/.claude/skills/` for global availability.
+A multi-agent orchestration toolkit for Claude Code — 53 OSS-publishable skills in `skills/`. Skills are symlinked to `~/.claude/skills/` for global availability.
 
 The toolkit targets Claude Code as the primary host but the SKILL.md format is platform-agnostic — Claude.ai, Copilot CLI, Codex, and Gemini CLI all consume it. Skills should describe work in terms of capabilities ("read the file", "run the command") rather than Claude-Code-specific tool names where reasonable, so the same skill body works across hosts.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -12,7 +12,7 @@
 
 ## Where we are
 
-Skill-Madness is a mature **51-skill** library — a contract-first multi-agent orchestrator (14 phases), 10 role agents with exclusive file ownership, contract/meta/git/workflow skills — with a runtime + install layer on top. Two large efforts and two audits have landed; the latest audit's P0+P1 remediation has now merged, with a P2 fidelity backlog filed:
+Skill-Madness is a mature **53-skill** library — a contract-first multi-agent orchestrator (14 phases), 10 role agents with exclusive file ownership, contract/meta/git/workflow skills — with a runtime + install layer on top. Two large efforts and two audits have landed; the latest audit's P0+P1 remediation has now merged, with a P2 fidelity backlog filed:
 
 1. **Skill curation** (from `DeepResearch/skills-comparative_deepdive/PLAN-skill-creator.md`): authored 8 new skills, migrated 6, merged 3 pairs into 3 unified skills, and applied 8 categories of bulk in-place edits. Fully executed.
 2. **Ecosystem audit — surface pass** (`audit/MASTER_AUDIT_PLAN.md`, 7-dimension rubric, avg 4.49/5): all critical findings closed — 5 broken `composes_with` cross-references fixed, 7 oversized descriptions trimmed under the 1024-char ceiling, 2 missing frontmatter blocks restored. This was the *style / compliance / cross-ref* layer; its per-skill reports now live in `audit/reports-v1-sufrace/`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://github.com/ivy00johns/Skill-Madness/actions/workflows/lint-skills.yml"><img src="https://github.com/ivy00johns/Skill-Madness/actions/workflows/lint-skills.yml/badge.svg" alt="Skill Lint" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
-  <img src="https://img.shields.io/badge/skills-51-success.svg" alt="51 skills" />
+  <img src="https://img.shields.io/badge/skills-53-success.svg" alt="53 skills" />
   <img src="https://img.shields.io/badge/role%20agents-10-blueviolet.svg" alt="10 role agents" />
   <img src="https://img.shields.io/badge/orchestrator-14%20phases-success.svg" alt="14-phase orchestrator" />
   <img src="https://img.shields.io/badge/hosts-11-orange.svg" alt="11 hosts" />
@@ -42,13 +42,13 @@ Every AI coding tool ships the same trap: one agent, one context window, one set
 - 📜 **Contract-first** — `contract-author` writes OpenAPI / AsyncAPI / Pydantic / TypeScript / JSON Schema *before* a line of implementation. `contract-auditor` verifies every shipped module against the spec. Agents can't drift; the contract is the truth.
 - 🤖 **Ten role agents, exclusive ownership** — backend, frontend, infrastructure, QE, security, docs, observability, db-migration, performance, code-review. Each declares `owns.directories` / `owns.files` in its frontmatter. No two agents touch the same path. Conflicts get resolved before spawn, not after.
 - 🛡️ **QA gate that blocks** — `qe-agent` emits a `qa-report.json` with critical / high / medium / low findings plus contract-conformance and security scores. The orchestrator gates the merge on the report. Agents can't self-declare "done."
-- 🪜 **Progressive disclosure** — frontmatter (~100 tokens) always loaded, body loaded on trigger, references loaded on demand. A 51-skill library stays cheap to host.
+- 🪜 **Progressive disclosure** — frontmatter (~100 tokens) always loaded, body loaded on trigger, references loaded on demand. A 53-skill library stays cheap to host.
 - 🔁 **Two-runtime degradation** — Agent Teams (parallel tmux) → subagents (Task tool) → sequential. The orchestrator picks the highest mode the host supports; role skills work standalone in any of them.
-- 🧰 **51 skills, six categories, all CI-linted** — orchestrator, roles, contracts, meta-skills (skill-writer, skill-explorer, skill-review, skill-update), git workflow conventions, and 26 cross-cutting workflow skills (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, diagnose-loop, grill-me, …). Frontmatter, body length, and cross-skill ownership all gated on every push.
+- 🧰 **53 skills, six categories, all CI-linted** — orchestrator, roles, contracts, meta-skills (skill-writer, skill-explorer, skill-review, skill-update), git workflow conventions, and 26 cross-cutting workflow skills (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, diagnose-loop, grill-me, …). Frontmatter, body length, and cross-skill ownership all gated on every push.
 - 🌐 **Portable across eleven hosts** — `SKILL.md` is the canonical source; converters emit Claude Code, Copilot, Cursor, Aider, Windsurf, OpenCode, Qwen, OpenClaw, Gemini CLI, Antigravity, and Kimi formats. The orchestrator's parallel-dispatch metadata is Claude-Code-specific, but everything else (role definitions, contracts, workflows, git conventions, meta-skills) ports cleanly. See [Also works on ten other hosts](#-also-works-on-ten-other-hosts).
 
 > **Status — read before you pitch this to anyone:**
-> - **The orchestrator + 51-skill library is the mature part.** All bodies under 500 lines, zero ownership conflicts, zero broken cross-references, full Ubuntu + macOS lint matrix on every push.
+> - **The orchestrator + 53-skill library is the mature part.** All bodies under 500 lines, zero ownership conflicts, zero broken cross-references, full Ubuntu + macOS lint matrix on every push.
 > - **Claude Code is the end-to-end-verified host.** Multi-agent dispatch with file-ownership exclusivity and the `qa-report.json` gate runs live on Claude Code today. The other ten hosts receive skill *content* but don't run the orchestrator's parallel dispatch.
 > - **Lossy conversion is announced.** When a skill is converted to a non-Claude-Code host, orchestration-only fields (`allowed_tools`, `owns`, `composes_with`, `spawned_by`, `requires_agent_teams`) are stripped with a stderr line per skill. Skills marked `requires_claude_code: true` are skipped entirely for those targets. See `contracts/installer/per-tool-output-spec.md`.
 
@@ -79,7 +79,7 @@ From inside Claude Code:
 /plugin install skill-madness@skill-madness
 ```
 
-That installs all 51 skills into Claude Code's plugin storage. No clone, no symlink, no edits-to-the-repo workflow. Use this if you just want the skills.
+That installs all 53 skills into Claude Code's plugin storage. No clone, no symlink, no edits-to-the-repo workflow. Use this if you just want the skills.
 
 To update later: `/plugin update skill-madness`.
 
@@ -176,7 +176,7 @@ flowchart TB
         gpmc[git-post-merge-cleanup]
     end
 
-    subgraph workflows["⚙️ workflows/ — 29 skills"]
+    subgraph workflows["⚙️ workflows/ — 31 skills"]
         direction TB
         pb[plan-builder]
         cm[context-manager]
@@ -251,7 +251,7 @@ flowchart TB
 
 ## 🧰 Skill catalog
 
-51 skills organized into six categories. All bodies under 500 lines, all frontmatter validated, zero ownership conflicts, zero broken cross-references.
+53 skills organized into six categories. All bodies under 500 lines, all frontmatter validated, zero ownership conflicts, zero broken cross-references.
 
 <details>
 <summary><b>📚 Full skill table</b> (click to expand)</summary>
@@ -521,7 +521,7 @@ Almost always a `pyyaml` version skew. CI installs `pyyaml` explicitly on macOS 
 </details>
 
 <details>
-<summary><b>"My non-Claude-Code host doesn't see all 51 skills"</b></summary>
+<summary><b>"My non-Claude-Code host doesn't see all 53 skills"</b></summary>
 
 Expected. Skills with `requires_claude_code: true` (notably the `orchestrator` and most of `roles/`) are skipped for hosts that can't execute multi-agent dispatch. Run `./scripts/convert.sh --verbose` to see the skip list per host.
 </details>
@@ -548,7 +548,7 @@ Set the override env var documented in `scripts/README.md` (e.g. `CURSOR_RULES_D
 
 ## 🗺️  Roadmap
 
-- [x] **Skill library** — 51 skills, six categories, all linted
+- [x] **Skill library** — 53 skills, six categories, all linted
 - [x] **Multi-tool installer** — convert / install / lint, eleven host adapters
 - [x] **CI matrix** — Ubuntu + macOS lint on every push
 - [x] **Contract-first specs** — OpenAPI / AsyncAPI / Pydantic / TypeScript / JSON Schema templates

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -5,7 +5,7 @@
 
 ## Status at a glance
 
-A mature library of **51 skills** (contracts · git · meta · orchestrator · roles · workflows), all PSFS-validated, full Ubuntu + macOS lint matrix on every push.
+A mature library of **53 skills** (contracts · git · meta · orchestrator · roles · workflows), all PSFS-validated, full Ubuntu + macOS lint matrix on every push.
 
 | Effort | State |
 |--------|-------|

--- a/docs/REMAINING-WORK.md
+++ b/docs/REMAINING-WORK.md
@@ -1,6 +1,6 @@
 # Remaining Work — Tactical Ledger
 
-**Last updated:** 2026-05-31
+**Last updated:** 2026-06-02
 **Companions:** [`PLAN.md`](../PLAN.md) (strategic roadmap + closure log), [`docs/FUTURE.md`](FUTURE.md) (frontier overflow)
 
 > **Editing this doc?**
@@ -60,6 +60,10 @@ Create `skills/workflows/plan-builder/references/second-order-effects.md` and wi
 ### PR1 — B2/B3/B4 process guidance in skill-writer / skill-review
 **P3 · Process · open (verify first) · Owner: —** · Source: [IP] Phase 4
 Add the three process additions: iterate-on-one-task-at-a-time (B2), a required triggering-test format (B3), and an optional perf-comparison step (B4) to the skill-writer / skill-review bodies. Partial evidence exists (skill-update mentions "diff before/after"); confirm exact B2/B3/B4 wording is present before closing — may be partly done.
+
+### PR2 — Changelog discipline: no inline version-history in code files
+**P2 · Process / contracts · open · Owner: —** · Source: user report 2026-06-02 (observed in downstream project TruthLens)
+A downstream build accumulated a 21-line inline `// Changelog:` block at the top of `contracts/types.ts` — a file imported app-wide and read on nearly every task, so the history is pure read-tax for zero runtime value, and it **self-propagates** (each editor pattern-matches the block and appends to it). Root-cause check done: this is **not** prescribed by `contract-author` or its `references/typescript-template.ts` (both clean — no changelog header; the Versioning section only says "increment version + write the full contract"). It's emergent drift — a project-local "bump the `types.ts` header" convention plus the self-propagating block — that the skills don't actively **prevent**. Fix: (1) add an explicit guardrail to `contract-author` (Versioning + Output sections): the changelog lives in `CHANGELOG.md` **only**; the types file carries a one-line `// — vX.Y.Z` marker, never an inline history block ("bump the header" = the version line). (2) Model it in `references/typescript-template.ts` with a `// version history → contracts/CHANGELOG.md` pointer comment so the template demonstrates the right pattern. (3) Mirror the matching orchestrator anti-pattern (drafted 2026-06-02 in the deployed `~/.claude/skills/orchestrator` copy — **not yet committed to this repo**). (4) Sweep other code-authoring skills/templates for the same latent pattern.
 
 ---
 

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrator
-version: 1.10.0
+version: 1.11.0
 description: |
   Coordinate multi-agent Claude Code builds end-to-end: read the plan/mission, design integration contracts, dispatch role-agents in parallel, gate on QA, ship. Under ultracode (standing opt-in) or an explicit "workflow"/"workflows" ask, it drives the implement + verify phases with the Workflow tool — fanning out the role-agents (`agent({agentType})`) against the contracts and adversarially verifying — instead of hand-spawning agents one message at a time. Use when the user mentions agent teams, parallel/swarm builds, multi-agent work, a MISSION.md file, a multi-phase mission, splitting work across Claude sessions, "workflow"/"dynamic workflow", or ultracode mode. Triggers on "agent team", "parallel build", "team build", "multi-agent", "swarm build", "build X with agents", "coordinate the build", "run the mission", "workflow", "dynamic workflows", "ultracode build", "orchestrate with workflows". Does NOT preempt brainstorming, planning, design-brief, or feature-dev — it picks up after those produce artifacts.
 requires_agent_teams: false
@@ -19,7 +19,7 @@ composes_with: [
   "contract-author", "contract-auditor", "dependency-coordinator",
   "context-manager", "deployment-checklist", "code-review-agent", "project-profiler",
   "mermaid-charts", "playwright",
-  "claude-design-brief", "ui-brief", "frontend-design:frontend-design", "ui-ux-pro-max", "ux-review", "render-sanity",
+  "claude-design-brief", "ui-brief", "frontend-design:frontend-design", "ui-ux-pro-max", "ux-review", "render-sanity", "design-token-guard",
   "nano-banana", "claude-api", "feature-dev:feature-dev",
   "git-commit", "git-pr", "git-pr-feedback", "git-post-merge-cleanup",
   "claude-mem:mem-search", "claude-mem:timeline-report", "claude-mem:knowledge-agent",
@@ -47,7 +47,7 @@ For single-agent or ad-hoc work, this skill is not the right tool.
 
 The orchestrator is the conductor — not the only player. It composes with three groups of skills:
 
-- **INVOKES at the right phase:** `nano-banana` (seed imagery), `ui-ux-pro-max` + `frontend-design` (UI quality), `ux-review` + `render-sanity` (post-build validation), `repo-deep-dive` (reference research), `llm-wiki` (project knowledge base), `mermaid-charts` (architecture diagrams), `deployment-checklist` (ship readiness).
+- **INVOKES at the right phase:** `nano-banana` (seed imagery), `ui-ux-pro-max` + `frontend-design` (UI quality), `ux-review` + `render-sanity` (post-build *render*-level validation), `design-token-guard` (post-build *source*-level gate — no inline styles / hardcoded colors bypassing tokens), `repo-deep-dive` (reference research), `llm-wiki` (project knowledge base), `mermaid-charts` (architecture diagrams), `deployment-checklist` (ship readiness).
 - **DISPATCHES role-agents in parallel:** `backend-agent`, `frontend-agent`, `infrastructure-agent`, `db-migration-agent`, `security-agent`, `observability-agent`, `performance-agent`, `docs-agent`, `qe-agent`.
 - **DELEGATES diff/code review to the external `/code-review` CLI:** during a build, the Phase 4 diff review pass is the external `/code-review` CLI, NOT a spawned `code-review-agent`. The in-repo `code-review-agent` skill is not a default build phase — invoke it only deliberately for a standalone, repo-aware review. See `references/mission-interpretation.md`.
 - **DOES NOT preempt:** `brainstorming`, `plan-builder`, `writing-plans`, `claude-design-brief`, `ui-brief`, `feature-dev`, `claude-mem:*`. If any of these belong before the build starts, let them run first — orchestrator picks up from the artifacts they produce.
@@ -105,7 +105,7 @@ If the user says "merge it", "push to main", or "create a PR" — then and only 
 6. Size the team based on the work — see `references/team-sizing.md`
 7. **Pre-build creative + research skills** — invoke these BEFORE contracts where the mission asks for them: `nano-banana` (generates real seed imagery — hero banners, product photos, category icons), `claude-design-brief` or `ui-brief` (design direction document), `repo-deep-dive` (reference repo analysis), `llm-wiki` (project knowledge base bootstrap), `mermaid-charts` (architecture diagrams). These produce ARTIFACTS the agents will consume — running them first means agents get real images and real architecture refs instead of placeholders.
 8. Author contracts (the critical phase) — invoke the `contract-author` skill
-9. Spawn agents in parallel with distilled prompts — see `references/agent-spawning.md` for template, AFK/HITL classification, and a worked example. For frontend-agent dispatch, REQUIRE the agent to invoke `frontend-design` and `ui-ux-pro-max` during their build (not just mention them — actually call the Skill tool).
+9. Spawn agents in parallel with distilled prompts — see `references/agent-spawning.md` for template, AFK/HITL classification, and a worked example. **Role labels are not subagent types:** `backend-agent`, `docs-agent`, `qe-agent`, etc. name the *work*, not a `subagent_type` — dispatch with `general-purpose` (always available) and carry the role skill in the prompt. Passing a `*-agent` label as the type fails with "Agent type not found." See the mapping table at the top of `references/agent-spawning.md`. For frontend-agent dispatch, REQUIRE the agent to invoke `frontend-design` and `ui-ux-pro-max` during their build (not just mention them — actually call the Skill tool).
 10. **Spawn QE agent for testing** — this is mandatory, not optional (see below)
 11. Coordinate and validate (wave gates between every parallel wave)
 12. Gate on QA report
@@ -132,6 +132,16 @@ Workflow mode is gated on those opt-in signals on purpose: the Workflow tool can
 agents, so absent ultracode or an explicit "workflow" ask, don't reach for it — the other runtimes
 stay the default and behave exactly as before. Each agent role skill works standalone regardless of
 runtime; only this orchestrator skill needs the full decision tree.
+
+**Model defaults don't change this gate.** As of Claude Code v2.1.170 (Fable 5), the
+dynamic-workflows *feature* ships enabled by default on Max/Team/API plans (off by default for
+Enterprise; `/config` opt-in on Pro) — but every model, Fable 5 included, defaults to `/effort
+high`, and *automatic* workflow orchestration only happens under `/effort ultracode` (a
+session-only Claude Code setting: `xhigh` reasoning + Claude plans a workflow per substantive
+task; resets every new session). So "the session model is Fable 5" is NOT an opt-in signal —
+wait for the ultracode system-reminder or an explicit ask, same as before. The prompt trigger
+keyword is `ultracode` (renamed from `workflow` in v2.1.160); a natural-language "use a
+workflow" counts as the same opt-in in any version.
 
 **Sequential mode**: When neither Agent Teams nor subagent spawning is available, work through each role one at a time within a single session. Apply the relevant role skill as your own instructions for that phase. The user may need to coordinate context resets between roles. Contracts and validation still apply — only the parallelism changes.
 
@@ -181,7 +191,7 @@ Every orchestrated build **must** spawn a QE agent. Testing is not optional. Eve
 
 1. **Contract diff** — curl commands vs fetch calls, line by line
 2. **Agent validation** — each agent runs their checklist
-3. **Wave gate (CRITICAL)** — between every wave of parallel agents, run the integrated install + typecheck + test loop and route failures back to the responsible agent. See `references/wave-gate.md` for the per-stack commands and failure routing.
+3. **Wave gate (CRITICAL)** — between every wave of parallel agents, run the integrated install + typecheck + test loop and route failures back to the responsible agent. **For any wave that touched UI, also run the `design-token-guard` source-convention gate** (`--json`; non-zero `summary.errors` blocks the wave, routed back by file) alongside typecheck — it's deterministic and parses once. See `references/wave-gate.md` for the per-stack commands and failure routing, and the `design-token-guard` skill's `references/wiring-into-orchestrator.md` for the gate snippet.
 4. **QE agent testing** — the QE agent writes and runs tests, produces `qa-report.json`
 5. **End-to-end testing** — you run this: startup, happy path, persistence, edge cases
 6. **QA gate** — QE agent's `qa-report.json` must pass gate rules
@@ -232,8 +242,11 @@ When agents approach context limits, follow the handoff protocol in `references/
 | **Declaring done without ux-review on UI builds** | Tests pass + dev server boots is not the bar for a UI project. After the build, invoke `ux-review` (or run Playwright + screenshots manually) and address what comes back. Visual quality is verifiable; verify it. |
 | **Treating "ux-review invoked" as the post-build gate** | Process-level checks ("did the skill run?") let visible bugs ship — stale mock IDs leaking into "live" pages, lone `?` / generic-fallback placeholder text where real data should be, lists rendering plausibly but linking to dead targets, "Couldn't load X · Unauthorized" dead-end shells on auth-gated routes. These render with 0 console errors and pass every test-suite-based gate. The outcome-level gate is `render-sanity`: its four objective checks (smell scan, click-through every list, signed-out matrix, signed-in matrix) must return PASS. A "ux-review invoked" line in MISSION_SKILLS.md without a render-sanity PASS is the bug v1.7's process rigor was masking. |
 | **Skipping `render-sanity` when the dev stack isn't up** | Don't invoke validation against a dead port and call it green. Either bring up the stack first (the workspace already has a one-command `dev` script per workspace-bootstrap rules) or report "Cannot run — dev server not responding." Silent skips are how broken builds get declared done. |
-| **Spawning an agent without AFK/HITL classification** | Every agent dispatch must declare whether it can finish unattended (AFK) or needs a human in the loop (HITL). Undeclared dispatches stall builds the moment a prompt fires with no one watching. |
-| **Hand-spawning agents one message at a time under ultracode / Workflow mode** | When the opt-in signals are present, deterministic fan-out is the whole point — author a Workflow script (`references/workflow-orchestration.md`) for the implement + verify phases instead of dispatching and babysitting replies manually. |
+| **Trusting render-level gates to catch hardcoded styling** | render-sanity and ux-review read *pixels*; a hardcoded color (`style={{background:"#07090c"}}`) renders identically to its token, so it passes every visual gate and lives only in source. Inline styles and off-token colors accumulate invisibly until a human eyeballs the code weeks later and burns hours on a manual token refactor. The source-level gate is `design-token-guard` — run it on every UI wave alongside typecheck. A green render does not certify token discipline. |
+| **Trusting a green gate without checking the fix is real** | A gate measures a *proxy* — lint count, type errors, tests passing. An agent told to "make it green" can move the number without fixing the cause: relocate a violation into the checker's blind spot (a banned `rounded-full` class reborn as an inline `borderRadius:"50%"`), silence it with an ignore directive, or delete the failing assertion. The metric goes green; the problem ships. When a gate flips red→green, read the diff that did it — did it *resolve* the finding or *relocate* it? Adversarial verification verifies the fix, not the count. A suspiciously easy green is a finding, not a win — the same false-green as a masked exit code. |
+| **Retrofitting a source-convention gate after the code exists** | A convention gate (`design-token-guard`, strict typecheck, a new lint rule) added *after* a fleet of agents has written the UI inherits a backlog — so it can only land in report-only "ratchet" mode, and clearing the debt becomes a manual multi-file burndown later (the painful kind a human notices). Scaffold these gates in the **bootstrap wave**, before the first frontend-agent writes a line, so violation #1 is caught at commit #1 and the backlog never accumulates. See `references/wave-gate.md`. |
+| **Maintaining a changelog inline in a code file** | A version-history block at the top of a constantly-imported source file (a shared `types.ts`, a long-lived service module) is read on nearly every task for zero runtime value — and it *self-propagates*: each agent that edits the file pattern-matches the existing block and appends to it, so it only grows. The dedicated `CHANGELOG.md` is the system of record; a code file gets at most a one-line `version: X.Y.Z` plus a pointer to the changelog. When a contract/convention says "bump the header," that means the version line — not a growing inline history. If you find an inline changelog while editing, that's a finding (file a cleanup item), not a thing to extend. |
+| **Spawning an agent without AFK/HITL classification** | Every agent dispatch must declare whether it can finish unattended (AFK) or needs a human in the loop (HITL). Undeclared dispatches stall builds the moment a prompt fires with no one watching. || **Hand-spawning agents one message at a time under ultracode / Workflow mode** | When the opt-in signals are present, deterministic fan-out is the whole point — author a Workflow script (`references/workflow-orchestration.md`) for the implement + verify phases instead of dispatching and babysitting replies manually. |
 | **Putting the contract/design phase inside a workflow** | Design and contracts are interactive, human-in-the-loop architecture — the 50% that can't be delegated. Keep them inline; workflows execute implement + verify, not the decisions that shape them. |
 | **Cramming the whole build into one mega-workflow** | One workflow per phase, run in sequence, so the wave gate and QA gate stay real checkpoints you read between. A single script that implements-and-ships hides the gates that keep multi-agent builds safe. |
 | **Letting a workflow silently cap coverage** | If a script bounds work (top-N findings, sampled routes, no retry), `log()` what was dropped — same audit ethos as the mission-skills manifest. Silent truncation reads as "covered everything." |
@@ -252,10 +265,11 @@ ALL must be true:
 8. **Visual assets exist for UI builds** — if the project has a UI, real seed imagery exists in `assets/` or `web/public/` (generated via `nano-banana` or sourced via another path). The bar is "looks like a product"; "stub URL placeholders" doesn't meet it.
 9. **Post-build UX review passed for UI builds** — `ux-review` invoked (or equivalent Playwright + screenshots pass), and the issues it surfaces are fixed or recorded.
 10. **Render-sanity returned PASS for UI builds** — `render-sanity` walked every user-facing route in a real browser, ran all four checks (smell scan, click-through, signed-out matrix, signed-in matrix), and returned zero critical findings. Process-level "I invoked ux-review" is not the same as outcome-level "the four checks came back clean" — render-sanity is the outcome gate. A FAIL here blocks the build until the criticals are fixed.
-11. Contract changelog clean
-12. QA gate passed — QE agent tests written, executed, and passing
-13. **One-command dev is wired** — for any project with multiple services, the workspace root has a single `dev` (or equivalent) script that runs the whole dev stack in one terminal with prefixed output. See `references/workspace-bootstrap.md`.
-14. **End-state report** — a single file (e.g., `BUILD_RESULTS.md` or the build's git commit summary) lists what shipped, what was deferred, the mission skill checklist state, and explicit handoff items for the user. The user should be able to read this file and know exactly where the build stopped.
+11. **Source-convention gate passed for UI builds** — `design-token-guard` returns zero error-severity findings: no inline styles or hardcoded colors bypassing the design-token system. This is the *source-level* complement to render-sanity's pixel-level checks — a hardcoded color renders identically to its token, so it sails through every visual gate and only exists in source. A clean render and a clean console do not certify token discipline; only this does. The inline-CSS class of bug lives exactly in render-sanity's blind spot, which is how it ships unseen and accumulates into a painful manual token refactor — so a UI build needs **both** gates, not one. Findings route back to the owning frontend-agent by file.
+12. Contract changelog clean
+13. QA gate passed — QE agent tests written, executed, and passing
+14. **One-command dev is wired** — for any project with multiple services, the workspace root has a single `dev` (or equivalent) script that runs the whole dev stack in one terminal with prefixed output. See `references/workspace-bootstrap.md`.
+15. **End-state report** — a single file (e.g., `BUILD_RESULTS.md` or the build's git commit summary) lists what shipped, what was deferred, the mission skill checklist state, and explicit handoff items for the user. The user should be able to read this file and know exactly where the build stopped.
 
 </what-to-do>
 

--- a/skills/orchestrator/references/wave-gate.md
+++ b/skills/orchestrator/references/wave-gate.md
@@ -30,3 +30,16 @@ If any step fails, the wave is **not complete**. Route each specific failure bac
 Agent self-validation can be bypassed by grep tricks, missing files, or unran tests. The integrated gate cannot — if install fails, the workspace is broken, full stop. Catching it here is 30 minutes of fix work; catching it when the human runs the project is a credibility hit and a damaged handoff.
 
 **The orchestrator does not declare "build complete" without a clean integrated gate.** This applies whether or not a QE agent is in the loop — the wave gate is the orchestrator's own check, not delegated.
+
+## Clean state means clean (avoiding false greens)
+
+The gate is only as honest as the state it runs in. A "green" that came from a dirty environment or a misread exit code is worse than a red — it ships a broken build with a passing label. Four traps that have produced false greens in real builds:
+
+- **Kill watch/dev servers and clear the build cache before the production build + e2e steps.** A `next dev` (or any watcher) writing the build directory while `next build` reads it yields phantom errors that have nothing to do with the code — e.g. `Cannot find module for page: /api/...` from a half-written `.next`. The build "fails" on a ghost, or worse, a stale cache lets a broken build "pass." Stop the dev server, `rm -rf` the cache, then build.
+- **Don't trust a wrapped exit code.** `cmd; echo done` reports the echo's status (0), not `cmd`'s — a failed build reads as green. Use `cmd && echo OK || echo "FAIL=$?"`, or read the tail for the framework's own success line (`✓ Compiled successfully`). Never infer pass from "the command returned."
+- **"test" means the full suite — unit + integration + e2e — not the files you think the wave touched.** Cross-file breakage (a drifted contract, a stale snapshot, a fixture that no longer matches) is the entire reason the gate exists; a scoped subset is blind to exactly the integration bugs the wave introduced. Gating typecheck + build but skipping the full test run is how a stale test slips to the human.
+- **Run e2e against the production build, not a live dev/watch server.** A loaded `dev --turbo`/watch server compiles per-route on first hit, so an e2e suite pointed at it spends its wall-clock waiting on compiles and times out (minutes→hours); the same suite against a fresh `next start` / built artifact finishes in seconds. It's also correctness — dev and prod can render and route differently.
+
+## Wire source-convention gates at bootstrap, not at the end
+
+`design-token-guard` and any lint / strict-type / convention gate is cheapest when it exists **before the first line of UI is written**. Scaffold its config + pre-commit hook + CI step in the bootstrap wave. Then the first frontend-agent commit is already checked and the gate can hard-fail from day one — instead of being retrofitted onto a fleet of finished files, where it inherits a backlog, can only run report-only ("ratchet") to avoid blocking the whole build, and leaves a manual multi-file burndown for later. Retrofitting works, but the burndown it creates is pure avoidable cost.

--- a/skills/orchestrator/references/workflow-orchestration.md
+++ b/skills/orchestrator/references/workflow-orchestration.md
@@ -2,7 +2,8 @@
 
 How to run the contract-first madness build on the **Workflow tool** — deterministic JS
 that fans out subagents — instead of hand-spawning agents one message at a time. Read this
-when ultracode is on, when the user said "workflow", or when a build is large enough that
+when ultracode is on (`/effort ultracode` or the `ultracode` prompt keyword), when the user
+asked for a workflow in their own words, or when a build is large enough that
 message-by-message dispatch would lose the thread.
 
 ## Table of contents
@@ -192,8 +193,25 @@ circuit breaker) so a stubborn failure surfaces to the human instead of spinning
 - **Nesting is one level.** The orchestrator (main loop) launches the workflow; a role-agent
   *inside* a workflow cannot call the Workflow tool again. Don't write briefs that tell an agent
   to "run a workflow."
-- **Permissions.** Run the build in a write-permissive mode (acceptEdits/auto) so workflow agents
-  don't burn context on permission prompts — same rule as hand-spawned agents.
+- **Permissions.** Workflow subagents always run in `acceptEdits` and inherit your tool
+  allowlist regardless of the session's permission mode — file edits are auto-approved, but
+  shell commands, web fetches, and MCP tools outside the allowlist still prompt mid-run.
+  Pre-add the commands the agents will need (the wave-gate install/typecheck/test commands at
+  minimum) to the allowlist before launching a long run; the `settings-consolidator` skill can
+  bootstrap this. The launch prompt itself depends on session mode: default/acceptEdits prompts
+  per run (unless "don't ask again" was chosen), auto prompts on first launch only and skips
+  entirely under ultracode, bypass/`claude -p`/SDK never prompt.
+- **Ultracode is session-only.** It resets on every new session, so re-check the opt-in signals
+  each session — yesterday's ultracode doesn't carry over. Resume is same-session only too: if
+  Claude Code exits mid-run, the next session starts the workflow fresh. Don't park a wave gate
+  across a session boundary.
+- **Fable 5 reroutes flagged agents.** Fable 5 runs safety classifiers for cybersecurity and
+  biology content; a security-review or pentest-flavored agent prompt can trip them and reroute
+  that request to Opus. That's expected routing, not a build failure — note it in the run log
+  and carry on.
+- **Save the run.** Once an implement or verify workflow does what you want, save it from
+  `/workflows` (`s`) into `.claude/workflows/` — the next build of the same shape reruns the
+  identical orchestration as a `/command` instead of re-authoring the script.
 - **Pipeline by default; barrier only when a stage needs all prior results.** Implement waves and
   QA-finding dedup are genuine barriers (`parallel`); most else pipelines.
 - **No silent caps.** If you bound coverage (top-N findings, sampled routes, no retry), `log()`

--- a/skills/roles/frontend-agent/SKILL.md
+++ b/skills/roles/frontend-agent/SKILL.md
@@ -140,6 +140,8 @@ Two rules from that file matter enough to repeat here so the rest of this step m
 
 - **No hardcoded `width: <px>` on layout containers.** `width: 1200px` on a wrapper locks the layout off mobile entirely. Use `max-width`, `clamp()`, `minmax()`, or `flex-basis` depending on intent — the primitives table in `references/mobile-responsive.md` picks for you. Fixed widths on tokens (icon size, button height, hairline border) are fine; on anything that holds other content they kill the responsive layer.
 
+- **Colors come from design tokens, never hardcoded literals.** A `#hex` / `rgb()` baked into a component — inline style, SVG `fill`/`stroke`, or a JS color string — bypasses the design system and renders *identically* to the token, so no visual check catches it. Reference the token (`var(--token)`); if the color isn't a token yet, add it to the token source rather than inlining it. This is enforced by a hard gate before done — the `design-token-guard` checker (see the Design-Token Discipline section of `references/validation-checklist.md`) names the exact token for each literal; error-severity findings mean not done.
+
 If you reach for `!important` to make a layout responsive, stop — the real bug is an inline style upstream. Move it to a class.
 
 For server-rendered themes (WordPress / Rails / Phoenix / Django / PHP) the same rules apply, plus the platform-specific stylesheet-registration mechanism — see the "Server-rendered themes" section of `references/mobile-responsive.md` (e.g. `wp_enqueue_style()` with `filemtime()` versioning for WordPress). Templates carry `class=` attributes only; no `<style>` blocks.

--- a/skills/roles/frontend-agent/references/validation-checklist.md
+++ b/skills/roles/frontend-agent/references/validation-checklist.md
@@ -174,6 +174,27 @@ grep -rn '!important' --include='*.css' --include='*.scss' . | wc -l
 
 If the count is non-trivial, fix the source (remove the inline styles or fixed widths that prompted it) rather than adding more `!important`.
 
+## Design-Token Discipline (source-level gate)
+
+The grep in §4 above catches inline *layout* styles, but it can't see a hardcoded
+**color** — `style={{ background: "#07090c" }}` renders identically to the token
+it should have used, so it sails through every visual check. That class of bug
+only exists in source, and it's how inline CSS accumulates until a painful manual
+token refactor. Close it deterministically with the `design-token-guard` skill:
+
+```bash
+# Run against the files you changed. --json for a parseable verdict.
+python3 ~/.claude/skills/design-token-guard/scripts/check_design_tokens.py \
+  --root . --json <your changed files or dirs> > /tmp/dtg.json
+python3 -c "import json;d=json.load(open('/tmp/dtg.json'));print('errors:',d['summary']['errors'])"
+```
+
+**Error-severity findings mean you are not done.** Each finding names the exact
+fix — when the literal matches a declared token it suggests `var(--token)`; when
+it doesn't, the color was never tokenized (add it to the token source or use the
+nearest existing token — don't leave the literal). This is the source-level
+complement to the render checks: a clean render does not certify token discipline.
+
 ## Accessibility Verification
 
 - Tab through every interactive element — focus indicator visible on each

--- a/skills/workflows/design-token-guard/SKILL.md
+++ b/skills/workflows/design-token-guard/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: design-token-guard
+version: 1.0.1
+composes_with: ["orchestrator", "frontend-agent", "render-sanity", "ux-review", "code-review-agent", "sync-skills"]
+description: >-
+  Source-level gate that prevents inline styles and hardcoded CSS from
+  bypassing a project's design-token system. Use whenever frontend work touches
+  colors, styling, or themes — before committing or declaring a UI task done,
+  when auditing for hardcoded hex/rgb/inline styles, when setting up enforcement
+  so inline CSS can't slip in again, or as an orchestrator/agent wave-gate.
+  Trigger on: "inline CSS", "inline styles", "hardcoded colors", "hardcoded
+  hex", "style={{}}", "theme/token drift", "design tokens", "we keep shipping
+  inline styles", "lint for tokens", "why did this get through review".
+  Framework- and stack-agnostic (React/JSX, Vue, Svelte, Angular, Astro, HTML;
+  CSS variables, SCSS/Less, JS theme objects, design-token JSON) — it
+  auto-discovers the project's tokens, so it is NOT specific to any one repo or
+  to Tailwind. Don't skip it because a visual/render review passed: render gates
+  can't see a hardcoded color — it renders identically to the token.
+---
+
+# design-token-guard
+
+## The problem this solves
+
+A hardcoded color renders *identically* to the token it should have used.
+`style={{ background: "#07090c" }}` and `style={{ background: "var(--tl-tooltip)" }}`
+produce the same pixels. So every **render-level** gate — visual review, e2e,
+screenshots, "console is clean" — passes a component that has silently bypassed
+the design system. The violation only exists in **source**.
+
+That is why inline styles and hardcoded CSS accumulate invisibly until someone
+eyeballs the code weeks later and burns hours on a token refactor. The fix is a
+**source-level gate**: a deterministic check that reads the diff for styling
+that bypasses the token system, run *before* the code is declared done, and
+wired into the repo so it can't regress.
+
+This skill is that gate. It does two things:
+
+1. **Audit** — run the bundled checker (`scripts/check_design_tokens.py`) to find
+   every inline style and hardcoded color, each mapped to the exact token to use.
+2. **Enforce** — scaffold the check into the repo (config + ESLint rule +
+   pre-commit hook + `lint:tokens` script) so the gate runs on every commit/CI,
+   not just when an agent remembers to look.
+
+It is **dynamic**: it auto-discovers whatever token system the project already
+uses and derives the rules from it. TruthLens and a vanilla Vue app are two
+*configs* of one skill, not two skills.
+
+## Step 1 — Audit
+
+Run the checker from the project root. It needs no flags for a first pass:
+
+```bash
+python3 <skill-dir>/scripts/check_design_tokens.py --root .
+```
+
+What it does automatically:
+- **Discovers the token source** — scans for CSS custom properties
+  (`--name: …`), SCSS/Less vars (`$name`, `@name`), JS/TS theme objects, or
+  design-token JSON. From those it builds a `color-value → token` map.
+- **Scans the source tree** (`.tsx/.ts/.jsx/.js/.vue/.svelte/.astro/.html`),
+  skipping `node_modules`, build dirs, config files, and the token files
+  themselves.
+- **Reports** each finding as `file:line:col`, the offending snippet, and — when
+  the literal matches a declared token — the exact fix:
+
+  ```
+  no-hardcoded-color (error) — 2
+    src/components/schedule/EventBar.tsx:69:17
+      fill="#0E1116"
+      → hardcoded color #0E1116 is var(--tl-bg-0)  ·  use var(--tl-bg-0)
+  ```
+
+Useful flags:
+- `--staged` — only git-staged files (this is what the pre-commit hook uses).
+- `--json` — machine-readable output for a gate/CI to parse (`{ ok, summary, findings }`).
+- `PATHS…` — limit to specific files/dirs (e.g. just the component you changed).
+- `--config <path>` — explicit config location.
+
+Exit code is `1` when there are **error**-severity findings, `0` when clean — so
+it drops straight into a gate or CI step.
+
+## Step 2 — Interpret and fix
+
+Two outcomes per color finding, and they need different fixes — don't blur them:
+
+- **"… is `var(--token)`"** — the literal duplicates an existing token. Replace
+  it with the token reference. Mechanical and safe.
+- **"… is not a declared token"** — the color was never tokenized. This is the
+  more important signal: either it's a genuinely new design value (add it to the
+  token source with a real name, then reference it) or it's an off-palette
+  mistake (use the nearest existing token). Don't paper over it by leaving the
+  literal — that's how palettes rot.
+
+For `no-inline-style` findings, move the value into a token or a utility class.
+Inline styles whose values are all dynamic (`var(--…)`, JS expressions) are
+**allowed** by default — the rule fires on hardcoded literals, not on the
+mechanism. Use `"inlineStyleMode": "strict"` only if the project bans inline
+style attributes outright.
+
+## Step 3 — Enforce (scaffold into the repo)
+
+A one-time audit doesn't stop regression. Wire the gate into the repo so it runs
+without anyone remembering. Read `references/scaffolding.md` for the full
+procedure; the short version:
+
+1. **Write `.design-guard.json`** at the repo root (template:
+   `assets/design-guard.config.json`). Set `tokenSources` explicitly so
+   discovery is deterministic in CI, and turn on any project-specific rules.
+2. **Add the checker to the repo** — copy `scripts/check_design_tokens.py` into
+   the project's `scripts/`, or reference the skill path. Add a script:
+   `"lint:tokens": "python3 scripts/check_design_tokens.py --root ."`.
+3. **Pre-commit hook** — install `assets/pre-commit` (runs `--staged`, blocks the
+   commit on error-severity findings). Wire via Husky/lefthook if present, else a
+   plain `.git/hooks/pre-commit`.
+4. **ESLint editor-time subset** — merge `assets/eslint-tokens.snippet.mjs` into
+   the repo's flat config (create `eslint.config.mjs` if absent). ESLint gives
+   in-editor squiggles for the patterns it expresses well (inline-style literals,
+   forbidden radius/partisan-color classes). The Python checker stays the
+   authority — it's the only layer that can do the `value → token` mapping, so
+   pre-commit/CI run *that*, and ESLint is fast feedback, not the source of truth.
+5. **CI** — add a `lint:tokens` step to the pipeline (`assets/ci-step.yml` shows a
+   GitHub Actions example).
+
+Tell the user which layers you installed and which you skipped (e.g. "no Husky
+here, used a raw git hook").
+
+## The rule set
+
+Two **universal** rules, on by default (these are the "no inline CSS" core):
+
+| rule | catches | default |
+|---|---|---|
+| `no-hardcoded-color` | `#hex`, `rgb()/rgba()`, `hsl()/hsla()` literals anywhere a token belongs — inline styles, SVG `fill`/`stroke`, JS color strings, Tailwind arbitrary `[#…]` | error |
+| `no-inline-style` | `style={{…}}` / `style="…"` / `:style` / `[style]` carrying hardcoded literals (React/Vue/Svelte/Angular/HTML) | warn |
+
+A **project-specific library**, off by default — opt in via config when a repo
+has these conventions:
+
+| rule | catches |
+|---|---|
+| `no-class-in-svg` | utility/Tailwind classes on `<svg>` primitives (`rect`, `path`, `g`, …) where styling should be token attributes |
+| `restricted-radius` | border-radius above `maxRadiusPx`, or `rounded-{md,lg,xl,…}` classes |
+| `forbidden-colors` | configured regexes — banned second accent, partisan red/blue, etc. |
+| `no-arbitrary-tailwind` | Tailwind arbitrary *values* — `text-[10px]`, `max-w-[1100px]`, `leading-[1.75]` — that bypass the spacing/type scale. Arbitrary *colors* (`border-[rgba(…)]`) are already caught by `no-hardcoded-color`, so this rule skips them. `*-[var(--token)]` is allowed. |
+
+Each rule's severity is `"error" | "warn" | "off"`. Errors fail the gate
+(exit 1); warnings report but pass. Full config reference and per-rule notes:
+`references/config.md`.
+
+## Using it as an agent / orchestrator gate
+
+When a frontend build runs under an orchestrator or agent team, this is a **hard
+source-level wave-gate**, complementary to the render-level gates (render-sanity,
+ux-review) — those check pixels, this checks source, and a build needs both:
+
+- A **frontend-agent** runs `--json` against the files it changed *before*
+  reporting done; error-severity findings mean the task isn't done.
+- The **orchestrator** runs it at the wave gate alongside typecheck/test. Parse
+  `summary.errors`; non-zero blocks the wave and routes back to the owning agent.
+
+See `references/wiring-into-orchestrator.md` for the exact gate snippet and how
+this plugs into the orchestrator's Definition of Done.
+
+## Reference files
+
+- `references/config.md` — full `.design-guard.json` schema, every field, per-rule notes, and adapting to non-CSS-variable token systems (SCSS, JS theme, Style Dictionary).
+- `references/scaffolding.md` — step-by-step repo enforcement: config, hook, ESLint, CI, with the Husky/lefthook/raw-hook decision.
+- `references/wiring-into-orchestrator.md` — the agent self-check + orchestrator wave-gate snippets, and the Definition-of-Done line this closes.

--- a/skills/workflows/design-token-guard/assets/ci-step.yml
+++ b/skills/workflows/design-token-guard/assets/ci-step.yml
@@ -1,0 +1,20 @@
+# design-token-guard — CI step (GitHub Actions example).
+#
+# Add this job (or just the step) to .github/workflows/ci.yml. The checker is
+# pure-stdlib Python, so no install is needed beyond a Python runtime. It exits
+# non-zero on error-severity findings, failing the build.
+
+jobs:
+  design-token-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check for inline styles & hardcoded colors
+        run: python3 scripts/check_design_tokens.py --root .
+
+# If you vendored the checker elsewhere, adjust the path. To see machine-readable
+# output in logs, append `--json`. To scan only changed files in a PR, gate on
+# `git diff --name-only origin/${{ github.base_ref }}...` and pass those paths.

--- a/skills/workflows/design-token-guard/assets/design-guard.config.json
+++ b/skills/workflows/design-token-guard/assets/design-guard.config.json
@@ -1,0 +1,18 @@
+{
+  "tokenSources": ["src/styles/tokens.css"],
+  "scanExtensions": [".tsx", ".ts", ".jsx", ".js", ".vue", ".svelte", ".astro", ".html"],
+  "ignoreDirs": ["node_modules", ".git", ".next", "dist", "build", "out", "coverage"],
+  "ignorePathContains": [".config.", ".d.ts"],
+  "rules": {
+    "no-hardcoded-color": "error",
+    "no-inline-style": "warn",
+    "no-class-in-svg": "off",
+    "restricted-radius": "off",
+    "forbidden-colors": "off",
+    "no-arbitrary-tailwind": "off"
+  },
+  "inlineStyleMode": "literal",
+  "maxRadiusPx": 2,
+  "forbiddenColors": [],
+  "scanStyleSheets": false
+}

--- a/skills/workflows/design-token-guard/assets/eslint-tokens.snippet.mjs
+++ b/skills/workflows/design-token-guard/assets/eslint-tokens.snippet.mjs
@@ -1,0 +1,45 @@
+// design-token-guard — ESLint flat-config block (editor-time fast feedback).
+//
+// Merge the object below into the project's eslint.config.mjs `export default [ ... ]`
+// array. This is the EDITOR layer: it gives in-IDE squiggles for the patterns
+// ESLint expresses cleanly. It is deliberately a SUBSET — ESLint can't resolve a
+// hex back to its token name, so the authoritative check (with the value→token
+// map) stays the Python checker run at pre-commit/CI. Keep both; they're layers,
+// not duplicates.
+//
+// no-restricted-syntax selectors below cover JSX. For Vue/Svelte/Angular
+// templates, rely on the pre-commit checker — those need template-aware parsers.
+
+export const designTokenGuardRules = {
+  files: ['**/*.{ts,tsx,js,jsx}'],
+  rules: {
+    'no-restricted-syntax': [
+      'error',
+      {
+        // Hardcoded color literal in JSX inline style: style={{ x: "#abc123" }}
+        selector:
+          'JSXAttribute[name.name="style"] Literal[value=/#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\\b|rgba?\\(|hsla?\\(/]',
+        message:
+          'Hardcoded color in an inline style — use a design token (var(--…)). Run `npm run lint:tokens` for the exact token.',
+      },
+      {
+        // Hardcoded color anywhere in a JSX attribute (fill="#…", color strings)
+        selector:
+          'JSXAttribute Literal[value=/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/]',
+        message:
+          'Hardcoded color literal — reference a design token instead. Run `npm run lint:tokens`.',
+      },
+    ],
+    // Forbidden utility classes (radius cap / partisan colors). Tune the regex
+    // to the project; delete this rule entirely if the project isn't class-based.
+    'no-restricted-properties': 'off',
+  },
+};
+
+// If the project uses tailwindcss with eslint-plugin-tailwindcss, you can ALSO
+// forbid radius/partisan utilities at lint time. Example (optional):
+//
+//   'no-restricted-syntax': [..., {
+//     selector: 'Literal[value=/\\brounded-(?:md|lg|xl|2xl|3xl|full)\\b/]',
+//     message: 'Radius exceeds the project cap — use the smallest radius token.',
+//   }]

--- a/skills/workflows/design-token-guard/assets/pre-commit
+++ b/skills/workflows/design-token-guard/assets/pre-commit
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# design-token-guard pre-commit hook.
+#
+# Blocks a commit that introduces inline styles or hardcoded colors that bypass
+# the design-token system. Scans ONLY staged files, so it's fast and only ever
+# complains about code you're actually committing.
+#
+# Install (raw git hook):
+#   cp assets/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+# Or wire through Husky/lefthook — see references/scaffolding.md.
+#
+# It calls the checker with --staged; the checker exits 1 on error-severity
+# findings, which aborts the commit. Warnings do not block.
+
+set -euo pipefail
+
+# Resolve the checker: prefer a copy committed into the repo, else fall back to
+# the skill's own copy. Adjust CHECKER if you vendored it elsewhere.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CHECKER="$REPO_ROOT/scripts/check_design_tokens.py"
+if [ ! -f "$CHECKER" ]; then
+  CHECKER="$HOME/.claude/skills/design-token-guard/scripts/check_design_tokens.py"
+fi
+if [ ! -f "$CHECKER" ]; then
+  echo "design-token-guard: checker not found; skipping (run scaffolding to install)." >&2
+  exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "design-token-guard: python3 not found; skipping." >&2
+  exit 0
+fi
+
+if python3 "$CHECKER" --root "$REPO_ROOT" --staged --quiet; then
+  exit 0
+else
+  echo "" >&2
+  echo "design-token-guard blocked this commit: hardcoded styling found above." >&2
+  echo "Fix the literals (use the suggested var(--token)) or, if intentional," >&2
+  echo "commit with --no-verify." >&2
+  exit 1
+fi

--- a/skills/workflows/design-token-guard/references/config.md
+++ b/skills/workflows/design-token-guard/references/config.md
@@ -1,0 +1,113 @@
+# `.design-guard.json` configuration reference
+
+The checker runs with zero config (it auto-discovers the token source and uses
+sensible defaults). A `.design-guard.json` at the repo root makes behavior
+deterministic and turns on project-specific rules. User config is shallow-merged
+over the defaults; the `rules` object is merged key-by-key.
+
+## Full schema
+
+```jsonc
+{
+  // Token source files. Empty/omitted => auto-discover (css/scss/less/json with
+  // token-ish names or many custom properties). Set this explicitly in CI so
+  // discovery never drifts. Paths are relative to the repo root.
+  "tokenSources": ["src/styles/tokens.css"],
+
+  // File extensions scanned for violations.
+  "scanExtensions": [".tsx", ".ts", ".jsx", ".js", ".vue", ".svelte", ".astro", ".html"],
+
+  // Directory names never walked.
+  "ignoreDirs": ["node_modules", ".git", ".next", "dist", "build", "out", "coverage"],
+
+  // Skip any file whose path contains one of these substrings.
+  "ignorePathContains": [".config.", ".d.ts"],
+
+  // Per-rule severity: "error" | "warn" | "off". Errors set exit code 1.
+  "rules": {
+    "no-hardcoded-color": "error",
+    "no-inline-style": "warn",
+    "no-class-in-svg": "off",
+    "restricted-radius": "off",
+    "forbidden-colors": "off",
+    "no-arbitrary-tailwind": "off"
+  },
+
+  // "literal" (default): no-inline-style fires only on inline styles carrying a
+  //   hardcoded literal; dynamic/token inline styles are allowed.
+  // "strict": fires on every inline style attribute, period.
+  "inlineStyleMode": "literal",
+
+  // restricted-radius threshold (px) and rounded-* class gate.
+  "maxRadiusPx": 2,
+
+  // forbidden-colors: regexes matched against each source line.
+  "forbiddenColors": [],
+
+  // Also scan .css/.scss/.less files for hardcoded colors? Usually false — that's
+  // where colors legitimately live. Turn on if component-level stylesheets
+  // (CSS modules, *.module.scss) should be token-only too.
+  "scanStyleSheets": false
+}
+```
+
+## Per-rule notes
+
+### `no-hardcoded-color` (universal)
+Flags `#hex` (3/4/6/8-digit), `rgb()/rgba()`, `hsl()/hsla()` literals across the
+scanned files. When the normalized value matches a declared token, the message
+names the exact token and suggests `var(--token)`. When it doesn't, it flags the
+color as **undeclared** — the higher-value signal, because it means the palette
+has an untracked value. Color literals inside comments and the token sources
+themselves are ignored.
+
+### `no-inline-style` (universal)
+Catches `style={{…}}` (JSX), `style="…"`, `:style`, and `[style]` (Vue/Svelte/
+Angular/HTML) attributes. Default `"literal"` mode fires only when the attribute
+carries a hardcoded literal — color literals are owned by `no-hardcoded-color`
+(more specific, has the token suggestion), so this rule's distinct contribution
+in literal mode is hardcoded **dimensions** and mixed literals. Switch to
+`"strict"` to forbid inline styles outright.
+
+### `no-class-in-svg` (opt-in)
+For projects whose convention is "SVG is styled with token attributes, never
+utility/Tailwind classes." Flags `className`/`class` carrying utility-looking
+tokens on `<rect>`, `<path>`, `<g>`, `<circle>`, etc.
+
+### `restricted-radius` (opt-in)
+Flags `rounded-{md,lg,xl,2xl,3xl,full}` classes and `border-radius: Npx` where
+`N > maxRadiusPx`. For editorial/sharp design systems with a hard radius cap.
+
+### `forbidden-colors` (opt-in)
+Each entry is a regex tested against every line. Use for a banned second accent,
+partisan red/blue, or any class/value the project forbids. Example:
+```json
+"forbiddenColors": ["\\b(?:text|bg|border)-(?:red|blue)-\\d{3}\\b", "#ff0000"]
+```
+
+### `no-arbitrary-tailwind` (opt-in)
+Flags Tailwind **arbitrary-value** utilities — `text-[10px]`, `max-w-[1100px]`,
+`leading-[1.75]`, `pb-[1px]` — that hardcode a value off the spacing/type scale.
+For projects that want strict scale discipline. Deliberately **off by default**:
+many design systems (and design-handoff ports) use specific px values on purpose,
+so blanket-flagging them is noise unless the project opts in. It skips two cases
+that are not violations: arbitrary *colors* (`border-[rgba(…)]`, owned by
+`no-hardcoded-color` which has the token suggestion) and token refs
+(`text-[var(--token)]`). Semantic utilities that map to tokens via the Tailwind
+config (`text-fg-2`, `border-ink-3`) have no brackets and are never flagged.
+
+## Adapting to non-CSS-variable token systems
+
+The checker derives its `value → token` map from whatever token sources it parses:
+
+- **CSS custom properties** (`--name: value;`) → suggestion is `var(--name)`.
+- **SCSS / Less** (`$name`, `@name`) → suggestion names the variable; reference it
+  the way your build expects (`$name`).
+- **JS/TS theme object** (`{ name: '#hex' }`) → the key is surfaced as the token
+  name; reference it through your theme accessor.
+- **Design-token JSON** (Style Dictionary `{ "color": { "bg": { "value": "#…" } } }`)
+  → the dotted path becomes the token name.
+
+If a project has multiple sources (e.g. a CSS file *and* a JSON), list them all
+in `tokenSources`; the first source to define a given color value wins the
+suggestion.

--- a/skills/workflows/design-token-guard/references/scaffolding.md
+++ b/skills/workflows/design-token-guard/references/scaffolding.md
@@ -1,0 +1,90 @@
+# Scaffolding repo enforcement
+
+A one-time audit doesn't prevent regression. These steps wire the gate into the
+repo so it runs on every commit and in CI — the difference between "we cleaned it
+up once" and "it can't come back." Install the layers that fit the repo; tell the
+user which you installed and which you skipped and why.
+
+## 1. Write `.design-guard.json`
+
+Copy `assets/design-guard.config.json` to the repo root and tailor it:
+- Set `tokenSources` to the project's real token file(s) — explicit, not
+  auto-discovered, so CI is deterministic.
+- Turn on any project-specific rules (`no-class-in-svg`, `restricted-radius`,
+  `forbidden-colors`) the repo's conventions call for. Leave them `off` otherwise.
+- Decide `inlineStyleMode`: `"literal"` (allow dynamic inline styles, forbid
+  hardcoded ones) for most repos; `"strict"` if the design system bans inline
+  styles entirely.
+
+## 2. Vendor the checker + add an npm script
+
+Copy `scripts/check_design_tokens.py` into the repo's `scripts/` (so CI/hook
+don't depend on the skill being installed on the runner). Add to `package.json`:
+
+```json
+{
+  "scripts": {
+    "lint:tokens": "python3 scripts/check_design_tokens.py --root ."
+  }
+}
+```
+
+Confirm it runs: `npm run lint:tokens` (or `pnpm lint:tokens`). For a non-Node
+repo, just document the `python3 scripts/check_design_tokens.py` invocation.
+
+## 3. Pre-commit hook
+
+The hook scans staged files only, so it's fast and scoped. Choose the wiring that
+matches the repo:
+
+- **Husky present** (`.husky/`): add to `.husky/pre-commit`:
+  ```sh
+  python3 scripts/check_design_tokens.py --root . --staged --quiet || exit 1
+  ```
+- **lefthook present** (`lefthook.yml`): add a command:
+  ```yaml
+  pre-commit:
+    commands:
+      design-token-guard:
+        run: python3 scripts/check_design_tokens.py --root . --staged --quiet
+  ```
+- **Neither** (raw git hook): `cp assets/pre-commit .git/hooks/pre-commit &&
+  chmod +x .git/hooks/pre-commit`. Note this isn't version-controlled — prefer
+  Husky/lefthook for team repos; the raw hook is fine for a solo repo.
+
+The hook blocks on error-severity findings; `--no-verify` is the documented
+escape hatch for an intentional exception.
+
+## 4. ESLint editor-time subset
+
+Merge `assets/eslint-tokens.snippet.mjs` into the repo's `eslint.config.mjs`
+(create one if absent). This gives in-editor squiggles for inline-style color
+literals — fast feedback while typing. It's intentionally a subset: ESLint can't
+map a hex back to its token, so it can't produce the "use `var(--tl-bg-0)`"
+suggestion. The Python checker remains the authority; ESLint is a convenience
+layer. Don't let the two definitions drift — when you change a rule, change the
+Python checker first and treat ESLint as best-effort mirroring.
+
+For Vue/Svelte/Angular template styles, skip ESLint and rely on the pre-commit
+checker, which is template-aware via regex.
+
+## 5. CI step
+
+Add `assets/ci-step.yml`'s step to the pipeline so a bypassed local hook
+(`--no-verify`, or a contributor without the hook installed) still gets caught on
+the server. The checker needs only a Python runtime.
+
+## 6. Seed cleanup vs. ratchet
+
+If the repo already has many violations (a legacy codebase), a hard gate will
+block every commit. Two options — pick with the user:
+- **Clean then gate** — fix the existing findings in one pass (the checker's
+  `value → token` suggestions make most of them mechanical), then turn the gate
+  to `error`. Best when the backlog is small.
+- **Ratchet** — set `no-hardcoded-color` to `error` only on changed files (the
+  pre-commit `--staged` path already does this) while the full-tree CI run stays
+  a `warn`-level report until the backlog is burned down. Stops new debt
+  immediately without blocking on old debt.
+
+State which you chose in the handoff so the user isn't surprised by the gate's
+strictness.

--- a/skills/workflows/design-token-guard/references/wiring-into-orchestrator.md
+++ b/skills/workflows/design-token-guard/references/wiring-into-orchestrator.md
@@ -1,0 +1,66 @@
+# Wiring into the orchestrator / agent builds
+
+This is the missing **source-level** gate in a contract-first multi-agent build.
+The orchestrator's existing gates are all **render-level** — `render-sanity`
+(click-through, smell scan), `ux-review` (visual hierarchy), QA (contract +
+security). None of them can see a hardcoded color, because it renders identically
+to the token it should have used. That's how inline CSS shipped through a "passing"
+build. This gate closes that hole by reading source, not pixels.
+
+## Frontend-agent self-check (before reporting done)
+
+Add to the frontend-agent's done criteria: run the checker against the files it
+changed and treat error-severity findings as "not done."
+
+```bash
+python3 ~/.claude/skills/design-token-guard/scripts/check_design_tokens.py \
+  --root . --json src/components/<the-files-it-touched> > /tmp/dtg.json
+# Parse: if .summary.errors > 0, the task is NOT done — fix and re-run.
+```
+
+In a frontend-agent prompt, phrase it as a hard gate, parallel to typecheck:
+> Before reporting done, run design-token-guard on your changed files. Any
+> `no-hardcoded-color` error means you bypassed the token system — fix it using
+> the suggested `var(--token)` (or add a new token if the color is genuinely new)
+> and re-run until clean.
+
+## Orchestrator wave-gate
+
+At the wave gate — where the orchestrator already runs install + typecheck +
+test between waves — add the token check for any wave that touched UI. It's a
+deterministic, parse-once gate:
+
+```bash
+python3 scripts/check_design_tokens.py --root . --json > /tmp/dtg.json
+ERRORS=$(python3 -c "import json;print(json.load(open('/tmp/dtg.json'))['summary']['errors'])")
+# ERRORS > 0  →  block the wave, route findings back to the owning frontend-agent.
+```
+
+Route by file: each finding has `file`/`line`, so the orchestrator hands each
+back to whichever agent owns that path (per `references/file-ownership.md`). This
+is the same failure-routing protocol as a failed typecheck.
+
+## Definition of Done line this closes
+
+The orchestrator's Definition of Done has render-level gates (#10 render-sanity)
+but no source-convention gate. Add one:
+
+> **Source-convention gate passed** — `design-token-guard` returns zero
+> error-severity findings for UI code (no inline styles or hardcoded colors
+> bypassing the token system). This is the source-level complement to
+> render-sanity's pixel-level checks; a UI build needs both. A green render and a
+> clean console do not certify token discipline — only this does.
+
+## Why both gates, not one
+
+Keep the framing explicit for the orchestrator so it doesn't treat this as
+redundant with render-sanity:
+
+| gate | reads | catches | misses |
+|---|---|---|---|
+| render-sanity / ux-review | the running UI (pixels) | broken pages, dead links, stale data, visual regressions | hardcoded colors, inline styles (they render fine) |
+| design-token-guard | the source | token-system bypasses, hardcoded CSS, inline styles | anything that's wrong only at runtime |
+
+Neither subsumes the other. The inline-CSS class of bug lives exactly in
+render-sanity's blind spot, which is why it accumulated unseen until a manual
+refactor — and why this gate has to run on every UI wave, not as an afterthought.

--- a/skills/workflows/design-token-guard/scripts/check_design_tokens.py
+++ b/skills/workflows/design-token-guard/scripts/check_design_tokens.py
@@ -1,0 +1,681 @@
+#!/usr/bin/env python3
+"""
+design-token-guard — a source-level gate that prevents inline styles and
+hardcoded CSS values from bypassing a project's design-token system.
+
+Why this exists: render-level gates (visual review, e2e, screenshots) never
+catch a hardcoded color, because `style={{ background: "#07090c" }}` renders
+identically to `var(--tl-tooltip)`. The violation is only visible in source.
+This is that missing source-level check.
+
+It is framework-agnostic (React/JSX, Vue, Svelte, Angular, Astro, plain HTML)
+and token-source-agnostic (CSS custom properties, SCSS/Less vars, JS/TS theme
+objects, design-token JSON). It auto-discovers the project's tokens and derives
+a value->token map, so the fix it suggests is exact ("#07090c is var(--tl-tooltip)")
+no matter the stack. No third-party dependencies — Python 3.8+ stdlib only.
+
+Usage:
+  python3 check_design_tokens.py [--root DIR] [--config PATH]
+                                 [--staged] [--json] [--quiet] [PATHS...]
+
+Exit codes: 0 = clean, 1 = error-severity findings, 2 = usage/config error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Defaults. Everything here is overridable via .design-guard.json at the root.
+# The two universal rules are "error"; the project-specific library is "off".
+# ---------------------------------------------------------------------------
+DEFAULT_CONFIG = {
+    # Token sources. Empty => auto-discover (see discover_token_sources).
+    "tokenSources": [],
+    # File extensions to scan for violations.
+    "scanExtensions": [
+        ".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs",
+        ".vue", ".svelte", ".astro", ".html",
+    ],
+    # Directories never walked.
+    "ignoreDirs": [
+        "node_modules", ".git", ".next", "dist", "build", "out",
+        "coverage", ".turbo", ".vercel", "__pycache__", ".svelte-kit",
+    ],
+    # Glob-ish substrings; a file whose path contains any of these is skipped
+    # for the violation scan (token-definition files belong here).
+    "ignorePathContains": [".config.", ".d.ts"],
+    "rules": {
+        # --- universal, on by default ---
+        "no-hardcoded-color": "error",
+        "no-inline-style": "warn",
+        # --- project-specific library, opt-in ---
+        "no-class-in-svg": "off",       # utility classes inside <svg> primitives
+        "restricted-radius": "off",     # border-radius above maxRadiusPx
+        "forbidden-colors": "off",      # see forbiddenColors list below
+        "no-arbitrary-tailwind": "off", # arbitrary VALUES: text-[10px], max-w-[1100px]
+    },
+    # no-inline-style mode: "literal" flags only inline styles carrying a
+    # hardcoded literal (dynamic/token-referencing inline styles are allowed);
+    # "strict" flags every inline style attribute regardless.
+    "inlineStyleMode": "literal",
+    # restricted-radius: any radius value over this many px (or a rounded-*
+    # utility class larger than ~2px) is flagged.
+    "maxRadiusPx": 2,
+    # forbidden-colors: list of regexes matched against each source line. Use
+    # for partisan colors, a banned second accent, etc.
+    "forbiddenColors": [],
+    # Scan CSS/SCSS files themselves for hardcoded colors? Usually off — that
+    # is where colors legitimately live (the token definitions).
+    "scanStyleSheets": False,
+}
+
+COLOR_KEYS = ("color", "background", "fill", "stroke", "border", "shadow",
+              "outline", "gradient")
+
+# A color literal: #hex (3/4/6/8), rgb()/rgba(), hsl()/hsla().
+COLOR_RE = re.compile(
+    r"#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})\b"
+    r"|rgba?\([^)]*\)"
+    r"|hsla?\([^)]*\)"
+)
+
+# Dimension literal inside a quoted string: "12px", '2rem', "1.5em" ...
+DIM_RE = re.compile(r"""['"]\s*-?\d*\.?\d+(px|rem|em|vh|vw|vmin|vmax|pt|ch)\s*['"]""")
+
+SVG_PRIMITIVES = (
+    "rect", "circle", "path", "line", "polyline", "polygon", "ellipse",
+    "g", "text", "tspan", "use", "defs", "linearGradient", "radialGradient",
+    "stop", "clipPath", "mask",
+)
+
+RADIUS_CLASS_RE = re.compile(r"\brounded-(?:md|lg|xl|2xl|3xl|full)\b")
+RADIUS_VALUE_RE = re.compile(r"border-radius\s*:\s*(\d*\.?\d+)px")
+
+# Tailwind arbitrary-value utility: prefix-[value] (text-[10px], max-w-[1100px]).
+ARBITRARY_TW_RE = re.compile(r"(?<![\w-])([a-z][a-z0-9]*(?:-[a-z0-9]+)*)-\[([^\]]+)\]")
+
+
+@dataclass
+class Finding:
+    rule: str
+    severity: str
+    file: str
+    line: int
+    col: int
+    snippet: str
+    message: str
+    suggestion: Optional[str] = None
+
+
+@dataclass
+class TokenIndex:
+    sources: List[str] = field(default_factory=list)
+    by_value: Dict[str, str] = field(default_factory=dict)  # norm value -> token ref
+    count: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Color normalization — canonical key so source literals match token values.
+# ---------------------------------------------------------------------------
+def normalize_color(raw: str) -> Optional[str]:
+    s = raw.strip().lower()
+    if s.startswith("#"):
+        h = s[1:]
+        if len(h) == 3:
+            h = "".join(c * 2 for c in h)
+        elif len(h) == 4:
+            h = "".join(c * 2 for c in h)
+        if len(h) == 6:
+            return "#" + h
+        if len(h) == 8:
+            r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+            a = round(int(h[6:8], 16) / 255, 3)
+            return _rgba_key(r, g, b, a)
+        return None
+    m = re.match(r"rgba?\(([^)]*)\)", s)
+    if m:
+        parts = [p.strip() for p in re.split(r"[,/ ]+", m.group(1)) if p.strip()]
+        try:
+            chans = []
+            for i in range(3):
+                p = parts[i]
+                if p.endswith("%"):            # rgb(100%, 50%, 0%) is on a 0-100 scale
+                    chans.append(int(round(float(p[:-1]) / 100 * 255)))
+                else:
+                    chans.append(int(round(float(p))))
+            r, g, b = (min(255, max(0, v)) for v in chans)
+        except (ValueError, IndexError):
+            return None
+        a = 1.0
+        if len(parts) >= 4:
+            try:
+                a = float(parts[3].rstrip("%"))
+                if parts[3].endswith("%"):
+                    a /= 100
+            except ValueError:
+                a = 1.0
+        if a >= 1.0:
+            return "#%02x%02x%02x" % (r, g, b)
+        return _rgba_key(r, g, b, round(a, 3))
+    m = re.match(r"hsla?\(([^)]*)\)", s)
+    if m:
+        return "hsl:" + re.sub(r"\s+", "", m.group(1))
+    return None
+
+
+def _rgba_key(r: int, g: int, b: int, a: float) -> str:
+    astr = ("%.3f" % a).rstrip("0").rstrip(".")
+    return "rgba(%d,%d,%d,%s)" % (r, g, b, astr)
+
+
+# ---------------------------------------------------------------------------
+# Token discovery + parsing.
+# ---------------------------------------------------------------------------
+def discover_token_sources(root: str, cfg: dict) -> List[str]:
+    if cfg["tokenSources"]:
+        return [os.path.join(root, p) for p in cfg["tokenSources"]]
+    found: List[str] = []
+    name_hints = ("token", "theme", "variable", "var", "design", "palette", "color")
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in cfg["ignoreDirs"]]
+        for fn in filenames:
+            low = fn.lower()
+            if low.endswith((".css", ".scss", ".less")) and any(h in low for h in name_hints):
+                found.append(os.path.join(dirpath, fn))
+            elif low.endswith((".json",)) and "token" in low:
+                found.append(os.path.join(dirpath, fn))
+    # Fallback: any css that declares many custom properties.
+    if not found:
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in cfg["ignoreDirs"]]
+            for fn in filenames:
+                if fn.lower().endswith((".css", ".scss")):
+                    p = os.path.join(dirpath, fn)
+                    try:
+                        txt = _read(p)
+                    except OSError:
+                        continue
+                    if len(re.findall(r"--[\w-]+\s*:", txt)) >= 5:
+                        found.append(p)
+    return found
+
+
+def build_token_index(sources: List[str]) -> TokenIndex:
+    idx = TokenIndex()
+    for src in sources:
+        try:
+            text = _read(src)
+        except OSError:
+            continue
+        idx.sources.append(src)
+        pairs: List[Tuple[str, str]] = []
+        if src.lower().endswith(".json"):
+            pairs = _parse_json_tokens(text)
+        else:
+            pairs += re.findall(r"(--[\w-]+)\s*:\s*([^;]+);", text)          # CSS vars
+            pairs += re.findall(r"(\$[\w-]+)\s*:\s*([^;]+);", text)           # SCSS
+            pairs += re.findall(r"(@[\w-]+)\s*:\s*([^;]+);", text)            # Less
+            pairs += re.findall(r"['\"]?([\w-]+)['\"]?\s*:\s*['\"](#[0-9a-fA-F]{3,8})['\"]", text)  # JS theme obj
+        for name, value in pairs:
+            idx.count += 1
+            for m in COLOR_RE.finditer(value):
+                key = normalize_color(m.group(0))
+                if key and key not in idx.by_value:
+                    idx.by_value[key] = _token_ref(name)
+    return idx
+
+
+def _parse_json_tokens(text: str) -> List[Tuple[str, str]]:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+    out: List[Tuple[str, str]] = []
+
+    def walk(node, path):
+        if isinstance(node, dict):
+            if "value" in node and isinstance(node["value"], (str, int, float)):
+                out.append(("-".join(path), str(node["value"])))
+            for k, v in node.items():
+                if k == "value":
+                    continue
+                walk(v, path + [str(k)])
+        elif isinstance(node, str):
+            out.append(("-".join(path), node))
+
+    walk(data, [])
+    return out
+
+
+def _token_ref(name: str) -> str:
+    if name.startswith("--"):
+        return "var(%s)" % name
+    return name  # $scss / @less / js-key referenced as-is in suggestion text
+
+
+# ---------------------------------------------------------------------------
+# File collection.
+# ---------------------------------------------------------------------------
+def collect_files(root: str, cfg: dict, explicit: List[str], staged: bool) -> List[str]:
+    exts = tuple(cfg["scanExtensions"])
+    if cfg["scanStyleSheets"]:
+        exts = exts + (".css", ".scss", ".less")
+
+    def keep(path: str) -> bool:
+        if not path.endswith(exts):
+            return False
+        if any(s in path for s in cfg["ignorePathContains"]):
+            return False
+        norm = path.replace(os.sep, "/")
+        if any(("/%s/" % d) in norm for d in cfg["ignoreDirs"]):
+            return False
+        return True
+
+    if staged:
+        try:
+            out = subprocess.run(
+                ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
+                cwd=root, capture_output=True, text=True, check=True,
+            ).stdout
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            # A gate that silently passes when git can't be queried is a false
+            # green — surface it instead of reporting "nothing to check".
+            print("design-token-guard: --staged could not list staged files "
+                  "(%s); treating as no files." % e, file=sys.stderr)
+            return []
+        staged_files: List[str] = []
+        for rel in out.splitlines():
+            ap = os.path.join(root, rel)
+            if keep(ap):  # keep() needs the joined path so the ignoreDirs "/d/" test matches
+                staged_files.append(ap)
+        return staged_files
+
+    if explicit:
+        files: List[str] = []
+        for p in explicit:
+            ap = p if os.path.isabs(p) else os.path.join(root, p)
+            if os.path.isdir(ap):
+                files += _walk(ap, cfg, keep)
+            elif os.path.isfile(ap) and keep(ap):
+                files.append(ap)
+        return files
+
+    return _walk(root, cfg, keep)
+
+
+def _walk(base: str, cfg: dict, keep) -> List[str]:
+    files: List[str] = []
+    for dirpath, dirnames, filenames in os.walk(base):
+        dirnames[:] = [d for d in dirnames if d not in cfg["ignoreDirs"]]
+        for fn in filenames:
+            p = os.path.join(dirpath, fn)
+            if keep(p):
+                files.append(p)
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Comment masking — blank comment spans while preserving length/newlines so
+# line/col stay accurate. Keeps the color rule from flagging documented hexes.
+# ---------------------------------------------------------------------------
+def mask_comments(text: str) -> str:
+    out = list(text)
+    i, n = 0, len(text)
+    state = None  # None | "line" | "block" | "string"
+    quote = ""
+    while i < n:
+        c = text[i]
+        two = text[i:i + 2]
+        if state is None:
+            if two == "//":
+                state = "line"; out[i] = out[i + 1] = " "; i += 2; continue
+            if two == "/*":
+                state = "block"; out[i] = out[i + 1] = " "; i += 2; continue
+            if text[i:i + 4] == "<!--":        # HTML/Vue/Svelte/Astro comment
+                state = "html"
+                out[i] = out[i + 1] = out[i + 2] = out[i + 3] = " "
+                i += 4; continue
+            if c in "\"'`":
+                state = "string"; quote = c; i += 1; continue
+        elif state == "line":
+            if c == "\n":
+                state = None
+            else:
+                out[i] = " "
+            i += 1; continue
+        elif state == "block":
+            if two == "*/":
+                out[i] = out[i + 1] = " "; state = None; i += 2; continue
+            if c != "\n":
+                out[i] = " "
+            i += 1; continue
+        elif state == "html":
+            if text[i:i + 3] == "-->":
+                out[i] = out[i + 1] = out[i + 2] = " "; state = None; i += 3; continue
+            if c != "\n":
+                out[i] = " "
+            i += 1; continue
+        elif state == "string":
+            if c == "\\":
+                i += 2; continue
+            if c == quote:
+                state = None
+            i += 1; continue
+        i += 1
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Position helpers.
+# ---------------------------------------------------------------------------
+def line_col(text: str, offset: int) -> Tuple[int, int]:
+    line = text.count("\n", 0, offset) + 1
+    last_nl = text.rfind("\n", 0, offset)
+    col = offset - last_nl
+    return line, col
+
+
+def line_at(text: str, offset: int) -> str:
+    start = text.rfind("\n", 0, offset) + 1
+    end = text.find("\n", offset)
+    if end == -1:
+        end = len(text)
+    return text[start:end].strip()
+
+
+# ---------------------------------------------------------------------------
+# Rules. Each returns a list of Finding.
+# ---------------------------------------------------------------------------
+def rule_hardcoded_color(path, rel, raw, masked, idx, cfg, sev) -> List[Finding]:
+    findings = []
+    for m in COLOR_RE.finditer(masked):
+        literal = raw[m.start():m.end()]
+        key = normalize_color(literal)
+        token = idx.by_value.get(key) if key else None
+        if token:
+            msg = "hardcoded color %s is %s" % (literal, token)
+            sugg = "use %s" % token
+        else:
+            msg = "hardcoded color %s is not a declared token" % literal
+            sugg = "add it to a token source, or reuse an existing token"
+        ln, col = line_col(masked, m.start())
+        findings.append(Finding("no-hardcoded-color", sev, rel, ln, col,
+                                line_at(raw, m.start()), msg, sugg))
+    return findings
+
+
+def rule_inline_style(path, rel, raw, masked, idx, cfg, sev) -> List[Finding]:
+    findings = []
+    mode = cfg["inlineStyleMode"]
+    # JSX: style={{ ... }}
+    for m in re.finditer(r"style\s*=\s*\{\{", masked):
+        body, end = _balanced(masked, m.end() - 1)  # start at first '{'
+        if body is None:
+            continue
+        raw_body = raw[m.end():end - 1] if end else raw[m.end():m.end() + len(body)]
+        _maybe_inline_finding(findings, raw, masked, m.start(), raw_body, mode, sev, rel)
+    # HTML/Vue/Svelte/Angular: style="..." or :style / [style]
+    for m in re.finditer(r"""(?::|\[)?style\]?\s*=\s*["']""", masked):
+        q = masked[m.end() - 1]
+        close = masked.find(q, m.end())
+        if close == -1:
+            continue
+        raw_body = raw[m.end():close]
+        _maybe_inline_finding(findings, raw, masked, m.start(), raw_body, mode, sev, rel)
+    return findings
+
+
+def _maybe_inline_finding(findings, raw, masked, start, raw_body, mode, sev, rel):
+    has_color = bool(COLOR_RE.search(raw_body))
+    has_dim = bool(DIM_RE.search(raw_body))
+    if mode == "strict":
+        fire, why = True, "inline style attribute (strict mode forbids all inline styles)"
+    else:
+        # Default: only fire when the inline style carries a hardcoded literal.
+        # Color literals are owned by no-hardcoded-color (more specific +
+        # suggestion), so here we fire for non-color literals like dimensions.
+        if has_dim and not has_color:
+            fire, why = True, "inline style with hardcoded dimension value"
+        elif has_dim and has_color:
+            fire, why = True, "inline style with hardcoded values"
+        else:
+            fire, why = False, ""
+    if fire:
+        ln, col = line_col(masked, start)
+        findings.append(Finding("no-inline-style", sev, rel, ln, col,
+                                line_at(raw, start), why,
+                                "move the value into a token / utility class"))
+
+
+def _balanced(text: str, open_idx: int) -> Tuple[Optional[str], int]:
+    depth = 0
+    i = open_idx
+    n = len(text)
+    while i < n:
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_idx:i + 1], i + 1
+        i += 1
+    return None, 0
+
+
+def rule_class_in_svg(path, rel, raw, masked, idx, cfg, sev) -> List[Finding]:
+    findings = []
+    tag_re = re.compile(r"<(" + "|".join(SVG_PRIMITIVES) + r")\b([^>]*)>", re.DOTALL)
+    for m in tag_re.finditer(masked):
+        attrs = m.group(2)
+        cm = re.search(r"(?:className|class)\s*=\s*[\"'{]([^\"'}]*)", attrs)
+        if cm and re.search(r"[a-z]+-[a-z0-9\[]", cm.group(1)):
+            ln, col = line_col(masked, m.start())
+            findings.append(Finding("no-class-in-svg", sev, rel, ln, col,
+                                    line_at(raw, m.start()),
+                                    "utility classes on <%s> — SVG should use token attrs/vars" % m.group(1),
+                                    "use fill/stroke with var(--token) instead of classes"))
+    return findings
+
+
+def rule_restricted_radius(path, rel, raw, masked, idx, cfg, sev) -> List[Finding]:
+    findings = []
+    maxpx = cfg["maxRadiusPx"]
+    for m in RADIUS_CLASS_RE.finditer(masked):
+        ln, col = line_col(masked, m.start())
+        findings.append(Finding("restricted-radius", sev, rel, ln, col,
+                                line_at(raw, m.start()),
+                                "%s exceeds the %dpx radius cap" % (m.group(0), maxpx),
+                                "use a smaller radius token / utility"))
+    for m in RADIUS_VALUE_RE.finditer(masked):
+        if float(m.group(1)) > maxpx:
+            ln, col = line_col(masked, m.start())
+            findings.append(Finding("restricted-radius", sev, rel, ln, col,
+                                    line_at(raw, m.start()),
+                                    "border-radius %spx exceeds the %dpx cap" % (m.group(1), maxpx),
+                                    "use a radius token"))
+    return findings
+
+
+def rule_forbidden_colors(path, rel, raw, masked, idx, cfg, sev) -> List[Finding]:
+    findings = []
+    pats = [re.compile(p) for p in cfg["forbiddenColors"]]
+    for m in re.finditer(r".+", masked):
+        for p in pats:
+            for hit in p.finditer(m.group(0)):
+                off = m.start() + hit.start()
+                ln, col = line_col(masked, off)
+                findings.append(Finding("forbidden-colors", sev, rel, ln, col,
+                                        line_at(raw, off),
+                                        "forbidden color pattern '%s'" % hit.group(0),
+                                        "use an approved token"))
+    return findings
+
+
+def rule_arbitrary_tailwind(path, rel, raw, masked, idx, cfg, sev) -> List[Finding]:
+    findings = []
+    for m in ARBITRARY_TW_RE.finditer(masked):
+        value = m.group(2)
+        # Colors inside arbitrary values are owned by no-hardcoded-color (it has
+        # the token suggestion); token refs and url() are legitimate, not off-scale.
+        if "var(--" in value or value.startswith("url(") or COLOR_RE.search(value):
+            continue
+        ln, col = line_col(masked, m.start())
+        findings.append(Finding("no-arbitrary-tailwind", sev, rel, ln, col,
+                                line_at(raw, m.start()),
+                                "arbitrary Tailwind value %s bypasses the scale" % m.group(0),
+                                "use a scale/token utility, or add a token for this value"))
+    return findings
+
+
+RULES = {
+    "no-hardcoded-color": rule_hardcoded_color,
+    "no-inline-style": rule_inline_style,
+    "no-class-in-svg": rule_class_in_svg,
+    "restricted-radius": rule_restricted_radius,
+    "forbidden-colors": rule_forbidden_colors,
+    "no-arbitrary-tailwind": rule_arbitrary_tailwind,
+}
+
+
+# ---------------------------------------------------------------------------
+# Driver.
+# ---------------------------------------------------------------------------
+def _read(path: str) -> str:
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        return f.read()
+
+
+def load_config(root: str, config_path: Optional[str]) -> dict:
+    cfg = json.loads(json.dumps(DEFAULT_CONFIG))  # deep copy
+    path = config_path or os.path.join(root, ".design-guard.json")
+    if os.path.isfile(path):
+        try:
+            user = json.loads(_read(path))
+        except (OSError, json.JSONDecodeError) as e:
+            print("design-token-guard: bad config %s: %s" % (path, e), file=sys.stderr)
+            sys.exit(2)
+        for k, v in user.items():
+            if k == "rules" and isinstance(v, dict):
+                cfg["rules"].update(v)
+            else:
+                cfg[k] = v
+    return cfg
+
+
+def run(root: str, cfg: dict, files: List[str], idx: TokenIndex) -> List[Finding]:
+    findings: List[Finding] = []
+    token_srcs = {os.path.abspath(s) for s in idx.sources}
+    for path in files:
+        if os.path.abspath(path) in token_srcs:
+            continue
+        try:
+            raw = _read(path)
+        except OSError:
+            continue
+        masked = mask_comments(raw)
+        rel = os.path.relpath(path, root)
+        for rule_name, fn in RULES.items():
+            sev = cfg["rules"].get(rule_name, "off")
+            if sev == "off":
+                continue
+            findings += fn(path, rel, raw, masked, idx, cfg, sev)
+    findings.sort(key=lambda f: (f.file, f.line, f.col))
+    return findings
+
+
+def report_human(findings, idx, cfg, quiet) -> None:
+    errs = sum(1 for f in findings if f.severity == "error")
+    warns = sum(1 for f in findings if f.severity == "warn")
+    files = len({f.file for f in findings})
+    if not findings:
+        if not quiet:
+            print("design-token-guard: clean — no inline styles or hardcoded CSS found.")
+            _print_footer(idx, cfg)
+        return
+    print("design-token-guard: %d findings (%d error%s, %d warning%s) across %d file%s\n"
+          % (len(findings), errs, "" if errs == 1 else "s",
+             warns, "" if warns == 1 else "s", files, "" if files == 1 else "s"))
+    by_rule: Dict[str, List[Finding]] = {}
+    for f in findings:
+        by_rule.setdefault(f.rule, []).append(f)
+    for rule, items in by_rule.items():
+        sev = items[0].severity
+        print("%s (%s) — %d" % (rule, sev, len(items)))
+        for f in items:
+            print("  %s:%d:%d" % (f.file, f.line, f.col))
+            print("    %s" % f.snippet)
+            line = "    → %s" % f.message
+            if f.suggestion:
+                line += "  ·  %s" % f.suggestion
+            print(line)
+        print("")
+    _print_footer(idx, cfg)
+
+
+def _print_footer(idx, cfg) -> None:
+    src = ", ".join(os.path.basename(s) for s in idx.sources) or "none found"
+    print("Token source: %s (%d tokens, %d color values mapped)"
+          % (src, idx.count, len(idx.by_value)))
+
+
+def report_json(findings, idx, cfg) -> None:
+    errs = sum(1 for f in findings if f.severity == "error")
+    out = {
+        "ok": errs == 0,
+        "summary": {
+            "total": len(findings),
+            "errors": errs,
+            "warnings": sum(1 for f in findings if f.severity == "warn"),
+            "files": len({f.file for f in findings}),
+        },
+        "tokenSources": idx.sources,
+        "tokensIndexed": idx.count,
+        "colorValuesMapped": len(idx.by_value),
+        "findings": [asdict(f) for f in findings],
+    }
+    print(json.dumps(out, indent=2))
+
+
+def main(argv: List[str]) -> int:
+    ap = argparse.ArgumentParser(description="Prevent inline styles and hardcoded CSS.")
+    ap.add_argument("--root", default=".", help="project root (default: cwd)")
+    ap.add_argument("--config", help="path to .design-guard.json")
+    ap.add_argument("--staged", action="store_true", help="scan git-staged files only")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--quiet", action="store_true", help="suppress the clean-run message")
+    ap.add_argument("paths", nargs="*", help="explicit files/dirs to scan")
+    args = ap.parse_args(argv)
+
+    root = os.path.abspath(args.root)
+    if not os.path.isdir(root):
+        print("design-token-guard: --root %s is not a directory" % root, file=sys.stderr)
+        return 2
+
+    cfg = load_config(root, args.config)
+    sources = discover_token_sources(root, cfg)
+    idx = build_token_index(sources)
+    if not idx.sources and not args.json:
+        print("design-token-guard: warning — no token source discovered; "
+              "no-hardcoded-color can flag literals but cannot suggest tokens. "
+              "Set \"tokenSources\" in .design-guard.json.\n", file=sys.stderr)
+
+    files = collect_files(root, cfg, args.paths, args.staged)
+    findings = run(root, cfg, files, idx)
+
+    if args.json:
+        report_json(findings, idx, cfg)
+    else:
+        report_human(findings, idx, cfg, args.quiet)
+
+    return 1 if any(f.severity == "error" for f in findings) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/workflows/use-freellmapi/SKILL.md
+++ b/skills/workflows/use-freellmapi/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: use-freellmapi
+version: 1.1.0
+description: |
+  Wire any project to FreeLLMAPI — a local OpenAI-compatible proxy that aggregates 19 free LLM provider
+  tiers (~1.7B+ tokens/month) behind one endpoint — so you can prototype without paying for API calls.
+  Use when a user wants to switch a project off paid OpenAI/Anthropic/etc. onto free models, point an app
+  at a local LLM proxy, cut their LLM bill for prototyping, or stand up FreeLLMAPI itself. Detects the
+  project's current LLM client (OpenAI or Anthropic SDK, LangChain, LlamaIndex, Vercel AI SDK, Continue,
+  raw HTTP), ensures the proxy is running (installs it if missing), rewires base_url + api_key behind an
+  env toggle so you can flip back, and verifies with a live test call. Trigger on "use the free llm api",
+  "use freellmapi", "switch this to free models", "point this at freellmapi", "stop paying for openai
+  here", "free llm proxy", "prototype without api costs", "configure this for the free llm api".
+requires_agent_teams: false
+requires_claude_code: false
+min_plan: starter
+owns:
+  directories: []
+  patterns: []
+  shared_read: ["*"]
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+composes_with: ["project-profiler"]
+spawned_by: []
+metadata:
+  author: ivy00johns
+  category: workflows
+  tags: [llm, prototyping, openai-compatible, freellmapi, free-tier]
+  documentation: https://github.com/tashfeenahmed/freellmapi
+---
+
+# use-freellmapi
+
+Point a project at **FreeLLMAPI** — a local proxy that aggregates the free tiers of 19 LLM providers
+(Google, Groq, Cerebras, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, HuggingFace, Z.ai,
+Ollama Cloud, NVIDIA, Kilo, Pollinations, LLM7, OpenCode Zen, OVH, Agnes AI, Reka) behind a single
+OpenAI-compatible endpoint. A router picks the best available model per request and fails over when one
+is rate-limited. The payoff: prototype against real models for free, with zero code changes beyond a
+base URL and a key.
+
+## The whole integration, in three facts
+
+FreeLLMAPI is an **OpenAI-compatible** proxy. Wiring a project to it is almost always just three values:
+
+| What | Value |
+| --- | --- |
+| **base_url** | `http://localhost:3001/v1` (default; `PORT` may differ) |
+| **api_key** (bearer) | `freellmapi-…` — the proxy's single *unified key* |
+| **model** | `"auto"` — let the router pick and fail over; pin one like `"gemini-2.5-flash"`; or `"fusion"` to blend a panel of models into one answer |
+
+Because the surface is OpenAI-compatible, any OpenAI client library works unchanged — chat, streaming,
+tool calling, vision, and embeddings all route through the same endpoint. The proxy also accepts the
+**Anthropic-style `x-api-key` header**, so Anthropic SDK clients can point at it too (use the unified
+key as the `x-api-key`). Everything past this point is about doing the swap *cleanly, reversibly, and
+verified* — not about anything exotic.
+
+> Read `references/capabilities.md` for the exact supported surface (endpoints, the two virtual models
+> `auto` and `fusion`, embeddings families, vision/tools) and the short list of things FreeLLMAPI does
+> **not** do yet (image generation, audio, legacy `/v1/completions`, moderation, `n > 1`). Check it
+> before promising a capability.
+
+## Workflow
+
+Work top to bottom. Steps 1–2 stand up the proxy and confirm it can actually serve a request; steps
+3–5 rewire the project and prove it works end to end. Don't skip the verify — "it should work" is not
+the same as a 200 with a completion in it.
+
+### Step 1 — Make sure the proxy is running
+
+Probe the unauthenticated liveness endpoint:
+
+```bash
+curl -fsS http://localhost:3001/api/ping
+# {"status":"ok","timestamp":"..."}  → running, go to Step 2
+```
+
+If nothing answers, install and start it with the official one-liner (needs Docker running):
+
+```bash
+curl -fsSL https://tashfeenahmed.github.io/freellmapi/install.sh | bash
+```
+
+This sets up `~/freellmapi`, generates an at-rest `ENCRYPTION_KEY`, pulls
+`ghcr.io/tashfeenahmed/freellmapi:latest`, starts the container on `:3001`, and waits for `/api/ping`.
+Re-running is safe — it preserves the existing `.env`. When it finishes, probe `/api/ping` again to
+confirm. If Docker isn't available, fall back to a source install (`git clone` + `npm install` +
+`npm run dev`); see the repo README's *Local development* section.
+
+If the user already runs it on a non-default port or another host, use that `base_url` everywhere below.
+
+### Step 2 — Get the unified key and make sure a provider can serve requests
+
+**Unified key** (`freellmapi-…`): the single bearer token your app uses. Get it from:
+
+- the **Keys page header** at `http://localhost:3001` (the dashboard), or
+- the first-run container logs:
+  `cd ~/freellmapi && docker compose logs 2>&1 | grep -i "unified api key"`
+
+**A fresh proxy has no provider keys, so chat requests fail until at least one provider is enabled.**
+This is the one part you can't do for the user — adding keys and toggling providers happens in the
+browser dashboard. Make it explicit and offer to wait. Two paths:
+
+- **Fastest, zero-key smoke test:** on the dashboard, enable a **keyless** provider — Pollinations
+  (GPT-OSS 20B), Kilo `:free`, or OVH work with no API key at all. Good enough to prove the pipe end to
+  end in under a minute.
+- **Real prototyping:** add free provider keys on the **Keys** page (Google AI Studio, Groq, Cerebras,
+  etc. — each has a free signup), then reorder the **Fallback Chain** to taste.
+
+Hold here until the user confirms at least one provider is enabled — otherwise Step 5 will fail with a
+"no model available" error and look like a wiring bug when it isn't.
+
+### Step 3 — Detect the project's current LLM wiring
+
+Find how the project talks to an LLM today so you pick the right recipe and the smallest diff:
+
+```bash
+# language + client library + where the client is built
+# (quote the --include globs — zsh expands bare *.py before grep sees it and the command fails)
+grep -rniE "openai|anthropic|langchain|llama_?index|@?ai-sdk|base_?url|api_?key" \
+  --include="*.py" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.mjs" . \
+  | grep -viE "node_modules|/dist/|/build/" | head -40
+```
+
+Determine: the language (Python / JS-TS), the client library, the file(s) where the client is
+constructed, and where its `base_url` / `api_key` / `model` come from (env vars vs hardcoded). Then open
+`references/recipes.md` and read **only the section for the detected stack** — it has copy-paste wiring
+for OpenAI (Python/Node), LangChain, LlamaIndex, Vercel AI SDK, Continue, raw HTTP/curl, and the
+Anthropic-SDK-via-`x-api-key` case.
+
+### Step 4 — Rewire it, reversibly (the env-toggle pattern)
+
+The point of prototyping with free models is that you'll flip *back and forth* — free models for cheap
+iteration, the paid provider for a quality check or a demo. A hardcoded swap forces a code edit every
+time and risks losing the original config. So **drive the three values from environment variables and
+keep the original provider as a documented fallback**, rather than editing call sites.
+
+Concretely:
+
+1. Introduce (or reuse) env vars for the base URL, key, and model. Many OpenAI clients already read
+   `OPENAI_BASE_URL` / `OPENAI_API_KEY` from the environment, so reusing those names is ideal. But "no
+   code change at all" only holds when **both** are true: (a) the client is built with no explicit
+   `base_url`/`api_key` args, **and** (b) something actually loads `.env` into the process — a shell
+   `set -a; source .env`, a process manager's `env_file`, or a dotenv loader the app already calls.
+   Plain Python and plain Node do **not** auto-read a `.env` file. If neither is true (very common — a
+   prototype with the key hardcoded, and no dotenv), you will edit the call site and/or add a loader;
+   that's expected, not a failure. Each recipe in `references/recipes.md` notes how its stack loads env.
+2. Point the client constructor at those env vars instead of literals (only if it wasn't already).
+3. In `.env`, set them to the FreeLLMAPI values and **keep the original provider's values commented
+   right above them**, labeled, so flipping back is uncommenting two lines:
+
+   ```dotenv
+   # --- FreeLLMAPI (free, local proxy) — active ---
+   OPENAI_BASE_URL=http://localhost:3001/v1
+   OPENAI_API_KEY=freellmapi-xxxxxxxxxxxxxxxxxxxxxxxx
+   LLM_MODEL=auto
+
+   # --- Original provider (paid) — flip back by swapping which block is active ---
+   # OPENAI_BASE_URL=https://api.openai.com/v1
+   # OPENAI_API_KEY=sk-...
+   # LLM_MODEL=gpt-4o-mini
+   ```
+
+4. Default the model to `"auto"` so the router chooses and fails over, but keep the option to pin a
+   specific model where a call needs a known capability (e.g. a vision model).
+5. Write or update a committed **`.env.example`** with the same two labeled blocks but placeholder
+   values (`freellmapi-xxxx`, `sk-...`). Without it, moving a hardcoded key into `.env` leaves the repo
+   with no record of which env vars it now needs — the example is the documentation.
+
+Show the user the `.env` block and the (usually tiny) code diff. Never write a real provider key into a
+file that's tracked by git — confirm `.env` is gitignored, and if a key was previously hardcoded in
+source, move it to `.env` as part of this step.
+
+### Step 5 — Verify with a live call
+
+Prove the pipe works before declaring success. First a direct smoke test (substitute the real key):
+
+```bash
+curl -i -s http://localhost:3001/v1/chat/completions \
+  -H "Authorization: Bearer freellmapi-xxxx" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"Reply with the single word: ok"}]}'
+```
+
+A healthy response is a `200` with a chat completion, and an **`X-Routed-Via: <platform>/<model>`**
+header telling you which provider actually served it. Then run the **project's own** code path (its
+test, its entry script, a representative call) so you've confirmed the app — not just curl — talks to
+the proxy.
+
+Map failures to causes instead of guessing:
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `401` invalid API key | wrong/missing unified key | re-copy it from the dashboard Keys header |
+| `4xx` no model / no provider | no provider enabled on the proxy | back to Step 2 — enable a provider |
+| `429` | the picked key is rate-limited | router fails over; add more provider keys for headroom |
+| connection refused | proxy not running / wrong port | back to Step 1; check `PORT` |
+
+### Step 6 — Hand off
+
+Tell the user, briefly: how to flip back (uncomment the original `.env` block), where the dashboard is
+(`http://localhost:3001` — manage keys, reorder the fallback chain or save named **routing profiles**
+that auto-sort by intelligence/speed/budget, watch analytics, use the playground), what `model:"auto"`
+does, that `model:"fusion"` blends a panel of models for a quality bump on hard prompts, and the
+relevant **not-supported** caveats from `references/capabilities.md` if their project uses image
+generation, audio, legacy completions, moderation, or `n > 1` (those won't route — they'll need the
+real provider for those calls).
+
+## References
+
+- **`references/recipes.md`** — per-framework, copy-paste env-toggle wiring. Read the one section that
+  matches the detected stack; ignore the rest.
+- **`references/capabilities.md`** — exact supported surface (chat, streaming, tools, vision,
+  embeddings + their families, the Responses API shim), plus the not-supported list and gotchas
+  (sticky sessions, fresh-install-has-no-keys, anonymous providers, the `X-Routed-Via` header).

--- a/skills/workflows/use-freellmapi/references/capabilities.md
+++ b/skills/workflows/use-freellmapi/references/capabilities.md
@@ -1,0 +1,143 @@
+# FreeLLMAPI capabilities & gotchas
+
+What the proxy can serve, what it can't, and the behaviors that surprise people. Check this before
+promising a project a capability — if the project's LLM calls need something on the **not-supported**
+list, those specific calls won't route through the proxy and still need the real provider.
+
+## Supported endpoints
+
+| Endpoint | Notes |
+| --- | --- |
+| `POST /v1/chat/completions` | The main surface. Streaming + non-streaming. |
+| `POST /v1/responses` | OpenAI **Responses API** shim (the wire format current Codex CLI needs), translated over the same router. Image *input* not supported here yet — use chat completions for vision. |
+| `POST /v1/embeddings` | Family-based routing (see below). |
+| `GET  /v1/models` | Lists available models. |
+| `GET  /api/ping` | Unauthenticated liveness — `{"status":"ok"}`. Use this to detect "is it running". |
+
+**Auth:** every `/v1` call needs the unified key (`freellmapi-…`), accepted as either
+`Authorization: Bearer <key>` or `x-api-key: <key>`. The `/api/*` dashboard routes use a separate
+email+password session and are not what apps talk to.
+
+## Routing behavior
+
+- **`model: "auto"`** (or omitting `model`) → the router scores enabled models and picks the best one
+  that's under its rate caps, then **fails over** to the next in the fallback chain on a 429/5xx/timeout
+  (up to ~20 attempts). You can also pin a specific id like `gemini-2.5-flash`.
+- **`X-Routed-Via: <platform>/<model>`** response header tells you which provider actually served the
+  call; `X-Fallback-Attempts: N` appears if it fell over between providers. Great for debugging "why is
+  this answer weird" — check which model you actually got.
+- **Sticky sessions:** a multi-turn conversation keeps hitting the same model for 30 minutes (avoids
+  the hallucination spike from mid-conversation model switches). Agent harnesses that manage their own
+  conversation ids can pin affinity with an `X-Session-Id` header.
+- **Per-IP proxy rate limit:** default 120 req/min per client IP (`PROXY_RATE_LIMIT_RPM`, `0` disables).
+- **`/v1/models` advertises context windows.** Each model — and `auto` itself (reporting the largest
+  window among currently-available models) — carries `context_window` and `context_length`, so clients
+  that size their input off the model list (Continue, some agent harnesses) stop truncating against a
+  stale default.
+
+## Virtual models
+
+Two model ids aren't real models — they're router behaviors you select by name. Both show up in
+`/v1/models` and are available whenever at least one routable model is connected.
+
+- **`auto`** — the default. The router picks the best enabled model for the request and fails over down
+  the fallback chain. Use it unless a call needs a specific capability (then pin an id).
+- **`fusion`** — multi-model synthesis. The prompt fans out to a panel of *diverse* models in parallel,
+  then a judge model blends their answers into one. The point: for a hard reasoning/writing prompt you
+  get an answer better than any single free model, still for free. Invoke it like any model and tune it
+  with an optional `fusion` object:
+
+  ```json
+  {
+    "model": "fusion",
+    "messages": [{"role": "user", "content": "..."}],
+    "fusion": {
+      "models": ["gemini-2.5-flash", "llama-3.3-70b"],
+      "k": 4,
+      "judge": "gemini-2.5-pro",
+      "strategy": "synthesize",
+      "expose_panel": true
+    }
+  }
+  ```
+
+  Every field is optional. `models` pins the panel (otherwise it auto-picks `k` diverse models, default
+  4, hard max 8, one per platform first). `judge` pins the synthesizer (otherwise the top-ranked
+  available model). `strategy` is `synthesize` (default, judge blends) or `best_of` (skip the judge,
+  return the longest single panel answer — cheaper, no extra call). `expose_panel: true` attaches the
+  per-model answers under `x_fusion`; a lightweight `_fusion` summary (which models + judge) is always
+  included. Streaming works (it emits additive `_fusion` frames standard OpenAI clients ignore).
+  **Fusion does not support image input or tool calling yet** — those return a clear `422`
+  (`fusion_no_vision` / `fusion_no_tools`); use a vision/tool-capable model directly for those.
+
+## Tool calling
+
+OpenAI-style `tools` / `tool_choice` pass through, and the full multi-step flow round-trips
+(assistant `tool_calls` → `tool` role follow-up → final answer) across every provider the router
+reaches. OpenAI-compatible providers get the request passed through; Gemini requests are translated to
+Google's `functionDeclarations` shape and back. Works with `stream: true`. A Gemini-only extra: pass a
+tool named `google_search` (aliases `googlesearch` / `google_search_retrieval`) and the proxy maps it to
+Gemini's native Google Search grounding, so a Gemini route can answer with fresh web results.
+
+## Vision
+
+Send images as standard OpenAI `image_url` content blocks (base64 `data:` URLs or `http(s)` URLs).
+When a request contains an image, the router **restricts itself to vision-capable models** and ignores
+text-only ones. If no vision model is enabled, the request returns a clear `422` (`code:
+"no_vision_model"`) rather than dropping the image silently. Image input is **chat-completions only**,
+not `/v1/responses`.
+
+## Embeddings
+
+`/v1/embeddings` is OpenAI-compatible with one deliberate rule: **failover never crosses models.**
+Vectors from different models live in incompatible spaces, so embeddings route by **family** (one model
+identity + dimension) and only fail over among providers serving that same family. Pick one family per
+vector store and stick with it.
+
+| Family (`model`) | Dims | Providers (failover order) |
+| --- | --- | --- |
+| `gemini-embedding-001` *(default)* | 3072 | Google |
+| `text-embedding-3-large` | 3072 | GitHub Models |
+| `llama-nemotron-embed-vl-1b-v2` *(vision-language)* | 2048 | NVIDIA → OpenRouter |
+| `llama-nemotron-embed-1b-v2` | 2048 | NVIDIA |
+| `text-embedding-3-small` | 1536 | GitHub Models |
+| `embed-v4.0` *(disabled by default)* | 1536 | Cohere |
+| `bge-m3` | 1024 | Cloudflare → Hugging Face |
+| `qwen3-embedding-0.6b` | 1024 | Cloudflare |
+| `nv-embedqa-e5-v5` | 1024 | NVIDIA |
+| `embeddinggemma-300m` | 768 | Cloudflare |
+
+`model` accepts `auto` (the configured default family — `gemini-embedding-001` out of the box), a family
+name, or a provider-specific id (which resolves to its family). The default family and per-provider
+toggles live on the dashboard's **Models → Embeddings** page. Two things worth flagging to the user:
+**`embed-v4.0` (Cohere) ships disabled** — it shares Cohere's tight 1K-calls/month chat quota, so enable
+it deliberately. And `llama-nemotron-embed-vl-1b-v2` is a **vision-language** family that can embed
+images as well as text — the only multimodal embedder in the catalog. The proxy normalizes each
+provider's native embedding quirks (NVIDIA's `input_type`, Cohere's `/v2/embed`, Hugging Face's
+feature-extraction shape) behind the OpenAI request format, so the client just sends `{model, input}`.
+
+## Not supported yet
+
+These have no route — calls to them fail, so the project still needs the real provider for them:
+
+- **Image generation** (`/v1/images/*`)
+- **Audio / speech** (`/v1/audio/*`)
+- **Legacy completions** (`/v1/completions`) — only the *chat* endpoint exists
+- **Moderation** (`/v1/moderations`)
+- **`n > 1`** (multiple completions per request)
+- **Per-user billing / multi-tenant auth** — single-user by design
+
+## Gotchas worth saying out loud
+
+- **A fresh proxy serves nothing until a provider is enabled.** No keys = every chat request 4xx's with
+  "no model available." This looks exactly like a wiring bug but isn't. Add a provider first.
+- **Keyless providers** (Pollinations GPT-OSS 20B, Kilo `:free`, OVH) need no API key at all — the proxy
+  sends no auth header upstream. Enable one on the dashboard for an instant zero-config smoke test.
+  (LLM7 also has an anonymous free tier but isn't registered keyless — it may carry a shared key.)
+- **Free tiers are rate-limited and uneven.** Latency and quality vary by which provider served a call
+  (`X-Routed-Via`). Add several provider keys so the router has headroom to fail over. This is a
+  *prototyping* tool, not a production SLA.
+- **The unified key is per-install**, stored in the proxy's SQLite, shown on the dashboard Keys header.
+  Regenerating it on the dashboard invalidates the old one — update the app's `.env` if you do.
+- **Localhost only by default.** The container binds `127.0.0.1`. To reach it from another device, start
+  with `HOST_BIND=0.0.0.0` — only on a trusted LAN, since the proxy is single-user.

--- a/skills/workflows/use-freellmapi/references/recipes.md
+++ b/skills/workflows/use-freellmapi/references/recipes.md
@@ -1,0 +1,274 @@
+# Wiring recipes
+
+Per-framework, env-toggle wiring for FreeLLMAPI. Read **only** the section matching the project's
+detected stack. Every recipe uses three values from the environment so the swap is reversible (see
+SKILL.md Step 4):
+
+- `OPENAI_BASE_URL` → `http://localhost:3001/v1`
+- `OPENAI_API_KEY` → `freellmapi-…` (the unified key)
+- model → `auto` (router picks + fails over) or a pinned id
+
+Anything not listed here still works via the same base-url swap — these are just the common cases.
+
+## Contents
+
+- [OpenAI Python SDK](#openai-python-sdk)
+- [OpenAI Node / TypeScript SDK](#openai-node--typescript-sdk)
+- [LangChain (Python)](#langchain-python)
+- [LangChain (JS/TS)](#langchain-jsts)
+- [LlamaIndex (Python)](#llamaindex-python)
+- [Vercel AI SDK](#vercel-ai-sdk)
+- [Continue (VS Code / JetBrains)](#continue-vs-code--jetbrains)
+- [Raw HTTP / curl / fetch / requests](#raw-http--curl--fetch--requests)
+- [Embeddings (vector stores / RAG)](#embeddings-vector-stores--rag)
+- [Anthropic SDK via x-api-key](#anthropic-sdk-via-x-api-key)
+
+---
+
+## OpenAI Python SDK
+
+The SDK already reads `OPENAI_BASE_URL` and `OPENAI_API_KEY` from the environment — **but only if
+those vars are actually in the process environment.** Plain Python does not read a `.env` file on its
+own. So "only the `.env`, no code change" holds when the app is started through something that injects
+env (Docker `env_file`, a framework, or `set -a; source .env && python app.py`). For a standalone
+script with no loader, add `python-dotenv` (one line) so the `.env` is honored:
+
+```dotenv
+OPENAI_BASE_URL=http://localhost:3001/v1
+OPENAI_API_KEY=freellmapi-xxxx
+LLM_MODEL=auto
+```
+
+```python
+from dotenv import load_dotenv   # add `python-dotenv` to requirements
+load_dotenv()                    # call once at startup, before constructing the client
+```
+
+If the client passes them explicitly, route through the env (and prefer `model=auto`):
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url=os.environ["OPENAI_BASE_URL"],   # http://localhost:3001/v1
+    api_key=os.environ["OPENAI_API_KEY"],     # freellmapi-...
+)
+
+resp = client.chat.completions.create(
+    model=os.getenv("LLM_MODEL", "auto"),
+    messages=[{"role": "user", "content": "..."}],
+)
+print("routed via:", resp.headers.get("x-routed-via"))   # which provider served it
+```
+
+Streaming, `tools`/`tool_choice`, and `image_url` content blocks all pass through unchanged.
+
+## OpenAI Node / TypeScript SDK
+
+Same idea — the SDK reads `OPENAI_BASE_URL` / `OPENAI_API_KEY` from `process.env`, **if they're loaded**.
+Node doesn't read `.env` by default either: start with `node --env-file=.env app.js` (Node 20.6+), add
+`import "dotenv/config";` at the top, or rely on your framework (Next.js loads `.env` automatically).
+
+```ts
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: process.env.OPENAI_BASE_URL,   // http://localhost:3001/v1
+  apiKey: process.env.OPENAI_API_KEY,     // freellmapi-...
+});
+
+const resp = await client.chat.completions.create({
+  model: process.env.LLM_MODEL ?? "auto",
+  messages: [{ role: "user", content: "..." }],
+});
+```
+
+## LangChain (Python)
+
+`ChatOpenAI` honors `OPENAI_BASE_URL` / `OPENAI_API_KEY`, or pass `base_url` / `api_key` directly:
+
+```python
+import os
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    base_url=os.environ["OPENAI_BASE_URL"],   # http://localhost:3001/v1
+    api_key=os.environ["OPENAI_API_KEY"],     # freellmapi-...
+    model=os.getenv("LLM_MODEL", "auto"),
+)
+```
+
+For embeddings, use `OpenAIEmbeddings(base_url=..., api_key=..., model="auto")` — but pin **one**
+embeddings family for a given vector store (see `capabilities.md` → Embeddings; failover never crosses
+models, so vectors stay compatible).
+
+## LangChain (JS/TS)
+
+```ts
+import { ChatOpenAI } from "@langchain/openai";
+
+const llm = new ChatOpenAI({
+  configuration: { baseURL: process.env.OPENAI_BASE_URL }, // http://localhost:3001/v1
+  apiKey: process.env.OPENAI_API_KEY,                      // freellmapi-...
+  model: process.env.LLM_MODEL ?? "auto",
+});
+```
+
+Note the base URL goes inside `configuration` for the JS client.
+
+## LlamaIndex (Python)
+
+```python
+import os
+from llama_index.llms.openai import OpenAI
+
+llm = OpenAI(
+    api_base=os.environ["OPENAI_BASE_URL"],   # http://localhost:3001/v1  (note: api_base)
+    api_key=os.environ["OPENAI_API_KEY"],     # freellmapi-...
+    model=os.getenv("LLM_MODEL", "auto"),
+)
+```
+
+LlamaIndex sometimes validates model names against a known list and may reject `auto` or a non-OpenAI
+id with a context-window lookup error. The proxy now advertises `context_window`/`context_length` on
+`/v1/models` (so most clients stop truncating), but LlamaIndex's *name* validation is a separate check —
+if it still trips, pin a known OpenAI-shaped id the proxy serves (e.g. a GitHub Models `gpt-4o`) or pass
+`context_window=...` explicitly to bypass the metadata lookup.
+
+## Vercel AI SDK
+
+Use the OpenAI-compatible provider factory so you control the base URL:
+
+```ts
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText } from "ai";
+
+const freellm = createOpenAI({
+  baseURL: process.env.OPENAI_BASE_URL,   // http://localhost:3001/v1
+  apiKey: process.env.OPENAI_API_KEY,     // freellmapi-...
+});
+
+const { text } = await generateText({
+  model: freellm(process.env.LLM_MODEL ?? "auto"),
+  prompt: "...",
+});
+```
+
+`@ai-sdk/openai-compatible` works too; either way the only thing that matters is `baseURL` + `apiKey`.
+
+## Continue (VS Code / JetBrains)
+
+Edit `~/.continue/config.json` (or `config.yaml`) and add an OpenAI-compatible model entry:
+
+```json
+{
+  "models": [
+    {
+      "title": "FreeLLMAPI (auto)",
+      "provider": "openai",
+      "model": "auto",
+      "apiBase": "http://localhost:3001/v1",
+      "apiKey": "freellmapi-xxxx"
+    }
+  ]
+}
+```
+
+Keep the original model entry in the list — Continue lets you switch models from its dropdown, so both
+the free proxy and the paid provider can coexist with no flipping required.
+
+## Raw HTTP / curl / fetch / requests
+
+If the project hand-rolls requests, change the URL, the `Authorization` header, and the `model` field.
+Nothing else about the OpenAI request/response shape changes.
+
+```bash
+curl http://localhost:3001/v1/chat/completions \
+  -H "Authorization: Bearer freellmapi-xxxx" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"hi"}]}'
+```
+
+Pull the base URL and key from env (`os.environ`, `process.env`) rather than inlining them, so the
+env-toggle still applies.
+
+## Embeddings (vector stores / RAG)
+
+The same base-url swap routes `/v1/embeddings`, so any OpenAI-style embeddings client works unchanged.
+The one rule that makes or breaks an embeddings swap: **failover never crosses embedding models** —
+vectors from different models live in incompatible spaces. So the proxy routes embeddings by *family*
+(one model identity + dimension) and only fails over among providers serving that same family. The
+practical consequence for the project: **pick one family, write it down, and reuse it for every vector
+that lands in the same store.** A store half-embedded with `gemini-embedding-001` (3072-dim) and half
+with `bge-m3` (1024-dim) can't even be queried — the dimensions don't match. See `capabilities.md` →
+Embeddings for the full family table.
+
+The cleanest pattern is a dedicated env var for the embedding model, separate from the chat model, so
+the family is pinned explicitly and never silently drifts to the default:
+
+```dotenv
+OPENAI_BASE_URL=http://localhost:3001/v1
+OPENAI_API_KEY=freellmapi-xxxx
+LLM_MODEL=auto                         # chat: let the router pick
+EMBED_MODEL=gemini-embedding-001       # embeddings: pin ONE family for the whole store
+```
+
+**OpenAI Python SDK:**
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url=os.environ["OPENAI_BASE_URL"],   # http://localhost:3001/v1
+    api_key=os.environ["OPENAI_API_KEY"],     # freellmapi-...
+)
+
+resp = client.embeddings.create(
+    model=os.getenv("EMBED_MODEL", "gemini-embedding-001"),  # pinned family, not "auto"
+    input=["first chunk", "second chunk"],    # string or list of strings; batch when you can
+)
+vectors = [d.embedding for d in resp.data]
+```
+
+**OpenAI Node / TypeScript SDK:**
+
+```ts
+const resp = await client.embeddings.create({
+  model: process.env.EMBED_MODEL ?? "gemini-embedding-001",
+  input: ["first chunk", "second chunk"],
+});
+const vectors = resp.data.map(d => d.embedding);
+```
+
+**LangChain / LlamaIndex:** point `OpenAIEmbeddings(base_url=..., api_key=..., model="<family>")`
+(LangChain) or the framework's embedding class at the same base URL and key, with the family pinned.
+
+Notes that save a debugging session:
+
+- **`auto` for embeddings resolves to the default family** (`gemini-embedding-001`). That's fine for a
+  fresh store, but pinning the family explicitly is safer — if someone changes the dashboard default
+  later, `auto` would start writing incompatible vectors into an existing store.
+- **Match the family to the provider keys that are enabled.** `gemini-embedding-001` needs a Google
+  key; `text-embedding-3-*` needs GitHub Models; `bge-m3` is keyless-ish via Cloudflare. If the chosen
+  family's providers aren't enabled, the call 4xx's exactly like the fresh-install-no-keys case.
+- **Re-embedding cost is real but free here** — if you must switch families, re-embed the *entire*
+  store, don't mix. Being on a free proxy is what makes that bulk re-embed painless.
+- **`llama-nemotron-embed-vl-1b-v2` can embed images too** (vision-language) — reach for it only if the
+  store genuinely needs multimodal vectors; for plain text the default is simpler.
+
+## Anthropic SDK via x-api-key
+
+FreeLLMAPI's `/v1` surface also accepts the Anthropic-style `x-api-key` header — but it speaks the
+**OpenAI** wire format, not Anthropic's `/v1/messages` schema. So:
+
+- A client that just needs *an* LLM and was using the Anthropic SDK is cleanest to **switch to the
+  OpenAI SDK** pointed at the proxy (use one of the recipes above). Pass the unified key; it's accepted
+  via either `Authorization: Bearer` or `x-api-key`.
+- The Anthropic Messages API shape (`/v1/messages`, `content` blocks, `system` top-level) is **not**
+  translated by the proxy. Don't promise a drop-in Anthropic-SDK swap that keeps `/v1/messages`.
+
+For Claude Code / Anthropic-wire agents specifically, routing tools (e.g. CC Switch) send the key as
+`x-api-key`, which the proxy handles — but the request body must still be OpenAI-shaped chat
+completions to route.


### PR DESCRIPTION
## Summary

- Adds two new workflow skills (catalog 51 → 53), each already through a quality pass.
- **design-token-guard** — a *source-level* gate for hardcoded colors / inline styles that render gates can't see (a hex renders identically to its token), wired into the orchestrator wave-gate and frontend-agent definition-of-done.
- **use-freellmapi** — wire any project to the FreeLLMAPI local OpenAI-compatible proxy behind a reversible env toggle, so you can prototype on free models without code changes.

## Changes

**New skills**
- `design-token-guard` — auto-discovering Python checker + ESLint subset + pre-commit hook + CI step; config/scaffolding/orchestrator-wiring references.
- `use-freellmapi` — per-framework recipes (OpenAI/LangChain/LlamaIndex/Vercel AI SDK/Continue/raw HTTP/Anthropic-`x-api-key`) + an honest capabilities/not-supported reference.

**Checker hardening** (`check_design_tokens.py`)
- Mask `<!-- -->` HTML/Vue/Svelte/Astro comments so documented hexes don't false-flag.
- Fix `--staged` so files inside ignored dirs aren't scanned, and warn (instead of silently passing — a false green) when git can't be queried.
- Normalize percentage `rgb(100%, 0%, 50%)` to the correct hex so it matches declared tokens.

**Wiring + docs**
- frontend-agent: design-token discipline added to SKILL.md + validation-checklist.
- orchestrator: wave-gate false-green traps (dirty cache, wrapped exit codes, scoped tests, dev-vs-prod e2e), inline-changelog anti-pattern, scaffold-gates-at-bootstrap guidance, ultracode/Fable 5 corrections (`v1.10.0 → 1.11.0`).
- Catalog reconciled to 53 via `scripts/catalog.sh --sync` (README/plugin.json/marketplace/CLAUDE/PLAN/START-HERE + plugin.json skills array).

## Scope note

The orchestrator **subagent-type-mapping** fix is intentionally left to #22 — this branch does **not** touch `references/agent-spawning.md`, and the duplicate anti-pattern row was removed to avoid overlap.

## Test plan

- [x] `scripts/catalog.sh --check` — clean (total = 53)
- [x] `scripts/lint-skills.sh` — 0 errors on a clean tree (the only local errors come from gitignored `node_modules` / skill-creator `*-workspace`, absent on CI)
- [x] `tests/catalog/07-catalog-invariant.bats` — 13/13
- [x] `tests/standard/01-standard.bats` — green on a clean tree
- [x] `python3 -m py_compile check_design_tokens.py`; the three checker fixes verified with live HTML-comment / rgb% / `--staged`-ignored-dir cases
- [ ] Reviewer: confirm CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsmrmoh7x1htYKtebar1vs