### PR TITLE
feat: Add orchestrator-task-loop loops skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/ivy00johns"
   },
   "metadata": {
-    "description": "All the skills, all the agents, all the chaos — a contract-first multi-agent orchestrator and the 55-skill library it draws from.",
+    "description": "All the skills, all the agents, all the chaos — a contract-first multi-agent orchestrator and the 56-skill library it draws from.",
     "version": "0.1.0",
     "homepage": "https://github.com/ivy00johns/Skill-Madness",
     "license": "MIT"
@@ -15,7 +15,7 @@
     {
       "name": "skill-madness",
       "source": "./",
-      "description": "Install all 55 Skill-Madness skills: the 14-phase orchestrator, 9 role agents with exclusive file ownership, 3 contract skills (OpenAPI/AsyncAPI/Pydantic/TS/JSON Schema), 5 git workflow skills, 9 meta/skill-management skills, 13 cross-cutting workflows (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …), and the interactive-doc workflow.",
+      "description": "Install all 56 Skill-Madness skills: the 14-phase orchestrator, 9 role agents with exclusive file ownership, 3 contract skills (OpenAPI/AsyncAPI/Pydantic/TS/JSON Schema), 5 git workflow skills, 9 meta/skill-management skills, 13 cross-cutting workflows (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …), and the interactive-doc workflow.",
       "version": "0.1.0",
       "author": {
         "name": "ivy00johns"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-madness",
-  "description": "Contract-first multi-agent orchestrator with 55 skills: a 14-phase orchestrator that authors machine-readable contracts before code, dispatches 10 role agents in parallel with exclusive file ownership, and blocks the merge on a structured QA report. Plus meta-skills, git conventions, and cross-cutting workflow tools (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …).",
+  "description": "Contract-first multi-agent orchestrator with 56 skills: a 14-phase orchestrator that authors machine-readable contracts before code, dispatches 10 role agents in parallel with exclusive file ownership, and blocks the merge on a structured QA report. Plus meta-skills, git conventions, and cross-cutting workflow tools (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, llm-wiki, …).",
   "version": "0.1.0",
   "author": {
     "name": "ivy00johns",
@@ -81,6 +81,7 @@
     "./skills/workflows/use-freellmapi",
 
     "./skills/loops/fix-until-green",
-    "./skills/loops/loop-controller"
+    "./skills/loops/loop-controller",
+    "./skills/loops/orchestrator-task-loop"
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A multi-agent orchestration toolkit for Claude Code — 55 OSS-publishable skills in `skills/`. Skills are symlinked to `~/.claude/skills/` for global availability.
+A multi-agent orchestration toolkit for Claude Code — 56 OSS-publishable skills in `skills/`. Skills are symlinked to `~/.claude/skills/` for global availability.
 
 The toolkit targets Claude Code as the primary host but the SKILL.md format is platform-agnostic — Claude.ai, Copilot CLI, Codex, and Gemini CLI all consume it. Skills should describe work in terms of capabilities ("read the file", "run the command") rather than Claude-Code-specific tool names where reasonable, so the same skill body works across hosts.
 
@@ -42,8 +42,8 @@ All SKILL.md files use the frontmatter convention defined in `skills/meta/skill-
 - **`skills/contracts/`** (2) — contract-author (generates contracts from templates) and contract-auditor (verifies implementations match). Templates: OpenAPI, AsyncAPI, Pydantic, TypeScript, JSON Schema.
 - **`skills/meta/`** (5) — skill-writer, skill-review, skill-update, skill-explorer, skill-catalog.
 - **`skills/git/`** (4) — Git workflow conventions: git-commit, git-pr, git-pr-feedback, git-post-merge-cleanup.
-- **`skills/workflows/`** (29) — plan-builder, plan-intake, living-plan, context-manager, deployment-checklist, dependency-coordinator, project-profiler, wiki-research, interactive-doc, settings-consolidator, sync-skills, ui-brief, claude-design-brief, mermaid-charts, nano-banana, playwright, render-sanity, repo-deep-dive, llm-wiki, railway-deploy, architecture-rescue, caveman, diagnose-loop, grill-me, maintain-context, zoom-out, setup-project-skills, work-item-brief, website-walkthrough-video.
-- **`skills/loops/`** (2) — Autonomous-loop skills. loop-controller (the foundation harness: the 5-part loop contract, primitive selection — `/goal` vs `/loop` vs Stop-hook vs bash Ralph vs dynamic workflows, the mandatory guardrail stack, and the fresh-context evaluator) and fix-until-green (drive tests+lint+typecheck to passing without cheating the gate). Every concrete loop is a configuration of loop-controller.
+- **`skills/workflows/`** (31) — plan-builder, plan-intake, living-plan, context-manager, deployment-checklist, dependency-coordinator, project-profiler, wiki-research, interactive-doc, settings-consolidator, sync-skills, ui-brief, claude-design-brief, mermaid-charts, nano-banana, playwright, render-sanity, repo-deep-dive, llm-wiki, railway-deploy, architecture-rescue, caveman, diagnose-loop, grill-me, maintain-context, zoom-out, setup-project-skills, work-item-brief, website-walkthrough-video.
+- **`skills/loops/`** (3) — Autonomous-loop skills. loop-controller (the foundation harness: the 5-part loop contract, primitive selection — `/goal` vs `/loop` vs Stop-hook vs bash Ralph vs dynamic workflows, the mandatory guardrail stack, and the fresh-context evaluator), fix-until-green (drive tests+lint+typecheck to passing without cheating the gate), and orchestrator-task-loop (the outer loop over the Agent Teams shared task list — drain the board until every task is completed + passing its TaskCompleted gate, feeding idle workers via TeammateIdle; experimental, behind CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1). Every concrete loop is a configuration of loop-controller.
 
 ## Key Design Decisions
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -12,7 +12,7 @@
 
 ## Where we are
 
-Skill-Madness is a mature **55-skill** library — a contract-first multi-agent orchestrator (14 phases), 10 role agents with exclusive file ownership, contract/meta/git/workflow skills — with a runtime + install layer on top. Two large efforts and two audits have landed; the latest audit's P0+P1 remediation has now merged, with a P2 fidelity backlog filed:
+Skill-Madness is a mature **56-skill** library — a contract-first multi-agent orchestrator (14 phases), 10 role agents with exclusive file ownership, contract/meta/git/workflow skills — with a runtime + install layer on top. Two large efforts and two audits have landed; the latest audit's P0+P1 remediation has now merged, with a P2 fidelity backlog filed:
 
 1. **Skill curation** (from `DeepResearch/skills-comparative_deepdive/PLAN-skill-creator.md`): authored 8 new skills, migrated 6, merged 3 pairs into 3 unified skills, and applied 8 categories of bulk in-place edits. Fully executed.
 2. **Ecosystem audit — surface pass** (`audit/MASTER_AUDIT_PLAN.md`, 7-dimension rubric, avg 4.49/5): all critical findings closed — 5 broken `composes_with` cross-references fixed, 7 oversized descriptions trimmed under the 1024-char ceiling, 2 missing frontmatter blocks restored. This was the *style / compliance / cross-ref* layer; its per-skill reports now live in `audit/reports-v1-sufrace/`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://github.com/ivy00johns/Skill-Madness/actions/workflows/lint-skills.yml"><img src="https://github.com/ivy00johns/Skill-Madness/actions/workflows/lint-skills.yml/badge.svg" alt="Skill Lint" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
-  <img src="https://img.shields.io/badge/skills-55-success.svg" alt="55 skills" />
+  <img src="https://img.shields.io/badge/skills-56-success.svg" alt="56 skills" />
   <img src="https://img.shields.io/badge/role%20agents-10-blueviolet.svg" alt="10 role agents" />
   <img src="https://img.shields.io/badge/orchestrator-14%20phases-success.svg" alt="14-phase orchestrator" />
   <img src="https://img.shields.io/badge/hosts-11-orange.svg" alt="11 hosts" />
@@ -42,13 +42,13 @@ Every AI coding tool ships the same trap: one agent, one context window, one set
 - 📜 **Contract-first** — `contract-author` writes OpenAPI / AsyncAPI / Pydantic / TypeScript / JSON Schema *before* a line of implementation. `contract-auditor` verifies every shipped module against the spec. Agents can't drift; the contract is the truth.
 - 🤖 **Ten role agents, exclusive ownership** — backend, frontend, infrastructure, QE, security, docs, observability, db-migration, performance, code-review. Each declares `owns.directories` / `owns.files` in its frontmatter. No two agents touch the same path. Conflicts get resolved before spawn, not after.
 - 🛡️ **QA gate that blocks** — `qe-agent` emits a `qa-report.json` with critical / high / medium / low findings plus contract-conformance and security scores. The orchestrator gates the merge on the report. Agents can't self-declare "done."
-- 🪜 **Progressive disclosure** — frontmatter (~100 tokens) always loaded, body loaded on trigger, references loaded on demand. A 55-skill library stays cheap to host.
+- 🪜 **Progressive disclosure** — frontmatter (~100 tokens) always loaded, body loaded on trigger, references loaded on demand. A 56-skill library stays cheap to host.
 - 🔁 **Two-runtime degradation** — Agent Teams (parallel tmux) → subagents (Task tool) → sequential. The orchestrator picks the highest mode the host supports; role skills work standalone in any of them.
-- 🧰 **55 skills, seven categories, all CI-linted** — orchestrator, roles, contracts, meta-skills (skill-writer, skill-explorer, skill-review, skill-update), git workflow conventions, 26 cross-cutting workflow skills (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, diagnose-loop, grill-me, …), and autonomous-loop skills (loop-controller, fix-until-green). Frontmatter, body length, and cross-skill ownership all gated on every push.
+- 🧰 **56 skills, seven categories, all CI-linted** — orchestrator, roles, contracts, meta-skills (skill-writer, skill-explorer, skill-review, skill-update), git workflow conventions, 26 cross-cutting workflow skills (plan-builder, repo-deep-dive, ui-brief, mermaid-charts, diagnose-loop, grill-me, …), and autonomous-loop skills (loop-controller, fix-until-green, orchestrator-task-loop). Frontmatter, body length, and cross-skill ownership all gated on every push.
 - 🌐 **Portable across eleven hosts** — `SKILL.md` is the canonical source; converters emit Claude Code, Copilot, Cursor, Aider, Windsurf, OpenCode, Qwen, OpenClaw, Gemini CLI, Antigravity, and Kimi formats. The orchestrator's parallel-dispatch metadata is Claude-Code-specific, but everything else (role definitions, contracts, workflows, git conventions, meta-skills) ports cleanly. See [Also works on ten other hosts](#-also-works-on-ten-other-hosts).
 
 > **Status — read before you pitch this to anyone:**
-> - **The orchestrator + 55-skill library is the mature part.** All bodies under 500 lines, zero ownership conflicts, zero broken cross-references, full Ubuntu + macOS lint matrix on every push.
+> - **The orchestrator + 56-skill library is the mature part.** All bodies under 500 lines, zero ownership conflicts, zero broken cross-references, full Ubuntu + macOS lint matrix on every push.
 > - **Claude Code is the end-to-end-verified host.** Multi-agent dispatch with file-ownership exclusivity and the `qa-report.json` gate runs live on Claude Code today. The other ten hosts receive skill *content* but don't run the orchestrator's parallel dispatch.
 > - **Lossy conversion is announced.** When a skill is converted to a non-Claude-Code host, orchestration-only fields (`allowed_tools`, `owns`, `composes_with`, `spawned_by`, `requires_agent_teams`) are stripped with a stderr line per skill. Skills marked `requires_claude_code: true` are skipped entirely for those targets. See `contracts/installer/per-tool-output-spec.md`.
 
@@ -79,7 +79,7 @@ From inside Claude Code:
 /plugin install skill-madness@skill-madness
 ```
 
-That installs all 55 skills into Claude Code's plugin storage. No clone, no symlink, no edits-to-the-repo workflow. Use this if you just want the skills.
+That installs all 56 skills into Claude Code's plugin storage. No clone, no symlink, no edits-to-the-repo workflow. Use this if you just want the skills.
 
 To update later: `/plugin update skill-madness`.
 
@@ -194,10 +194,11 @@ flowchart TB
         more["+ 13 more"]
     end
 
-    subgraph loops["🔁 loops/ — 2 skills"]
+    subgraph loops["🔁 loops/ — 3 skills"]
         direction TB
         lc[loop-controller]
         fug[fix-until-green]
+        otl[orchestrator-task-loop]
     end
 
     orch --> contracts
@@ -258,7 +259,7 @@ flowchart TB
 
 ## 🧰 Skill catalog
 
-55 skills organized into seven categories. All bodies under 500 lines, all frontmatter validated, zero ownership conflicts, zero broken cross-references.
+56 skills organized into seven categories. All bodies under 500 lines, all frontmatter validated, zero ownership conflicts, zero broken cross-references.
 
 <details>
 <summary><b>📚 Full skill table</b> (click to expand)</summary>
@@ -528,7 +529,7 @@ Almost always a `pyyaml` version skew. CI installs `pyyaml` explicitly on macOS 
 </details>
 
 <details>
-<summary><b>"My non-Claude-Code host doesn't see all 55 skills"</b></summary>
+<summary><b>"My non-Claude-Code host doesn't see all 56 skills"</b></summary>
 
 Expected. Skills with `requires_claude_code: true` (notably the `orchestrator` and most of `roles/`) are skipped for hosts that can't execute multi-agent dispatch. Run `./scripts/convert.sh --verbose` to see the skip list per host.
 </details>
@@ -555,7 +556,7 @@ Set the override env var documented in `scripts/README.md` (e.g. `CURSOR_RULES_D
 
 ## 🗺️  Roadmap
 
-- [x] **Skill library** — 55 skills, seven categories, all linted
+- [x] **Skill library** — 56 skills, seven categories, all linted
 - [x] **Multi-tool installer** — convert / install / lint, eleven host adapters
 - [x] **CI matrix** — Ubuntu + macOS lint on every push
 - [x] **Contract-first specs** — OpenAPI / AsyncAPI / Pydantic / TypeScript / JSON Schema templates

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -5,7 +5,7 @@
 
 ## Status at a glance
 
-A mature library of **55 skills** (contracts · git · meta · orchestrator · roles · workflows), all PSFS-validated, full Ubuntu + macOS lint matrix on every push.
+A mature library of **56 skills** (contracts · git · meta · orchestrator · roles · workflows), all PSFS-validated, full Ubuntu + macOS lint matrix on every push.
 
 | Effort | State |
 |--------|-------|

--- a/skills/loops/fix-until-green/SKILL.md
+++ b/skills/loops/fix-until-green/SKILL.md
@@ -17,7 +17,7 @@ requires_claude_code: true
 min_plan: starter
 disable-model-invocation: true
 allowed-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-composes_with: ["loop-controller", "qe-agent", "diagnose-loop", "git-commit", "orchestrator"]
+composes_with: ["loop-controller", "orchestrator-task-loop", "qe-agent", "diagnose-loop", "git-commit", "orchestrator"]
 spawned_by: ["orchestrator"]
 ---
 

--- a/skills/loops/loop-controller/SKILL.md
+++ b/skills/loops/loop-controller/SKILL.md
@@ -17,7 +17,7 @@ requires_claude_code: true
 min_plan: starter
 disable-model-invocation: true
 allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "Agent", "Workflow"]
-composes_with: ["orchestrator", "fix-until-green", "qe-agent", "contract-auditor", "diagnose-loop", "context-manager", "loop", "schedule"]
+composes_with: ["orchestrator", "fix-until-green", "orchestrator-task-loop", "qe-agent", "contract-auditor", "diagnose-loop", "context-manager", "loop", "schedule"]
 spawned_by: ["orchestrator"]
 ---
 

--- a/skills/loops/loop-controller/references/authoring.md
+++ b/skills/loops/loop-controller/references/authoring.md
@@ -30,6 +30,13 @@ composition of two.
 | 8 | **Performance** | benchmark under repeatable conditions → optimize highest-leverage → re-benchmark | metric under target on every measured path, no regression | performance |
 | 9 | **Self-healing** | watch logs/CI → on actionable error, trace root cause → fix → verify → PR | error resolved and verified, or clean-log confirmation | observability + role |
 | 10 | **Exploration** | fan-out read-only subagents map subsystems → synthesize → find gaps | a written architecture summary answers the seed questions | project-profiler |
+| 11 | **Orchestrate-until-drained** | assign the next unblocked task to an idle teammate; gate each completed task | every task `completed` AND passing its `TaskCompleted` gate, no dangling `blockedBy` (default-FAIL, whole-board) | orchestrator |
+
+Row 11 is the **meta-archetype**: an outer loop over a *list* of any-archetype
+inner loops (each task's gate may itself be a Fix-until-green, Build-until-spec,
+or Review-and-revise loop). It doesn't slot cleanly into a single row because its
+proof is a *whole-board predicate*, not one process's exit — it's
+`orchestrator-task-loop`, the Agent Teams configuration of this harness.
 
 Two structural rules every archetype shares: **name the proof artifact**
 (coverage report, benchmark, PR, audit, evaluator verdict), and **re-verify the

--- a/skills/loops/orchestrator-task-loop/SKILL.md
+++ b/skills/loops/orchestrator-task-loop/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: orchestrator-task-loop
+version: 1.0.0
+description: >-
+  The outer orchestration loop over the Agent Teams shared task list: the lead
+  loops the board until EVERY task is completed AND each passes its TaskCompleted
+  gate, feeding idle workers via the TeammateIdle hook so the team never stalls.
+  One pass = read the board, assign the highest-priority unblocked task to each
+  idle teammate, gate each completed task (pass counts it; fail rolls it back),
+  re-verify the whole board. Generalizes ralph-orchestrator onto Agent
+  Teams. Experimental — gated behind CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1; falls
+  back to the orchestrator's subagent/sequential path when off. Use to drain a
+  task board or keep the team working until done under a build.
+  Trigger on: "loop over the task list", "drain the task board", "keep the team
+  working until done", "agent teams loop", "orchestrator task loop", "keep idle
+  teammates fed". A configuration of loop-controller — it supplies the harness;
+  this skill supplies the proof (the task list fully drained) and the
+  assignment/supervision discipline.
+requires_claude_code: true
+requires_agent_teams: true
+min_plan: starter
+disable-model-invocation: true
+allowed-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "Agent", "Task", "Workflow"]
+composes_with: ["loop-controller", "orchestrator", "fix-until-green", "qe-agent", "contract-auditor", "context-manager", "diagnose-loop", "git-commit", "loop", "schedule"]
+spawned_by: ["orchestrator"]
+---
+
+# orchestrator-task-loop
+
+> **A configuration of [`loop-controller`].** That skill supplies the loop
+> machinery — primitive selection, the full guardrail stack, state
+> externalization. This skill supplies the two things specific to draining the
+> task list: a **mechanical proof** (every task `completed` **and** passing its
+> `TaskCompleted` gate) and the **assignment/supervision discipline** that keeps
+> the loop from declaring victory on a half-drained list. Read `loop-controller`
+> for the guardrails; they're inherited, not repeated here.
+>
+> **Why `disable-model-invocation`:** this loop spawns teammates and drives an
+> entire task list to completion on its own — assigning, supervising, gating, and
+> re-triggering its own stop. You want to *type* `/orchestrator-task-loop` (or
+> have the orchestrator dispatch it) — not have Claude silently start an unbounded
+> team-supervision loop because a task board happened to exist.
+>
+> **Experimental.** Agent Teams is disabled by default and gated behind
+> `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, with known limitations (no session
+> resumption for in-process teammates, lagging task-state propagation, slow
+> shutdown). This is a prototype-behind-the-flag skill. If the flag is unset, it
+> refuses to start and points you at the orchestrator's subagent/sequential path
+> (see Step 1 + the degradation note).
+
+## The 5-part contract
+
+| Part | This loop |
+|---|---|
+| **trigger** | A populated Agent Teams shared task list (tasks `pending`/`in_progress`, team spawned) **and** `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` — or an explicit `/orchestrator-task-loop`. Dispatched by the orchestrator after contracts exist and the board is seeded (one task per contract-bounded unit, `blockedBy` edges from the dependency graph). |
+| **action** | **One supervision pass:** read the board → for every `idle` teammate (surfaced by `TeammateIdle`), assign the highest-priority `pending` task whose `blockedBy` set is fully `completed` → let teammates work in their own context windows and claim tasks → on `completed`, run that task's `TaskCompleted` gate (**pass → done; fail → rolled back to `pending` with the failure as feedback**) → surface blocked/ambiguous tasks for HITL. **Assignment, not implementation** — the loop routes and supervises; teammates do the work. |
+| **proof** | The board is **drained**: every task `completed` **AND** each passed its `TaskCompleted` gate **AND** no `blockedBy` edge points at a non-`completed` task — observed in one full read. Default-FAIL: assume undrained until that whole-board predicate holds. (See "The proof".) |
+| **memory** | The **shared task list file** is the durable state (task states + `blockedBy` + gate verdicts survive across passes and fresh contexts) — this loop's "feature-list JSON," default-FAIL. Plus a **checkpoint commit per task**, the team's **peer-message log**, and an optional `PROGRESS.md` roll-up. No cross-iteration state lives in the lead's conversation. |
+| **stop** | board drained (success) **OR** hard iteration (pass) cap **OR** the **3-failure circuit breaker** (board/task unchanged across 3 consecutive passes, or a task ping-pongs `completed`→gate-fail→`pending` ≥3×) **OR** enforced token/cost budget cap **OR** an HITL-blocked task with no unblocked work left. |
+
+## The proof: a fully drained task list, default-FAIL
+
+"Done" is **not** "every teammate said they finished." It is a mechanical,
+default-FAIL predicate over the *whole* board, re-evaluated after every pass
+("restart the streak"):
+
+**`DONE` ⟺ for every task `t` on the board:**
+1. `t.state == completed`, **and**
+2. `t` passed its `TaskCompleted` gate (last verdict PASS — a `completed` task whose gate is unrun or failed does **not** count), **and**
+3. every `b ∈ t.blockedBy` is itself `completed` and gate-passing (no dangling dependency), **and**
+4. no `pending`/`in_progress` tasks remain, and no `idle` teammate has assignable work.
+
+Each clause starts `false` and flips only on evidence read from the task-list
+file. The proof is over the **board**, not the last task touched: completing task
+N while a `TaskCompleted` rollback re-opened task M means the board is **not**
+drained — only a full re-read catches it. This is exactly `loop-controller`'s
+default-FAIL + re-verify-the-whole rule applied to a task board instead of one
+exit code, and it is where this loop differs from a single-task loop: the verifier
+is the *board predicate*, evaluated every pass.
+
+## Step 1 — Detect the Agent Teams runtime, or degrade
+
+Before assigning anything, confirm the substrate. Precedence:
+
+1. **`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`** must be set. If it is unset, this
+   loop **refuses to start** — tell the user to set the flag, or hand back to the
+   orchestrator's subagent/sequential path (the orchestrator's runtime tree:
+   subagents via Task/Agent, else sequential). The shared task list + Teammate/Task
+   hooks this loop relies on only exist under native Agent Teams.
+2. **A spawned team + a populated shared task list.** If contracts exist but the
+   board isn't seeded, that's the orchestrator's job, not this loop's — seed one
+   task per contract-bounded unit of work, with `blockedBy` edges from the
+   dependency graph, *then* loop.
+
+Read caps (max passes, budget), state-file paths, and the seed source from
+`.claude/profile.yaml` / the orchestrator's plan when present — don't invent tasks
+the plan already defines. Substrate mechanics (states, `blockedBy`, TeammateTool,
+peer messaging, the flag, known limitations) are in `references/agent-teams.md`.
+
+## Step 2 — Assign ready work, keep idle workers fed
+
+One pass routes work; it does not write code:
+
+- **`TeammateIdle` = "assign new work."** When a teammate goes idle, pick the
+  **highest-priority `pending` task whose `blockedBy` is fully `completed`** and
+  assign it. This feeder is what keeps the loop converging instead of stalling
+  with idle workers and undrained tasks.
+- **Teammates work in their own context windows** and claim tasks
+  (`pending`→`in_progress`). All coordination flows through the shared file +
+  peer-message log — no central bottleneck.
+- **Cap build/test parallelism per `loop-controller` Step 5.** Fan out search and
+  read-only verification freely, but don't let two teammates run the integrated
+  build at once — concurrent builds destroy the backpressure signal.
+
+The assignment algorithm in full (priority + unblocked-set selection) is in
+`references/hooks.md` under the `TeammateIdle` feeder.
+
+## Step 3 — Gate each completed task (the inner loop hooks in here)
+
+When a teammate marks a task `completed`, its **`TaskCompleted` gate** fires —
+this is the proof's atom and the loop's backpressure edge:
+
+- **Pass → the task counts toward the proof.**
+- **Fail (exit 2) → the task is rolled back** to `pending`/`in_progress` with the
+  failure surfaced as feedback. A task does **not** count until its gate is green.
+- **Each task's gate can be driven by a [`fix-until-green`] inner loop.** The
+  teammate working a code task runs `fix-until-green` to drive its
+  tests+lint+typecheck red→green; only then does `TaskCompleted` pass and this
+  outer loop counts it. The outer loop **never reaches into** a task's gate — it
+  consumes the verdict. (This is the inner/outer composition; see "Under the
+  orchestrator".)
+- The gate may be a **deterministic script** (mechanical bars) or an
+  **agent-type/prompt hook** — a fresh-context evaluator subagent with **no
+  Write/Edit tools** (`loop-controller` Step 2) for subjective bars; for
+  build-until-spec tasks, [`contract-auditor`] is the natural evaluator.
+- **QA-gated tasks consult the qe-agent's `qa-report.json`** (`gate_decision.proceed`,
+  CRITICAL blockers, contract_conformance/security ≥ 3) — the same gate the
+  orchestrator already uses. The loop **informs, it does not decide**.
+
+## Step 4 — Re-verify the whole board, checkpoint
+
+After any task flips, re-scan the **entire** board against the §proof predicate —
+not just the task that moved. "Restart the streak": a fix that completed task N
+but a rollback that re-opened task M means the board is still undrained, and only a
+full re-read catches it. On each task that passes its gate, **commit a checkpoint**
+naming the task — the git trail is the loop's undo (`git reset --hard` to the last
+green task + re-loop) and post-mortem. When the predicate holds for the whole
+board, the loop is done; report the drained board as evidence.
+
+## Guardrails specific to this loop
+
+Inherits the full stack from `loop-controller` → `references/safety.md`. The caps
+this loop sets, mapped onto the team substrate:
+
+- **Hard iteration cap** — a max number of supervision passes (read from
+  `.claude/profile.yaml` if set). Hitting it is **stop-and-escalate**, never
+  "lower the gate."
+- **Enforced token/cost budget** — a ceiling that **terminates**, not just warns.
+  Agent Teams uses 3–5×+ a single session's tokens; the documented 11-day /
+  tens-of-thousands-of-dollars runaway had observability but no enforcement. Set
+  per-teammate budget caps **and** a board-level ceiling.
+- **No-progress / oscillation = the orchestrator's 3-failure circuit breaker.** If
+  board state (or a single task) is unchanged across **3 consecutive passes**, or a
+  task ping-pongs `completed`→gate-fail→`pending` ≥3×, **stop and escalate**. This
+  *is* `loop-controller`'s guardrail and the orchestrator's existing breaker — one
+  vocabulary, not a new one. See `skills/orchestrator/references/circuit-breaker.md`.
+- **Checkpoint commit per task** — commit working state each time a task passes its
+  gate (Step 4).
+- **HITL for ambiguous/blocked tasks** — pause and surface any task that's blocked
+  with no path forward, ambiguous, or about to touch something irreversible
+  (deploy, prod DB write, external API, force-push). Don't let the loop guess past a
+  real block.
+- **Sandbox** for any unattended run — workspace/worktree isolation so one
+  teammate's failure can't contaminate the board or other teammates.
+- **Never weaken the gate.** Forbidden, each a *finding*: editing the
+  `TaskCompleted` gate, the task list, or `qa-report.json` to mark a task done. A
+  task that went `completed` by relaxing its gate is not progress — read the diff
+  that flipped it.
+
+**Promote to unattended/overnight ONLY when every loop in the build has all five**
+(`safety.md` Stage 3): a hard external verifier, an *enforced* token budget,
+no-progress detection, checkpoint commits, and a sandbox. Until then, run
+**attended** — and because Agent Teams is experimental, stay attended until the
+loop completes consecutive clean runs (the staged-adoption ladder in
+`loop-controller/references/safety.md`). **Roll back to attended / kill** when:
+token spend grows non-linearly, board state is unchanged across passes, a
+`TaskCompleted` gate and human judgment disagree, or a task is about to touch an
+irreversible resource without a checkpoint.
+
+**Degradation (required, `requires_agent_teams: true`).** When
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is unset, this loop does not run — fall back
+to the orchestrator's subagent path (Task/Agent fan-out with the wave gate driving
+each wave red→green via `fix-until-green`) or sequential mode. The proof and the
+discipline survive; only the shared-task-list substrate and the Teammate/Task hooks
+are unavailable.
+
+## Choosing the driver primitive
+
+Per `loop-controller` Step 1, this loop's primitive is the **Stop/SubagentStop
+hook + TeammateIdle hook combination**: the Stop hook blocks the lead's exit while
+the board predicate (§proof) is not yet `DONE`; `TeammateIdle` keeps workers fed so
+the board actually converges between blocks. Secondary, for interactive runs: a
+`/goal`-style condition over the whole board ("every task `completed` and passing
+its `TaskCompleted` gate, or stop after N passes"). The hook scripts, the
+`stop_hook_active` guard, and the auto-conversion-to-SubagentStop note are in
+`references/hooks.md`.
+
+## Under the orchestrator (the wiring this unblocks)
+
+`loop-controller` already notes the two-level structure — an inner loop per role,
+an outer loop over the shared task list — and says "that orchestrator wiring is a
+separate, later skill." **This is that skill.**
+
+- **Outer = this skill.** Loops over the **whole board** (assignment + supervision):
+  drain every task to `completed` + gate-passing.
+- **Inner = [`fix-until-green`].** Drives **one task's** gate red→green (three exit
+  codes, no cheating). They **compose**: a task's `TaskCompleted` gate is satisfied
+  by dispatching `fix-until-green`; the outer loop consumes the verdict.
+- **`qe-agent` still decides the build gate.** Echoing `fix-until-green`: the loop
+  informs, the `qe-agent`'s `qa-report.json` / `gate_decision` decides — a rollback
+  or a circuit-breaker escalation is a real blocker, not a number to paper over.
+- **Generalizes ralph-orchestrator:** orchestrator decomposes → spawns workers →
+  loops the board; `validation.failed` is a worker re-trigger. Here the orchestrator
+  is the event router and `TaskCompleted` is the `validation.passed/failed` edge,
+  onto Agent Teams' native shared task list.
+
+## Reference files
+
+- `references/agent-teams.md` — the shared-task-list substrate: states
+  (`pending`→`in_progress`→`completed`), `blockedBy` edges, seeding one task per
+  contract-bounded unit, teammates claiming/working in their own context windows,
+  peer-message coordination, the drained-board predicate as a checkable routine, the
+  `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` flag, and the known-limitations caveats.
+- `references/hooks.md` — the three hooks in full: the `TaskCompleted` gate (payload,
+  exit-2 rollback, backing it with `fix-until-green` or `qa-report.json`), the
+  `TeammateIdle` feeder (assignment algorithm), and the `Stop`/`SubagentStop`
+  re-trigger (script + `stop_hook_active` guard + auto-conversion).
+
+[`loop-controller`]: ../loop-controller/SKILL.md
+[`fix-until-green`]: ../fix-until-green/SKILL.md
+[`contract-auditor`]: ../../contracts/contract-auditor/SKILL.md

--- a/skills/loops/orchestrator-task-loop/references/agent-teams.md
+++ b/skills/loops/orchestrator-task-loop/references/agent-teams.md
@@ -1,0 +1,114 @@
+# The Agent Teams shared task list
+
+This is the loop's **durable state** and its **proof artifact** — the analogue of
+`fix-until-green`'s three exit codes, but a *whole-board predicate* instead of one
+process's exit. Where `fix-until-green` reads `tests && lint && typecheck` into one
+green/red, this loop reads N task verdicts into one **drained / undrained** signal.
+Everything here is gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`; without
+it, none of this substrate exists and the loop degrades (see below).
+
+## The experimental flag (precondition)
+
+- Native Agent Teams is **disabled by default**. Set
+  `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` to enable the shared task list, the
+  `TeammateTool`, the peer-message inbox, and the Teammate/Task lifecycle hooks.
+- **Known limitations (prototype-behind-the-flag):**
+  - **No session resumption** for in-process teammates — a killed teammate's
+    context is gone; the *shared file* is what survives, not the teammate.
+  - **Task-state propagation lags.** A transition you just triggered may not be
+    visible on the next read. **Re-read before trusting a transition**, and treat a
+    single read as a snapshot, never as ground truth across passes.
+  - **Slow shutdown.** Tearing the team down is not instant; budget for it when
+    you hit a cap or circuit breaker.
+- **Fallback when unset:** the orchestrator's subagent path (Task/Agent fan-out)
+  or sequential mode. Those runtimes have **no shared task list and no Teammate
+  hooks** — the proof and the assignment discipline survive, but you drive them by
+  hand / via the wave gate instead of via this substrate.
+
+## Task states
+
+```
+pending ──claim──▶ in_progress ──mark done──▶ completed
+   ▲                                              │
+   └──────────── TaskCompleted gate FAIL ─────────┘  (rollback, failure as feedback)
+```
+
+- The three explicit states are `pending` → `in_progress` → `completed`, plus an
+  **implicit gate verdict** attached when `TaskCompleted` fires: **PASS / FAIL /
+  unrun**.
+- A `completed` task whose gate is **unrun or FAIL does NOT count** toward the
+  proof. `completed` is **necessary, not sufficient** — "completed" is the
+  teammate's claim; the gate verdict is the proof.
+- **Rollback edge:** a `TaskCompleted` FAIL re-opens `completed` → `pending` /
+  `in_progress`, carrying the failure as feedback for the next attempt. This is the
+  backpressure edge; it is what stops the board declaring victory on unverified
+  work.
+
+## blockedBy dependency edges
+
+- Each task carries a **`blockedBy` set** (task ids). A task is **assignable only
+  when every id in its `blockedBy` is `completed`-and-gate-passing** — a dependency
+  that is merely `completed` (gate unrun/FAIL) does not unblock its dependents.
+- **Seed edges from the orchestrator's dependency graph** — one task per
+  contract-bounded unit of work. The edge set encodes the build order.
+- **Cycle / dangling-edge checks belong to seeding, not the loop.** The loop trusts
+  a well-formed graph; if seeding produced a cycle or an edge to a non-existent
+  task, that's a seeding bug to surface, not something the loop should route around.
+
+## Seeding the board
+
+- **One task per contract-bounded unit:** a contract from `contracts/`, or an
+  ownership-scoped slice of work. **Don't invent tasks the plan already defines** —
+  read the orchestrator plan / `.claude/profile.yaml` first and seed from it.
+- Set **`priority` and `blockedBy` at seed time** — the feeder (see `hooks.md`)
+  sorts by priority within the assignable set, so priority is meaningless if it
+  isn't seeded.
+- Seeding is the orchestrator's job. If contracts exist but the board is empty,
+  seed *then* loop — the loop does not author tasks mid-flight.
+
+## How teammates work
+
+- **Claim semantics:** a teammate moves a task `pending` → `in_progress`, works it
+  **in its own context window**, and marks it `completed`. The lead never does the
+  work — it routes and supervises.
+- **TeammateTool + peer messaging:** coordination flows through the **shared file**
+  and the **peer-message log / inbox**, not through the lead. The lead is **not a
+  message relay** — it routes assignments and runs gates; teammates talk to each
+  other directly. No central bottleneck.
+
+## The drained-board predicate (the checkable routine)
+
+This is the routine the loop runs **every pass** — the analogue of `gate-commands.md`
+composing three exit codes into one pass/fail, here composing N task verdicts into
+one board verdict. Read the task-list file and evaluate, **default-FAIL**:
+
+```
+DRAINED = true        # optimistic; any failing clause flips it false
+for each task t on the board:
+    if t.state != completed:                      DRAINED = false   # clause 1
+    if gate_verdict(t) != PASS:                   DRAINED = false   # clause 2
+    for b in t.blockedBy:
+        if b.state != completed or gate_verdict(b) != PASS:
+                                                  DRAINED = false   # clause 3
+if any task is pending or in_progress:            DRAINED = false   # clause 4
+if any idle teammate has an assignable task:      DRAINED = false   # clause 4
+return DRAINED
+```
+
+- **Default-FAIL:** assume **undrained** until the **whole board** is observed
+  satisfying all four clauses **in one read**. A partial read is not evidence.
+- **"Restart the streak":** re-evaluate the **WHOLE board** after *any* task flips.
+  A rollback on task M can **un-drain** a board that looked done because task N just
+  passed — only a full re-read catches it. Never short-circuit on "the task I just
+  touched is green."
+- This predicate is clause-for-clause the §proof in `SKILL.md`; keep them in sync.
+
+## Composing with the orchestrator's plan
+
+- Read **caps** (`max_passes`, token/cost budget) and **state-file paths** from
+  `.claude/profile.yaml` when present; the **seed source** is the orchestrator
+  plan.
+- Profile `minimal | standard | strict` governs advisory-vs-blocking handling of
+  gate verdicts — strict treats a FAIL as a hard block; advisory surfaces it but
+  lets the loop continue routing other tasks. The drained-board predicate is the
+  same regardless; the profile only changes how aggressively a FAIL halts the pass.

--- a/skills/loops/orchestrator-task-loop/references/hooks.md
+++ b/skills/loops/orchestrator-task-loop/references/hooks.md
@@ -1,0 +1,163 @@
+# The three hooks that drive orchestrator-task-loop
+
+This loop is driven by **three native Agent Teams lifecycle hooks**:
+
+- **`TaskCompleted`** — the per-task gate (the proof's atom).
+- **`TeammateIdle`** — keeps the board fed so it converges.
+- **`Stop` / `SubagentStop`** — blocks the lead's exit until the board drains.
+
+All three are gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`. When the flag
+is unset every handler is **inert** — the loop refuses to start and degrades to the
+orchestrator's subagent/sequential path (see the precondition check at the end).
+
+## Hook 1 — TaskCompleted (the per-task gate)
+
+Fires when a teammate marks a task `completed`. It runs **that task's gate** and is
+the loop's **backpressure edge**.
+
+**Exit-code contract:**
+
+- **exit 0 → the task counts** toward the proof (gate verdict PASS).
+- **exit 2 (or any non-zero) → roll the task back** to `pending` / `in_progress`
+  and **surface the failure as feedback** for the next attempt. The task does
+  **not** count until its gate is green.
+
+The gate is **per-task**:
+
+- a **deterministic script** for mechanical bars (tests/lint/typecheck/build), or
+- an **agent-type / prompt hook** for subjective bars — a **fresh-context evaluator
+  subagent with NO Write/Edit tools** (`loop-controller` Step 2), so the judge can't
+  edit the thing it's grading.
+
+**Backing it with `fix-until-green`.** For a code task, the teammate's gate **is** a
+`fix-until-green` run: drive tests + lint + typecheck to exit 0, *then*
+`TaskCompleted` passes. The **outer loop consumes the inner verdict** — it never
+reaches into the inner loop. This is the inner/outer composition.
+
+**Backing it with `qa-report.json`.** For a QA-gated task, consult the qe-agent's
+report — `gate_decision.proceed`, CRITICAL blockers, and
+`contract_conformance` / `security ≥ 3` — the **same gate the orchestrator uses**.
+The loop **informs; the qa-report decides**.
+
+**Sample payload sketch** (shape, not a literal schema):
+
+```json
+{ "hook": "TaskCompleted", "taskId": "be-auth-7", "teammate": "backend-1", "state": "completed" }
+```
+
+The handler reads `taskId`, runs that task's gate, and emits the exit code above.
+
+## Hook 2 — TeammateIdle (the feeder)
+
+Fires when a teammate goes idle. The handler = **"assign new work"** — this is what
+keeps the outer loop **converging instead of stalling** with idle workers and
+undrained tasks.
+
+**Assignment algorithm in full:**
+
+```
+on TeammateIdle(teammate):
+    assignable = [ t for t in board
+                   if t.state == pending
+                   and all(b is completed-and-gate-passing for b in t.blockedBy) ]
+    if assignable is empty:
+        if any task still pending/in_progress:
+            # remaining work is blocked on an in_progress dependency, or genuinely stuck
+            wait on the in_progress dependency, OR surface for HITL if nothing will unblock it
+        else:
+            # nothing left to assign — let the Stop hook evaluate the drained predicate
+            return
+    else:
+        pick = max(assignable, key = priority)   # highest-priority unblocked pending task
+        assign(pick, teammate)                    # pending -> in_progress (teammate claims)
+```
+
+Filter to the assignable set (`blockedBy` satisfied) → sort by priority → assign
+one. If **none** are assignable but tasks remain, the remainder is **blocked** —
+wait on an `in_progress` dependency, or escalate to HITL if nothing will unblock it.
+
+## Hook 3 — Stop / SubagentStop (the re-trigger)
+
+The lead's **`Stop` hook blocks exit while the board predicate is not `DONE`**, and
+re-feeds "keep assigning and supervising." It carries over the **two invariants**
+from `fix-until-green`'s stop-hook, in spirit:
+
+1. **Guard `stop_hook_active`.** Block **iff** the board is undrained. When the flag
+   is set **and** the board is drained, **let the stop through** — otherwise you get
+   an infinite loop (the hook blocking its own re-entry forever).
+2. **The drained-board check is the ONLY authority.** A **fully drained,
+   all-gates-green** board must **always** allow the stop. Nothing else may veto a
+   genuinely-done board.
+
+**Repo Stop-hook contract:** signal a block by **printing
+`{"decision":"block","reason":...}` to stdout and exiting 0** — *never* via a
+non-zero exit. **Allowing** the stop prints **no decision** and exits 0.
+
+**Reference gate script** (bash, mirrors `fix-until-green`'s `fix-until-green-gate.sh`):
+
+```bash
+#!/usr/bin/env bash
+# orchestrator-task-loop Stop/SubagentStop gate
+set -euo pipefail
+
+# 0. Experimental-flag precondition — inert if teams are off.
+[ "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-}" = "1" ] || exit 0
+
+payload="$(cat)"
+
+# 1. Invariant 1: never re-block once already in a stop-hook re-entry.
+if [ "$(jq -r '.stop_hook_active // false' <<<"$payload")" = "true" ]; then
+  exit 0
+fi
+
+# 2. Let the loop's own guards decide escalation, not the hook:
+#    a tripped cap / circuit breaker / budget / HITL block allows the stop.
+if ./scripts/guardrail-tripped.sh; then
+  exit 0
+fi
+
+# 3. The drained-board predicate (from agent-teams.md) is the ONLY authority.
+if ./scripts/board-drained.sh; then
+  exit 0                              # Invariant 2: drained board always allows stop.
+fi
+
+# 4. Undrained: block, naming the undrained tasks as the reason.
+undrained="$(./scripts/board-undrained-tasks.sh)"
+jq -cn --arg r "Board not drained; outstanding: $undrained. Keep assigning and gating." \
+  '{decision:"block", reason:$r}'
+exit 0
+```
+
+The script: read payload → check `stop_hook_active` → **allow if a guardrail
+tripped** (so the loop's own caps/breaker/budget/HITL decide escalation, not the
+hook) → run the drained-board predicate from `agent-teams.md` → **green board
+allows**, **undrained board blocks** with the undrained tasks as the `reason`.
+
+**Auto-conversion.** A `Stop` hook declared in the skill/agent **frontmatter is
+auto-converted to `SubagentStop`** when the loop runs as a subagent — so the gate
+**travels with the skill** and fires whether the loop is the top-level lead or a
+spawned subagent. (Mirrors `fix-until-green`'s stop-hook auto-conversion note.)
+
+## Wiring
+
+- **Per-skill (inherited by subagents):** declare the hooks in frontmatter; the
+  `Stop` → `SubagentStop` auto-conversion carries the gate to spawned teammates.
+- **Orchestrated registration:** register alongside the existing **qa-gate hook** —
+  the two coexist; `TaskCompleted` gates a single task, the qa-gate gates the build.
+- **Profile `minimal | standard | strict`:** advisory-vs-blocking handling of a
+  gate FAIL. `strict` blocks the stop on any FAIL; `minimal`/`standard` may surface
+  a FAIL advisorily while continuing to route other tasks — but a **drained** board
+  always allows the stop regardless of profile.
+
+## The experimental-flag precondition check
+
+A short guard at the top of **every** handler:
+
+```bash
+[ "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-}" = "1" ] || exit 0
+```
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS != 1`, the hooks are **inert** — the loop
+**refuses to start** and **degrades** to the orchestrator's subagent / sequential
+path (no shared task list, no Teammate hooks; the proof and discipline survive,
+driven by hand / the wave gate instead).

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrator
-version: 1.12.0
+version: 1.13.0
 description: |
   Coordinate multi-agent Claude Code builds end-to-end: read the plan/mission, design integration contracts, dispatch role-agents in parallel, gate on QA, ship. Under ultracode (standing opt-in) or an explicit "workflow"/"workflows" ask, it drives the implement + verify phases with the Workflow tool — fanning out the role-agents (`agent({agentType})`) against the contracts and adversarially verifying — instead of hand-spawning agents one message at a time. Use when the user mentions agent teams, parallel/swarm builds, multi-agent work, a MISSION.md file, a multi-phase mission, splitting work across Claude sessions, "workflow"/"dynamic workflow", or ultracode mode. Triggers on "agent team", "parallel build", "team build", "multi-agent", "swarm build", "build X with agents", "coordinate the build", "run the mission", "workflow", "dynamic workflows", "ultracode build", "orchestrate with workflows". Does NOT preempt brainstorming, planning, design-brief, or feature-dev — it picks up after those produce artifacts.
 requires_agent_teams: false
@@ -25,7 +25,7 @@ composes_with: [
   "claude-mem:mem-search", "claude-mem:timeline-report", "claude-mem:knowledge-agent",
   "skill-writer", "skill-review", "skill-update",
   "railway-deploy", "loop", "schedule",
-  "loop-controller", "fix-until-green"
+  "loop-controller", "fix-until-green", "orchestrator-task-loop"
 ]
 spawned_by: []
 ---
@@ -52,7 +52,7 @@ The orchestrator is the conductor — not the only player. It composes with thre
 - **DISPATCHES role-agents in parallel:** `backend-agent`, `frontend-agent`, `infrastructure-agent`, `db-migration-agent`, `security-agent`, `observability-agent`, `performance-agent`, `docs-agent`, `qe-agent`.
 - **DELEGATES diff/code review to the external `/code-review` CLI:** during a build, the Phase 4 diff review pass is the external `/code-review` CLI, NOT a spawned `code-review-agent`. The in-repo `code-review-agent` skill is not a default build phase — invoke it only deliberately for a standalone, repo-aware review. See `references/mission-interpretation.md`.
 - **DOES NOT preempt:** `brainstorming`, `plan-builder`, `writing-plans`, `claude-design-brief`, `ui-brief`, `feature-dev`, `claude-mem:*`. If any of these belong before the build starts, let them run first — orchestrator picks up from the artifacts they produce.
-- **RUNS the validation phases AS LOOPS (not one-shot checks):** the wave gate and the QA gate are convergence loops. `fix-until-green` is the contract for driving install/typecheck/test/QA red→green *without cheating the gate* — it is the QE inner loop and the wave-gate driver; `loop-controller` is the underlying harness (iterate → evaluate → guardrail → stop) whose no-progress/oscillation guardrail *is* the 3-failure circuit breaker and whose iteration/budget caps bound wave-gate retries. Both are `disable-model-invocation: true`: you **explicitly dispatch** them, they never auto-trigger because a test happened to fail. They shape *how* the validation phases iterate rather than being invoked at a single phase. See `skills/loops/`.
+- **RUNS the validation phases AS LOOPS (not one-shot checks):** the wave gate and the QA gate are convergence loops. `fix-until-green` is the contract for driving install/typecheck/test/QA red→green *without cheating the gate* — it is the QE inner loop and the wave-gate driver; `loop-controller` is the underlying harness (iterate → evaluate → guardrail → stop) whose no-progress/oscillation guardrail *is* the 3-failure circuit breaker and whose iteration/budget caps bound wave-gate retries. Both are `disable-model-invocation: true`: you **explicitly dispatch** them, they never auto-trigger because a test happened to fail. They shape *how* the validation phases iterate rather than being invoked at a single phase. Under native Agent Teams, `orchestrator-task-loop` drives the whole-task-list OUTER loop (drain the shared task list until every task is completed + passing its `TaskCompleted` gate, feeding idle workers via `TeammateIdle`), and each task's gate can be driven by a `fix-until-green` INNER loop (inner/outer composition). All three are `disable-model-invocation: true` — explicitly dispatched, never auto-triggered. See `skills/loops/`.
 
 <what-to-do>
 
@@ -124,7 +124,7 @@ Is ultracode on (a system-reminder says so) OR did the user say "workflow"/"work
         deterministic JS that fans out the role-agents and adversarially verifies the result.
         Design/contracts stay inline. See "Dynamic Workflows" below + references/workflow-orchestration.md.
   NO → Is CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS set?
-    YES → Native Agent Teams (tmux, TeammateTool, inbox, shared task list)
+    YES → Native Agent Teams (tmux, TeammateTool, inbox, shared task list). Outer drive loop = orchestrator-task-loop: the lead loops the shared task list until every task is completed and passes its TaskCompleted gate, fed by the TeammateIdle hook.
     NO → Is the Agent/Task tool available?
       YES → Subagents via Task/Agent tool (parallel, no TeammateTool)
       NO → Sequential mode (work through roles one at a time, user coordinates)
@@ -183,7 +183,7 @@ Directory ownership takes precedence over pattern ownership. Subdirectory carve-
 - **All inter-agent communication goes through you**
 - **Contract changes require the full protocol**: pause → update → version → notify → confirm
 - **Shared file changes go through you** — relay to the owning agent
-- **Circuit breaker at 3 failures** — see `references/circuit-breaker.md`. This *is* `loop-controller`'s no-progress / oscillation guardrail applied to agent dispatch (same set of failures surviving 3 consecutive iterations → stop and escalate). Every bounded-retry loop in this build — the wave gate, the QA gate, this circuit breaker — is a `loop-controller` configuration, so one stop-condition vocabulary (max iterations, no-progress detection, enforced budget, escalate-to-human) governs all three instead of three ad-hoc loops.
+- **Circuit breaker at 3 failures** — see `references/circuit-breaker.md`. This *is* `loop-controller`'s no-progress / oscillation guardrail applied to agent dispatch (same set of failures surviving 3 consecutive iterations → stop and escalate). Every bounded-retry loop in this build — the wave gate, the QA gate, this circuit breaker, and the Agent Teams outer task-list loop (`orchestrator-task-loop`) — is a `loop-controller` configuration, so one stop-condition vocabulary (max iterations, no-progress detection, enforced budget, escalate-to-human) governs them all instead of ad-hoc loops. `orchestrator-task-loop`'s no-progress guardrail *is* this 3-failure breaker (board/task unchanged across 3 passes, or a task ping-ponging completed→gate-fail→pending ≥3×).
 
 ## QE Agent Is Mandatory
 
@@ -289,7 +289,7 @@ ALL must be true:
 - **`references/agent-spawning.md`** — the agent prompt template, AFK/HITL classification, spawn permissions, and a worked backend-agent example.
 - **`references/wave-gate.md`** — per-stack install/typecheck/test commands and failure-routing protocol.
 - **`references/workspace-bootstrap.md`** — required root README sections and the per-stack one-command `dev` aggregator table.
-- **`references/circuit-breaker.md`** — the 3-failure circuit breaker for agent dispatch; this is `loop-controller`'s no-progress / oscillation guardrail. The sibling `loop-controller` and `fix-until-green` skills (in `skills/loops/`) are the general loop harness that this build's wave gate, QA gate, and circuit breaker are all configurations of — `loop-controller` is the engine, `fix-until-green` is the config that plugs a three-exit-code proof into it. Both are `disable-model-invocation: true`: dispatch them explicitly.
+- **`references/circuit-breaker.md`** — the 3-failure circuit breaker for agent dispatch; this is `loop-controller`'s no-progress / oscillation guardrail. The sibling `loop-controller`, `fix-until-green`, and `orchestrator-task-loop` skills (in `skills/loops/`) are the general loop harness that this build's wave gate, QA gate, circuit breaker, and Agent Teams outer task-list loop are all configurations of — `loop-controller` is the engine, `fix-until-green` is the config that plugs a three-exit-code proof into it, and `orchestrator-task-loop` is the outer loop that drains the shared task list. All three are `disable-model-invocation: true`: dispatch them explicitly.
 - **`references/handoff-protocol.md`** — context-window handoff protocol for long-running builds.
 
 </supporting-info>


### PR DESCRIPTION
## Summary

- Ships the **deferred P1 loop** from `docs/research/DEEP-RESEARCH-LOOPS.md`: **`orchestrator-task-loop`** — the **outer** orchestration loop over the Agent Teams shared task list. The lead loops the board until *every* task is `completed` **and** passes its `TaskCompleted` gate, feeding idle workers via the `TeammateIdle` hook — generalizing ralph-orchestrator onto native Agent Teams. Experimental, gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
- It is the **third config of `loop-controller`** (alongside `fix-until-green`) and the **outer** loop to `fix-until-green`'s **inner** loop: each task's `TaskCompleted` gate can be driven by a `fix-until-green` inner loop; the outer loop consumes the verdict. Catalog **55 → 56** (loops 2 → 3); the `loops` category already existed, so no category-list changes.

## Changes

- **New skill** `skills/loops/orchestrator-task-loop/` — `SKILL.md` (241 lines) + `references/agent-teams.md` (shared-task-list substrate, states, `blockedBy`, TeammateTool, the flag, known limits) + `references/hooks.md` (`TaskCompleted` gate / `TeammateIdle` feeder / `Stop` re-trigger). A **default-FAIL whole-board proof** (every task completed + gate-passing + no dangling `blockedBy`), the full guardrail stack inherited from `loop-controller` and mapped onto the team substrate (the 3-failure circuit breaker *is* its no-progress detection; enforced budget; checkpoint commit per task; HITL; sandbox), the "promote to unattended only when…" preconditions, and a degradation path for when Agent Teams is off.
- **Wiring (bidirectional)** — `orchestrator` `composes_with` += the new skill; the **Native Agent Teams runtime branch**, the loops Composition bullet, the circuit-breaker bullet, and the circuit-breaker reference pointer all name it as the outer loop (`orchestrator` `1.12.0 → 1.13.0`). `loop-controller` + `fix-until-green` `composes_with` += `orchestrator-task-loop`; `loop-controller/references/authoring.md` taxonomy row added.
- **Catalog/docs** — `catalog.sh --sync` bumped `plugin.json` / `marketplace.json` / `README` / `CLAUDE.md` / `PLAN.md` / `START-HERE.md` to 56; README mermaid node (`otl`) + feature bullet added (these two aren't auto-synced).

## How it was built (ultracode)

Dynamic Workflow: **understand** (archetype spec / skill template / wiring+registration, parallel) → **design** (schema'd full spec) → **implement** (single author, no write conflicts) → **verify** (mechanical + adversarial). The adversarial pass caught two stale README spots that `--sync` doesn't touch (mermaid node list + feature bullet); both fixed.

## Test plan

- [x] `scripts/catalog.sh --check` — clean at **56**.
- [x] `scripts/lint-skills.sh skills/` — **0 errors** (CI-equivalent: gitignored `node_modules` / `*-workspace` moved aside).
- [x] `bats tests/catalog tests/install-plan` — **all pass** (incl. the per-category-counts test; loops resolves at 3).
- [x] New SKILL.md frontmatter valid; description 1017 chars (≤1024), no `<`/`>`; bidirectional `composes_with` consistent.

### Noted (deferred, not in scope)
- `tests/install-plan` test 31's `find`-based disk-truth doesn't exclude gitignored `*-workspace` snapshots — a pre-existing test-harness gap (passes clean once junk is excluded). Worth a `grep -v workspace` fix separately, like `tests/catalog` already does.
- Pre-existing: the orchestrator wave-gate line references `design-token-guard/references/wiring-into-orchestrator.md`, which doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsmrmoh7x1htYKtebar1vs