### PR TITLE
docs: Align primitives.md with the ultracode keyword rename

### DIFF
--- a/skills/loops/loop-controller/references/primitives.md
+++ b/skills/loops/loop-controller/references/primitives.md
@@ -107,7 +107,9 @@ Fan-out, not convergence-in-place.
 
 - **`/batch`** spreads one large change across **5–30 parallel worktree-isolated
   subagents**, each opening a PR.
-- **Dynamic workflows** (research preview, CLI **v2.1.154+**): Claude writes a
+- **Dynamic workflows** (debuted as a research preview at CLI **v2.1.154**; the
+  opt-in keyword was renamed `workflow` → **`ultracode`** at v2.1.160, and the
+  feature ships default-on for Max/Team/API at v2.1.170 / Fable 5): Claude writes a
   **JavaScript orchestration script** that fans out across up to **1,000
   subagents (16 concurrent)**, keeping intermediate results in script variables
   (not context). Primitives: `agent()` (one subagent, optional JSON-schema-


### PR DESCRIPTION
## Summary

- `loop-controller/references/primitives.md` described dynamic workflows as *"(research preview, CLI v2.1.154+)"*, which predated the orchestrator's current framing of the `workflow` → `ultracode` keyword rename. This is a one-spot, docs-only consistency fix so the loops reference matches `orchestrator/SKILL.md`'s Runtime Detection notes.

## Changes

- `primitives.md`: the dynamic-workflows note now reads — *debuted as a research preview at CLI v2.1.154; the opt-in keyword was renamed `workflow` → `ultracode` at v2.1.160; ships default-on for Max/Team/API at v2.1.170 / Fable 5.*

## Context

The `ultracode` migration itself was already complete (the orchestrator's description, Runtime Detection, and `workflow-orchestration.md` all use it; `primitives.md:120` already deferred to "the orchestrator's Workflow mode (ultracode)"). This only tightens the one stale version-string parenthetical. All other "workflow" mentions are intentional (the `Workflow` tool, the `skills/workflows/` category, the dynamic-workflows feature, and the retained "use a workflow" natural-language alias).

## Test plan

- [x] Docs-only change to one reference file; no frontmatter, no skill body, no catalog impact.
- [x] Wording matches `orchestrator/SKILL.md:138-145` verbatim on the version/keyword facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsmrmoh7x1htYKtebar1vs