### PR TITLE
test: Exclude gitignored junk from install-plan per-category disk count

### DIFF
--- a/tests/install-plan/01-plan-apply-lifecycle.bats
+++ b/tests/install-plan/01-plan-apply-lifecycle.bats
@@ -248,10 +248,19 @@ assert 'archive' not in cats
 
 @test "profile resolution: per-category skill counts match disk (catalog rule)" {
   plan --profile full --tool claude-code --out "$ROOT/plan.json"
-  # Disk truth: count skill dirs per category, excluding archive/in-progress.
+  # Disk truth: count skill dirs per category using the SAME filter as
+  # scripts/catalog.sh, so this independent check agrees with what the catalog
+  # registered. A real skill's SKILL.md sits at skills/<category>/<skill>/SKILL.md
+  # (depth <=3), so -maxdepth 3 drops the gitignored junk that lives deeper —
+  # bundled node_modules SKILL.md scaffolds and *-workspace eval snapshots. The
+  # explicit greps make that intent obvious and stay robust if such junk ever
+  # appears at a shallower depth; no real skill path contains those tokens.
+  # Without this, gitignored junk inflates the per-category counts and the test
+  # fails on a working tree that has eval workspaces or installed node_modules.
   local disk
-  disk="$(find "$REPO_ROOT/skills" -name SKILL.md -type f \
+  disk="$(find "$REPO_ROOT/skills" -maxdepth 3 -name SKILL.md -type f \
             | grep -v '/archive/' | grep -v '/in-progress/' \
+            | grep -v '/node_modules/' | grep -v -- '-workspace/' \
             | while IFS= read -r f; do
                 d="$(dirname "$f")"; slug="$(basename "$d")"
                 parent="$(basename "$(dirname "$d")")"


### PR DESCRIPTION
## Summary

- The `tests/install-plan` test *"profile resolution: per-category skill counts match disk (catalog rule)"* built its disk-truth with a bare `find skills -name SKILL.md`, which also counts gitignored junk nested below a skill root — bundled `node_modules` SKILL.md scaffolds and `*-workspace` eval snapshots. On a working tree that has eval workspaces or installed `node_modules`, those inflate a category's count and the test fails **locally** (it passes on CI only because that junk is gitignored and absent from a clean checkout).
- This surfaced during the loops work: every CI-equivalent local run needed a manual "move the junk aside" dance just to get this one test green. `tests/catalog` already excludes the junk; this brings `install-plan` in line.

## Changes

`tests/install-plan/01-plan-apply-lifecycle.bats` — the disk-truth `find` now mirrors `scripts/catalog.sh`'s filter exactly, so this independent check uses the same definition of "a skill" the catalog registered:
- `-maxdepth 3` — a real skill's SKILL.md is at `skills/<category>/<skill>/SKILL.md` (depth ≤3); the junk all lives at depth ≥4.
- explicit `grep -v '/node_modules/'` and `grep -v -- '-workspace/'` — defensive + self-documenting; no real skill path contains those tokens.

## Test plan

- [x] `bats tests/catalog tests/install-plan` now passes **34/34 with the junk present** (previously this test failed on the inflated `workflows` count); counts resolve at 56 either way.
- [x] No product code touched — test-harness only. No change to a clean-checkout run (the junk is gitignored, so CI was already green; this just makes local runs match CI without the manual junk-move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsmrmoh7x1htYKtebar1vs