### PR TITLE
fix: Clear the FA-fidelity skill backlog (FA1/FA2/FA4/FA5 + CL1)

### DIFF
--- a/skills/git/git-commit/SKILL.md
+++ b/skills/git/git-commit/SKILL.md
@@ -107,6 +107,12 @@ PRs merge with a **squash merge** by default unless the branch has a meaningful 
 
 ---
 
+## Co-Authored-By Trailer
+
+Commits in this repo end with a `Co-Authored-By: Claude ... <noreply@anthropic.com>` trailer and a `Claude-Session:` line. These are applied automatically from the agent's environment/system instructions — do **not** hand-type them into the message body, and do not invent or alter the email or session URL. Write your `type: description` subject and optional body as normal; the trailers are appended below the body, separated by a blank line, as the last lines of the message.
+
+---
+
 ## Quick Checklist
 
 - [ ] Subject line: `type: description` (lowercase, imperative, no scope, no period)

--- a/skills/meta/skill-explorer/SKILL.md
+++ b/skills/meta/skill-explorer/SKILL.md
@@ -19,6 +19,8 @@ spawned_by: []
 
 The user has accumulated a large toolkit (40+ repo skills plus plugin skills loaded into every session). Names blur together, descriptions overlap, and reaching for the wrong entry point (typically `orchestrator`) wastes a turn before getting redirected. This skill is the deliberate entry point for "what do I have / which one is right for this".
 
+**skill-explorer vs its siblings.** Use `skill-explorer` (this skill) to *discover, recall, explain, and route* — it names the right skill and stops, leaving you to fire it. Use `madness` when you want that routing decision *acted on* — it picks the entry point and launches it (confirming first on anything expensive). Use `skill-catalog` when you want the authoritative generated inventory/counts of what is installed, not a recall or routing answer. (There is no `find-skills` skill in this repo; that name belongs to a separately-installed plugin.)
+
 It answers four kinds of question:
 
 

--- a/skills/roles/qe-agent/SKILL.md
+++ b/skills/roles/qe-agent/SKILL.md
@@ -28,6 +28,8 @@ spawned_by: ["orchestrator"]
 
 Verify that implementations match contracts, integrations connect, and edge cases are handled. Your job is to find problems — not to fix them.
 
+> **qe-agent vs contract-auditor.** `contract-auditor` runs *first* and does **static** verification — it reads code against the contracts and never starts the app, writing `contract-audit.md`. `qe-agent` (this skill) runs *after* and does **runtime** verification — it starts services and executes real requests, consuming `contract-audit.md` in its Phase 1 and owning the `qa-report.json` build gate. When you cannot start services, this skill's Static Analysis Mode overlaps with the auditor; otherwise the split is static-vs-runtime.
+
 ## When this skill applies
 
 This skill assumes a contract-first multi-agent build model:

--- a/skills/roles/security-agent/SKILL.md
+++ b/skills/roles/security-agent/SKILL.md
@@ -146,6 +146,9 @@ Generated: [timestamp]
 Before hand-auditing, run the deterministic scanner and triage its output rather than hunting from scratch:
 
 ```bash
+# scan-skills.sh is Skill-Madness repo-root tooling (not bundled with this skill).
+# It scans skills/ for secrets, injection, bidi-unicode, and untrusted composes.
+# Run it from the Skill-Madness checkout root when auditing a skills library:
 scripts/scan-skills.sh --json
 ```
 

--- a/skills/workflows/caveman/SKILL.md
+++ b/skills/workflows/caveman/SKILL.md
@@ -2,7 +2,7 @@
 name: caveman
 version: 1.1.0
 description: |
-  Ultra-compressed communication mode. Cuts response tokens ~75% by dropping articles, filler, pleasantries, and hedging while preserving full technical accuracy (code, error strings, file paths untouched). Persists across every response until the user says 'stop caveman' or 'normal mode'; body covers the auto-clarity exception list. Trigger on: 'caveman mode', 'talk like caveman', 'less tokens', 'be terse', 'compress', '/caveman', 'fewer tokens', 'stop being verbose'.
+  Ultra-compressed communication mode. Cuts response tokens ~75% by dropping articles, filler, pleasantries, and hedging while preserving full technical accuracy (code, error strings, file paths untouched). Persists across every response until the user says 'stop caveman', 'normal mode', or 'be normal again'; body covers the auto-clarity exception list. Trigger on: 'caveman mode', 'talk like caveman', 'less tokens', 'be terse', 'compress', '/caveman', 'fewer tokens', 'stop being verbose'.
 requires_agent_teams: false
 requires_claude_code: true
 min_plan: starter

--- a/skills/workflows/claude-design-brief/SKILL.md
+++ b/skills/workflows/claude-design-brief/SKILL.md
@@ -31,7 +31,7 @@ This skill is the sibling of `ui-brief` (which targets Claude Code / production 
 
 ## Coverage Guide — What Needs To Be In The Brief
 
-These are the decisions Claude Design is likely to lack if you don't address them. Cover each one in whatever form fits the project — as prose, per-direction blocks, embedded in the opening framing, or wherever it lands most naturally. They do not need to be labeled or in any fixed order. The test is not "did I address all 13 categories by name" — it is "does this brief leave Claude Design nothing to ask."
+These are the decisions Claude Design is likely to lack if you don't address them. Cover each one in whatever form fits the project — as prose, per-direction blocks, embedded in the opening framing, or wherever it lands most naturally. They do not need to be labeled or in any fixed order. The test is not "did I address all 12 categories by name" — it is "does this brief leave Claude Design nothing to ask."
 
 | Decision area | What to commit |
 |---|---|

--- a/skills/workflows/deployment-checklist/references/pre-deploy.md
+++ b/skills/workflows/deployment-checklist/references/pre-deploy.md
@@ -45,7 +45,7 @@ npm run test:e2e
 
 ```bash
 # Check .env.example has all required vars
-diff <(grep -oP '^\w+' .env.example | sort) <(grep -oP '^\w+' .env | sort)
+diff <(grep -oE '^[A-Za-z_][A-Za-z0-9_]*' .env.example | sort) <(grep -oE '^[A-Za-z_][A-Za-z0-9_]*' .env | sort)
 
 # Verify no placeholder values in target environment
 grep -n "TODO\|CHANGEME\|xxx\|your-.*-here" .env

--- a/skills/workflows/design-token-guard/SKILL.md
+++ b/skills/workflows/design-token-guard/SKILL.md
@@ -16,6 +16,8 @@ description: >-
   auto-discovers the project's tokens, so it is NOT specific to any one repo or
   to Tailwind. Don't skip it because a visual/render review passed: render gates
   can't see a hardcoded color — it renders identically to the token.
+compatibility: Claude Code; requires Python 3.8+ (stdlib only) to run scripts/check_design_tokens.py; ESLint scaffolding step is optional
+allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep"]
 ---
 
 # design-token-guard

--- a/skills/workflows/diagnose-loop/SKILL.md
+++ b/skills/workflows/diagnose-loop/SKILL.md
@@ -19,6 +19,8 @@ spawned_by: []
 
 > **Tradeoff caveat.** This skill biases toward thoroughness over speed. For trivial bugs with obvious causes (typos, off-by-one, a missing import the stack trace already points at), skip phases and just fix it. For everything else — flaky tests, performance regressions, "it works on my machine," intermittent failures, anything you've stared at for more than 15 minutes — the discipline is the point. Adapted from mattpocock's `diagnose` pattern.
 
+> **diagnose-loop vs systematic-debugging.** The plugin skill `superpowers:systematic-debugging` is the general "form a hypothesis before you touch a fix" discipline for any bug or unexpected behavior. Reach for `diagnose-loop` (this skill) specifically when the payoff is in *building a fast, deterministic, binary feedback loop first* — flaky tests, performance regressions, hard-to-reproduce or intermittent failures. For a straightforward bug where you just need disciplined hypothesizing, `superpowers:systematic-debugging` is the lighter fit.
+
 ## Phase 1 — Build a feedback loop (THE SKILL)
 
 **Spend disproportionate effort here. Be aggressive. Be creative. Refuse to give up.**

--- a/skills/workflows/interactive-doc/SKILL.md
+++ b/skills/workflows/interactive-doc/SKILL.md
@@ -17,6 +17,8 @@ spawned_by: []
 
 Pair an Obsidian-friendly markdown source with a self-contained HTML companion. The .md is the canonical source of truth — token-efficient, wiki-linkable, what other agents and tools consume. The HTML is the experience for humans who want to *read* it instead of *grep* it. Same content, two surfaces.
 
+> **Design tokens do not apply here.** These docs are standalone, handmade artifacts that live in a repo or vault, not product UI governed by a project's design-token system — so `design-token-guard` / `class-extraction-guard` are out of scope. The HTML's own theming uses CSS variables in `:root` (see House style below); that local convention is the only "token" layer, and you should *not* try to wire these docs into an application's token pipeline or framework CSS.
+
 ## The two workflows
 
 This skill handles two distinct jobs. Identify which one applies before doing anything else.
@@ -148,7 +150,7 @@ You:
 User: "Create a doc explaining how SKILL.md works as an operational contract."
 
 You:
-1. Confirm the substance — what does the user know about this? Where does it live in the code? What sources can you draw from? (Check past chats with `conversation_search` if it'd help.)
+1. Confirm the substance — what does the user know about this? Where does it live in the code? What sources can you draw from? (Check past conversations if available and if it'd help.)
 2. Pick type → concept explainer (it's pedagogical, wants a live demo).
 3. Read references for concept-explainer, house-style, markdown-document.
 4. Write `skill-md-as-contract.md` first — full prose, frontmatter, callouts, wiki links to `[[hive-orchestrator]]` and `[[agent-anatomy]]`, a Mermaid diagram of the dispatch flow, file-referenced code samples.

--- a/skills/workflows/nano-banana/SKILL.md
+++ b/skills/workflows/nano-banana/SKILL.md
@@ -42,10 +42,10 @@ The bundled script uses `gemini-2.5-flash-image` — Google's current image gene
 
 ## Setup
 
-The script requires a `GEMINI_API_KEY` environment variable. It looks for the key in this order: process env → current project's repo-root `.env` → `~/.config/nano-banana/.env` as a user-wide fallback. If not set, direct the user to:
+The script requires a `GEMINI_API_KEY` environment variable. It looks for the key in this order: process env → the skills repo-root `.env` (`Skill-Madness/.env`) → the nano-banana skill's own `.env`. If not set, direct the user to:
 
 1. Get a key at https://aistudio.google.com/apikey
-2. Add it to the current project's repo-root `.env` (see `.env.example` for the template), or to `~/.config/nano-banana/.env` for a user-wide default
+2. Add it to the skills repo-root `.env` (`Skill-Madness/.env`; see `.env.example` for the template)
 
 ## Generating Images
 

--- a/skills/workflows/plan-builder/SKILL.md
+++ b/skills/workflows/plan-builder/SKILL.md
@@ -43,6 +43,7 @@ The orchestrator is powerful but needs a well-structured plan to work from. This
 - **Plan-builder** (this skill) synthesizes known inputs into a build plan. It works when you have source material, a clear goal, or a spec from brainstorming. It asks at most 3 clarifying questions before producing a draft — bias toward action.
 - **Writing-plans** produces TDD-level implementation detail (exact file paths, test code, commit messages) for single-agent sequential execution. Plan-builder produces architecture-level plans for multi-agent parallel execution.
 - **Orchestrator** consumes the plan this skill produces. It sizes teams, authors contracts, and spawns agents.
+- **Living-plan** is for *maintaining* an existing plan over time — a front door, a tactical ledger, and a report-intake loop so work stays tracked instead of rotting. Use plan-builder (this skill) to *create* a plan from source material once; use living-plan when the project already has a plan and you need to keep it alive as new reports and work items arrive.
 
 ```text
 brainstorming (vague idea) → plan-builder (structured plan) → orchestrator (agent army)

--- a/skills/workflows/render-sanity/SKILL.md
+++ b/skills/workflows/render-sanity/SKILL.md
@@ -156,7 +156,7 @@ This skill catches one specific failure mode: **the app renders, but renders bro
 
 ## When invoked by other skills
 
-- **`orchestrator`** is the primary invoker. It calls render-sanity at Phase 12 (post-build verification) BEFORE `ux-review` — render-sanity catches broken-content failures; ux-review then assesses polish on a known-good shell. A render-sanity FAIL blocks the build's Definition of Done.
+- **`orchestrator`** is the primary invoker. It calls render-sanity during post-build verification, BEFORE `ux-review` — render-sanity catches broken-content failures; ux-review then assesses polish on a known-good shell. A render-sanity FAIL blocks the build's Definition of Done.
 - **`ux-review`** MAY invoke render-sanity as a precondition. When it does, the render-sanity report becomes the "Critical Issues" section of the ux-review report.
 - **`feature-dev:feature-dev`** SHOULD invoke render-sanity after a feature is wired end-to-end, before declaring "the feature works."
 - **The user** can invoke this skill directly any time they want a fast objective answer to "is the UI actually working" — typically after a build claims done, after a refactor, after auth was added, or after seeing a screenshot with `?` / `Couldn't load` / dead links.

--- a/skills/workflows/sync-skills/SKILL.md
+++ b/skills/workflows/sync-skills/SKILL.md
@@ -74,10 +74,10 @@ $SCRIPT --dry-run --link --to-all
 
 Creates symlinks from global locations pointing to repo directories. This is the development workflow — edit skills in the repo and they're instantly live in Claude Code and Cursor.
 
-- **Claude Code**: Skills are **flattened** — each individual skill gets its own symlink directly under `~/.claude/skills/` (e.g., `~/.claude/skills/skill-audit` → `repo/skills/meta/skill-audit`). This is required because Claude Code only discovers skills at `~/.claude/skills/<skill-name>/SKILL.md`.
+- **Claude Code**: Skills are **flattened** — each individual skill gets its own symlink directly under `~/.claude/skills/` (e.g., `~/.claude/skills/skill-review` → `repo/skills/meta/skill-review`). This is required because Claude Code only discovers skills at `~/.claude/skills/<skill-name>/SKILL.md`.
 - **Cursor**: Symlinks are created at the **category level** (e.g., `~/.cursor/skills-cursor/meta` → `repo/skills/meta`)
 - Non-repo skills in global locations (e.g., `~/.claude/skills/builtWithAgent/`) are untouched
-- If a copy already exists where a symlink would go, the script warns and asks before replacing
+- If a copy already exists where a symlink would go, the script reports it and replaces the copy with a symlink (use `--dry-run` to preview first)
 
 ### Copy Mode (`--copy`)
 
@@ -118,7 +118,7 @@ $SCRIPT --from-cursor shell              # Pull only the shell skill
 
 ## How It Works
 
-**Linking:** For Claude Code, discovers every individual skill within category directories and creates a flattened symlink for each (e.g., `~/.claude/skills/skill-audit` → `repo/skills/meta/skill-audit`). For Cursor, creates category-level symlinks. If the target already exists as a real directory, warns before replacing.
+**Linking:** For Claude Code, discovers every individual skill within category directories and creates a flattened symlink for each (e.g., `~/.claude/skills/skill-review` → `repo/skills/meta/skill-review`). For Cursor, creates category-level symlinks. If the target already exists as a real directory, warns before replacing.
 
 **Status detection:** Checks each expected location and reports whether it's a symlink (and where it points), a copy, or missing. Also detects broken symlinks.
 

--- a/skills/workflows/ui-brief/SKILL.md
+++ b/skills/workflows/ui-brief/SKILL.md
@@ -23,6 +23,8 @@ Produce opinionated, design-leading UI briefs that survive contact with implemen
 
 The default failure mode for LLM-driven UI work is converging on the same shadcn-default-card-grid for every product. This skill exists to write a brief so opinion-dense and reference-specific that the implementing agent cannot drift back into that default. The output is a standalone Markdown file the user (or an orchestrator + frontend-agent) can paste into a fresh Claude Code session and execute against.
 
+**ui-brief vs its siblings.** Reach for `ui-brief` when the deliverable is a written spec to hand to a *Claude Code production build*; use `claude-design-brief` instead when you want hi-fi mockups or A/B/C directions drawn on the *Claude Design canvas* at claude.ai, and `frontend-design` (or `frontend-agent`) when you want the UI actually built rather than briefed.
+
 **Announce at start:** "Using ui-brief to write an opinionated design brief for [project]."
 
 ## Two Modes — Greenfield vs Rebuild


### PR DESCRIPTION
## Summary

- Clears the **decision-independent** half of the skill-fidelity backlog (FA1/FA2/FA4/FA5 + CL1) — 15 skills, small surgical edits, each adversarially verified by a fresh-context reviewer.
- Run as a migration-loop sweep under ultracode (discover → apply → verify pipeline, one agent per file).
- Leaves the four genuine **decisions** (FA7 metadata, FA8 scores, CL2 hermes, CL3 catalog-coverage) for a separate HITL pass — not in this PR.

## Changes

**FA5 cosmetics**
- `caveman` — description now lists all three exit phrases (`be normal again` was missing)
- `claude-design-brief` — self-check `13 → 12` categories (true decision-table row count)
- `render-sanity` — post-build phase wording de-numbered (the old "Phase 12" matched no canonical numbering)
- `interactive-doc` — drops the non-portable `conversation_search` tool reference

**CL1**
- `sync-skills` — `skill-audit` → `skill-review` (the referenced skill doesn't exist)

**FA1 doc-vs-script truth-up** (doc corrected to match the actual script)
- `nano-banana` — real `.env` lookup order; drops the `~/.config/nano-banana/.env` fallback the script never reads
- `sync-skills` — link-replace no longer claims it "asks" before replacing (the script `rm -rf`s without prompting)
- `security-agent` — `scan-skills.sh` documented as repo-root tooling, run from the repo root
- `deployment-checklist` — `grep -oP` (GNU-only; fails on macOS/BSD) → POSIX `grep -oE`

**FA4 disambiguation clauses**
- `ui-brief`, `plan-builder`↔`living-plan`, `interactive-doc` (tokens), `skill-explorer`↔siblings, `git-commit` (trailer convention), `diagnose-loop`↔`systematic-debugging`, `qe-agent`↔`contract-auditor`

**FA2 allowed-tools**
- `design-token-guard` — adds `allowed-tools` + `compatibility`

## Test plan

- [ ] `scripts/catalog.sh --check` passes (no skill count change; this PR edits bodies only)
- [ ] `scripts/lint-skills.sh skills/` exits 0 in CI (the local failures are from untracked `class-extraction-guard`, workspace debris, and gitignored `node_modules` — none are in this branch)
- [ ] `bats tests/standard` green in CI
- [ ] Spot-check the FA1 fixes against their scripts (nano-banana `.env`, sync-skills `_do_link`, deployment-checklist `grep`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)