### PR TITLE
fix: model-adaptation content corrections from the offline-window review

### DIFF
--- a/skills/meta/model-adaptation/SKILL.md
+++ b/skills/meta/model-adaptation/SKILL.md
@@ -7,10 +7,6 @@ requires_claude_code: false
 min_plan: starter
 compatibility: "Claude Code or Claude.ai; reference/advisory skill. No special tools required — WebFetch is optional, only to re-pull the live Anthropic guide."
 allowed-tools: ["Read", "Grep", "Glob", "Edit", "WebFetch"]
-metadata:
-  author: ivy00johns
-  category: meta
-  tags: [model-migration, prompting, fable-5, mythos-5, refusals, effort, long-running-agents]
 composes_with: ["skill-writer", "skill-review", "skill-update", "loop-controller", "orchestrator", "claude-api"]
 spawned_by: []
 ---
@@ -53,8 +49,9 @@ So migration is mostly **subtraction**:
 - **A brief instruction now beats an enumeration.** Where you once listed every bad
   behavior by name ("don't survey options, don't over-explain root causes, don't write
   narrating comments…"), one short instruction plus the *reason* now steers the whole
-  cluster. Fewer words, better result. (This is why `skill-writer`'s "explain the why,
-  not a wall of MUSTs" was already the right instinct — the newer model rewards it more.)
+  cluster. Fewer words, better result. (This is why `skill-review`'s long-standing
+  anti-pattern — *"Excessive MUST / NEVER / ALWAYS without explaining why"* in its
+  audit checklist — was already the right instinct; the newer model rewards it more.)
 - **Some old instructions now actively backfire.** The sharpest example: telling the
   model to reproduce, echo, or explain its internal reasoning *in the response* can trip
   a **`reasoning_extraction` refusal** on the Claude 5 family and silently elevate
@@ -75,7 +72,7 @@ This is the *only* part meant to age. The patterns below it are durable; these f
 
 | Model | Role today | What to know for adaptation |
 |---|---|---|
-| **Fable 5** | Frontier (Claude 5 family) | Long-horizon autonomy (multi-day runs), strong first-shot correctness, dispatches parallel subagents readily, high bug-finding recall. Runs safety classifiers (offensive cyber, bio/life-sciences, reasoning-extraction) → can return `stop_reason: "refusal"`. Adaptive thinking only; no extended-thinking budgets; summarized-only thinking output. |
+| **Fable 5** | Frontier (Claude 5 family) | Long-horizon autonomy (multi-day runs), strong first-shot correctness, dispatches parallel subagents readily, high bug-finding recall. Runs safety classifiers (offensive cyber, bio/life-sciences, frontier-LLM development, reasoning-extraction) → can return `stop_reason: "refusal"`. Adaptive thinking only; no extended-thinking budgets; summarized-only thinking output. |
 | **Mythos 5** | Frontier sibling (Claude 5 family) | Same family, same prompting patterns and refusal behavior as Fable 5. Everything here that says "Fable 5" applies to Mythos 5 unless a future note says otherwise. |
 | **Opus 4.8** | Prior baseline **and the fallback target** | The model a refused Claude 5 request should reroute to. Prompts/skills tuned for it are the ones this skill helps you prune. |
 
@@ -93,7 +90,7 @@ Depth lives in the two reference files; this is the map.
 |---|---|---|---|
 | **Prune over-prescription** | Prior-model prescription degrades Claude 5 output | On migration, delete enumerations/rigid templates the model no longer needs; keep the *why*, drop the MUSTs | `skill-review` anti-pattern checklist (*"Excessive MUST/NEVER/ALWAYS"*, *"Overly rigid templates"*) — now flagged as a **model-driven** re-review trigger, not just static smell |
 | **Reasoning-extraction refusal** | Telling the model to narrate/echo its reasoning as response text now trips a refusal | Never instruct "show your thinking / explain your reasoning in the output"; read structured `thinking` blocks or use a send-to-user tool instead | `skill-review` audit checklist (new anti-pattern) → detail in `references/refusal-and-fallback.md` |
-| **Brief instruction > enumeration** | One instruction + the reason steers a whole behavior cluster | Prefer a short "why" over naming every behavior; don't carry the *description* field's "pushy / over-enumerate" style into *behavioral* instructions | `skill-writer` body guidance; `references/long-run-hygiene.md` has the drop-in brevity instruction |
+| **Brief instruction > enumeration** | One instruction + the reason steers a whole behavior cluster | Prefer a short "why" over naming every behavior; don't carry the *description* field's "pushy / over-enumerate" style into *behavioral* instructions | `skill-review` audit checklist (*"Excessive MUST/NEVER/ALWAYS"* + the prior-model over-prescription trigger); `references/long-run-hygiene.md` has the drop-in brevity instruction |
 | **Give the reason, not only the request** | The model connects the task to context better when it knows intent | Already a scored `skill-review` rubric dimension (*"explains WHY, not just WHAT"*) — the Claude 5 family rewards it more | `skill-review` deep-review rubric |
 
 The one boundary to hold explicit: the **"pushy / over-enumerate"** philosophy is correct
@@ -141,8 +138,9 @@ The danger is that a skill-authoring toolkit can bake this into *every* skill it
 chain of thought"). If your app needs reasoning visibility, read the structured `thinking`
 blocks from adaptive thinking, or surface progress with a send-to-user tool — never ask
 the model to reproduce its reasoning in the response. `skill-review` now audits for this;
-the full mechanics, the other classifier domains (offensive cyber, bio/life-sciences), and
-the fallback configuration are in **`references/refusal-and-fallback.md`**.
+the full mechanics, the other classifier domains (offensive cyber, bio/life-sciences,
+frontier-LLM development), and the fallback configuration are in
+**`references/refusal-and-fallback.md`**.
 
 ## When a new model lands: the migration audit
 
@@ -153,9 +151,11 @@ Run this checklist against an existing skill/harness (or the whole toolkit) on a
 2. **Subtract first.** For each skill, ask per instruction: *does the new model already do
    this well without being told?* If yes, cut it. Rigid templates, anti-laziness nags, and
    long enumerations are the first candidates.
-3. **Hunt the refusal landmine.** Grep for reasoning-narration instructions
-   (`grep -riE "show your (thinking|reasoning)|narrate|reproduce.*reasoning|chain of thought"`).
-   Every hit that routes to the *response* is a refusal risk — rewrite it.
+3. **Hunt the refusal landmine.** Run the **audit recipe** in
+   `references/refusal-and-fallback.md` — that file owns the canonical grep (don't
+   inline a variant here; divergent copies of the sweep are exactly the drift this
+   skill exists to prevent). Every hit that routes reasoning to the *response* is a
+   refusal risk — rewrite it.
 4. **Check the long-run scaffolding.** For any loop/autonomous skill, confirm the
    `references/long-run-hygiene.md` patterns are wired: evidence-backed progress, the
    last-paragraph check, context-budget reassurance, effort selection, send-to-user.
@@ -167,7 +167,7 @@ Run this checklist against an existing skill/harness (or the whole toolkit) on a
 
 ## Reference files
 
-- `references/refusal-and-fallback.md` — the three Claude 5 classifier domains, the
+- `references/refusal-and-fallback.md` — the four Claude 5 classifier domains, the
   `reasoning_extraction` landmine in depth (what trips it, the symptom, the fix, how to
   audit for it), the `stop_reason: "refusal"` contract, and server-side vs client-side
   fallback to Opus 4.8. Read when a skill gets refused, when writing security-agent

--- a/skills/meta/model-adaptation/references/refusal-and-fallback.md
+++ b/skills/meta/model-adaptation/references/refusal-and-fallback.md
@@ -10,28 +10,33 @@ and the [Fable 5 prompting guide](https://platform.claude.com/docs/en/build-with
 
 ## Contents
 
-- The three classifier domains
+- The four classifier domains
 - The `reasoning_extraction` landmine (the one that bites a skill toolkit)
 - The `stop_reason: "refusal"` contract
 - Configuring fallback to Opus 4.8
 - Toolkit implications (security-agent, skill authoring)
 - Audit recipe
 
-## The three classifier domains
+## The four classifier domains
 
 Fable 5 and Mythos 5 run safety classifiers that can decline a request and return
-`stop_reason: "refusal"`. Three domains matter for this toolkit:
+`stop_reason: "refusal"`. All four domains matter for this toolkit:
 
 1. **Offensive cybersecurity** — building exploits, malware, or attack tooling. *Benign*
    security work (a `security-agent` doing defensive review, a pentest-flavored prompt in
    an authorized engagement) can also trip it. This is expected routing, not a bug.
 2. **Biology & life sciences** — lab methods, molecular mechanisms. Beneficial
    life-sciences tasks may also trigger it. Rare in this toolkit, but real.
-3. **Reasoning extraction** — attempts to extract the model's *summarized thinking*. This
+3. **Frontier-LLM development** (`frontier_llm`) — requests that could assist the
+   development of competing AI models. Anthropic's docs note *benign machine-learning
+   work can also trigger this category* — and this toolkit does exactly that kind of
+   work (model layers like `use-freellmapi`, LLM-judge evals, multi-agent harnesses),
+   so treat a refusal here as expected routing too.
+4. **Reasoning extraction** — attempts to extract the model's *summarized thinking*. This
    is the one a skill-authoring toolkit provokes by accident (next section).
 
-The first two are content-driven and mostly unavoidable for legitimate work in those
-domains — the answer is fallback configuration, not prompt surgery. The third is
+The first three are content-driven and mostly unavoidable for legitimate work in those
+domains — the answer is fallback configuration, not prompt surgery. The fourth is
 **self-inflicted** and fully in your control.
 
 ## The `reasoning_extraction` landmine

--- a/skills/meta/skill-review/references/audit-checklist.md
+++ b/skills/meta/skill-review/references/audit-checklist.md
@@ -100,9 +100,9 @@ These check whether a skill is written for the model actually running it. See th
   fallbacks to Opus 4.8 — so the skill quietly loses the frontier model. Flag every hit
   that routes reasoning to the response; a skill *doc* explaining "why" to the human, or
   an instruction to *think* internally without emitting it, is fine and stays. Rewrite
-  risky hits to read structured `thinking` blocks or use a send-to-user tool. Detail:
-  `model-adaptation/references/refusal-and-fallback.md`. Sweep with:
-  `grep -riE "show your (thinking|reasoning)|narrate.*(reasoning|thinking)|reproduce.*(reasoning|thought)|chain[ -]of[ -]thought" <skill>`
+  risky hits to read structured `thinking` blocks or use a send-to-user tool. Sweep
+  with the **audit recipe** in `model-adaptation/references/refusal-and-fallback.md`
+  — that file owns the canonical grep (inlined variants of it drift; one already did).
 - [ ] **Prior-model over-prescription.** The over-prescription smells above (excessive
   MUST/NEVER, overly rigid templates, fighting natural behavior) are *also* a
   model-migration signal: a stronger model needs less scaffolding, and prescription that


### PR DESCRIPTION
## Summary

Post-merge fixes for #37 (the review findings the merge didn't include):

- **Drop the frontmatter `metadata:` block** — FA7 (PR #34) removed it from every skill; model-adaptation had reintroduced it as the sole exception. (The frontmatter-spec gap that invited this is fixed in the tooling PR.)
- **Fix a fabricated attribution:** the skill quoted skill-writer guidance ("explain the why, not a wall of MUSTs") that exists nowhere in skill-writer; re-attributed — prose and the Bucket A "Enforced in" cell — to skill-review's real anti-pattern (*"Excessive MUST / NEVER / ALWAYS without explaining why"*).
- **Classifier domains: three → four.** The cited Anthropic refusals page defines `frontier_llm` alongside cyber / bio / reasoning-extraction, and this toolkit's model-layer + LLM-judge work is exactly the benign-ML class the docs warn can trigger it. Added to the reference (TOC, list, renumbered framing) and mirrored in the SKILL.md landscape table, landmine section, and reference blurb.
- **One canonical audit recipe:** the migration-audit step 3 grep had drifted from the recipe in its own reference (its bare `narrate` alternation returns only false positives), and skill-review's checklist carried a third variant (dropped `transcribe`). Both now point at the single canonical recipe in `refusal-and-fallback.md`.

## Test plan

- Full suite on a clean extraction: 303/303, lint OK, `catalog.sh --check` green at 69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LcMHfqckcwP2mue1LGqYx