### PR TITLE
fix: Make nano-banana find its API key across symlinked layouts

### DIFF
--- a/skills/workflows/nano-banana/SKILL.md
+++ b/skills/workflows/nano-banana/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nano-banana
-version: 1.3.0
+version: 1.4.0
 description: >
   Generate images using Google's Nano Banana (Gemini Image Generation) API and save them to the project. Use whenever
   the user asks to generate images, create product photos, hero banners, or lifestyle shots, mentions "Nano Banana" /
@@ -40,12 +40,16 @@ The bundled script uses `gemini-2.5-flash-image` — Google's current image gene
 - **4:5** — Lifestyle / editorial (1080x1350px)
 - Also: 1:4, 1:8, 2:3, 3:2, 4:1, 4:3, 5:4, 8:1, 9:16, 21:9
 
-## Setup
+## Setup — the key is already wired; do NOT hunt for it or ask for it
 
-The script requires a `GEMINI_API_KEY` environment variable. It looks for the key in this order: process env → the skills repo-root `.env` (`Skill-Madness/.env`) → the nano-banana skill's own `.env`. If not set, direct the user to:
+**Do not pre-check for the key with `env | grep` or `find`, and never ask the user to supply a key before you have actually run the script.** The script finds the key by itself, and a manual check will lie to you.
+
+Here is why this matters, because it has burned people (and cost real trust): this skill directory is normally a **symlink** into a separate repo — e.g. `~/.claude/skills/nano-banana → ~/Repos/.../Skill-Madness/skills/workflows/nano-banana`. The `GEMINI_API_KEY` lives in that repo's **root `.env`**, which sits *outside* `~/.claude/skills` entirely. The script calls `Path(__file__).resolve()`, so it follows the symlink to the real location and loads that `.env` every single time — it also walks every ancestor directory of both the script and your working directory, so it finds the key across layouts. But if *you* try to "verify" the key first with `find ~/.claude/skills -name .env` or `env | grep GEMINI`, you search the wrong tree, come up empty, and wrongly conclude the key is missing — then ask the user for a key they already set. That is the exact failure this section exists to prevent. Don't reproduce it.
+
+**The workflow is just: run the script.** It is self-sufficient about the key. The *only* trustworthy signal that the key is truly absent is the script exiting with its own `GEMINI_API_KEY ... is not set` error (which also prints the `.env` files it searched). Treat that error — and nothing else — as "key missing." Only then guide the user:
 
 1. Get a key at https://aistudio.google.com/apikey
-2. Add it to the skills repo-root `.env` (`Skill-Madness/.env`; see `.env.example` for the template)
+2. Add `GEMINI_API_KEY=...` to the skills repo-root `.env` (see `.env.example`), or `export GEMINI_API_KEY=...` in the shell.
 
 ## Generating Images
 
@@ -96,7 +100,7 @@ After generation:
 
 ### Step 4: Handle Issues
 
-- **API key missing**: Guide user to https://aistudio.google.com/apikey
+- **API key missing**: Trust this *only* if the **script itself** printed `GEMINI_API_KEY ... is not set` — never your own `grep`/`find` (see Setup for why that lies). If it genuinely is missing, guide the user to https://aistudio.google.com/apikey and to add it to the repo-root `.env`.
 - **Rate limited**: Wait a moment and retry, or suggest the user try again shortly
 - **Bad output**: Re-run with a tweaked prompt. Common fixes:
   - Add "Photorealistic" if output looks illustrated

--- a/skills/workflows/nano-banana/scripts/generate_image.py
+++ b/skills/workflows/nano-banana/scripts/generate_image.py
@@ -18,21 +18,57 @@ import sys
 import urllib.request
 import urllib.error
 
-# Load .env from the skills repo root (Skill-Madness/.env)
-# Walk up from scripts/ -> nano-banana/ -> workflows/ -> skills/ -> repo root
+# Resolve GEMINI_API_KEY from a .env if it isn't already exported.
+#
+# WHY THIS IS CAREFUL: this skill directory is usually a *symlink* into a separate
+# repo (e.g. ~/.claude/skills/nano-banana -> ~/Repos/.../Skill-Madness/.../nano-banana),
+# and the key lives in that repo's ROOT .env — OUTSIDE ~/.claude/skills. Path(__file__)
+# .resolve() follows the symlink, so we search from the REAL on-disk location. We then
+# walk every ancestor of both the resolved script dir and the current working directory
+# (plus ~/.env), so the key is found no matter how the repo is laid out. The nearest
+# .env that defines the key wins; we never overwrite a key already in the environment.
 _SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
-_REPO_ROOT = _SCRIPT_DIR.parent.parent.parent.parent
-for _candidate in [_REPO_ROOT / ".env", _SCRIPT_DIR.parent / ".env"]:
-    if _candidate.exists():
-        for line in _candidate.read_text().splitlines():
-            line = line.strip()
-            if line and not line.startswith("#") and "=" in line:
+
+
+def _candidate_env_files():
+    """Yield .env paths to search, nearest-first, de-duplicated."""
+    seen = set()
+    roots = [_SCRIPT_DIR]
+    try:
+        roots.append(pathlib.Path.cwd().resolve())
+    except OSError:
+        pass
+    for root in roots:
+        for directory in [root, *root.parents]:
+            candidate = directory / ".env"
+            if candidate not in seen:
+                seen.add(candidate)
+                yield candidate
+    home_env = pathlib.Path.home() / ".env"
+    if home_env not in seen:
+        yield home_env
+
+
+# Record where we looked so a genuine miss produces an actionable error (not a mystery).
+_SEARCHED_ENV_FILES = []
+if not os.environ.get("GEMINI_API_KEY"):
+    for _candidate in _candidate_env_files():
+        _SEARCHED_ENV_FILES.append(str(_candidate))
+        if not _candidate.exists():
+            continue
+        try:
+            for line in _candidate.read_text().splitlines():
+                line = line.strip()
+                if line.startswith("#") or "=" not in line:
+                    continue
                 key, _, value = line.partition("=")
-                key = key.strip()
-                value = value.strip().strip("\"'")
-                if key and key not in os.environ:
-                    os.environ[key] = value
-        break
+                if key.strip() == "GEMINI_API_KEY":
+                    os.environ["GEMINI_API_KEY"] = value.strip().strip("\"'")
+                    break
+        except OSError:
+            continue
+        if os.environ.get("GEMINI_API_KEY"):
+            break
 
 MODELS = {
     "standard": "gemini-2.5-flash-image",
@@ -57,7 +93,12 @@ def generate_image(prompt: str, output_path: str, aspect_ratio: str = "3:4",
     api_key = os.environ.get("GEMINI_API_KEY")
     if not api_key:
         print("Error: GEMINI_API_KEY environment variable is not set.", file=sys.stderr)
-        print("Get a key at https://aistudio.google.com/apikey", file=sys.stderr)
+        if _SEARCHED_ENV_FILES:
+            print("Searched these .env files (nearest-first) and found no GEMINI_API_KEY:", file=sys.stderr)
+            for path in _SEARCHED_ENV_FILES:
+                print(f"  - {path}", file=sys.stderr)
+        print("Add GEMINI_API_KEY=... to one of the above (or export it), or get a key at "
+              "https://aistudio.google.com/apikey", file=sys.stderr)
         sys.exit(1)
 
     model_id = MODELS.get(model_key, model_key)


### PR DESCRIPTION
## Summary

- The `.env` key lookup broke on the **first existing** `.env` whether or not it held `GEMINI_API_KEY`, so the documented fallback chain never ran — this is ledger item **RV6**, now closed by this PR.
- Worse in practice: because the skill dir is a symlink into this repo, an agent that "pre-checked" for the key with `env | grep` / `find ~/.claude/skills` searched the wrong tree, concluded the key was missing, and asked the user for a key they already set (the live failure this fixes).

## Changes

- `generate_image.py`: walk every ancestor of the resolved script dir and the cwd (plus `~/.env`) **nearest-first until the key is found**; never overwrite process env; print the searched paths on a genuine miss so the error is actionable.
- `SKILL.md` (v1.3.0 → 1.4.0): Setup rewritten — run the script, trust only its own "not set" error, never a manual pre-check.

## Test plan

- [ ] `scripts/lint-skills.sh skills/workflows/nano-banana` — 0 errors (verified locally)
- [ ] With the key only in the repo-root `.env`, run via the `~/.claude/skills` symlink — key found
- [ ] With no key anywhere, confirm the error lists the searched `.env` paths
- [ ] On merge: sweep the RV6 row to `docs/COMPLETED-WORK.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)