### PR TITLE
fix: Wire orphaned build loops + intent-to-loop routing (MR-1, MR-2)

### DIFF
--- a/skills/loops/loop-controller/SKILL.md
+++ b/skills/loops/loop-controller/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: loop-controller
-version: 1.1.1
+version: 1.2.0
 description: >-
   Wrap any task in a verifiable stop condition plus a mandatory guardrail stack
   so an autonomous loop converges instead of thrashing or burning the budget —
@@ -56,6 +56,31 @@ ever met.
 Everything else here — fix-until-green, coverage-loop, perf-loop — is a *config*
 of this harness: a specific proof plugged into the same machinery. Author new
 loops against this skill; don't reinvent the loop engine.
+
+## First — does a concrete loop already exist?
+
+Twelve configs of this harness already ship in `skills/loops/`. Route the intent
+to one of them before authoring anything — Steps 0–6 below are for the loop that
+*doesn't* exist yet. (Every one of these is `disable-model-invocation: true`:
+dispatch it by its slash command, or let the orchestrator dispatch the build
+loops. None auto-fires.)
+
+| The intent is… | Dispatch |
+|---|---|
+| "make tests / lint / typecheck pass", red CI, "run until green" | `fix-until-green` |
+| Drain a multi-agent build's shared task list until every task passes its gate (Agent Teams) | `orchestrator-task-loop` |
+| Build until an authored contract's criteria all hold (build-until-spec) | `contract-conformance-loop` |
+| "Keep my PR green / rebased / answer review comments while I'm away" | `babysit` |
+| "Raise test coverage to N%" | `coverage-loop` |
+| "Get this metric under its budget" (latency, bundle size, memory) | `perf-loop` |
+| "Watch the logs / CI and fix what breaks" | `self-healing-loop` |
+| "Migrate / transform every file in this enumerated set" | `migration-loop` |
+| "Keep the docs + changelog from rotting" (nightly) | `nightly-docs-and-changelog` |
+| "Keep dependencies current and audited" | `dependency-health-loop` |
+| "Map this unfamiliar codebase until my questions are answered" | `codebase-exploration-loop` |
+| "Weekly repo hygiene — stale branches, PRs, worktrees" | `repo-cleanup-loop` |
+
+No row fits → continue below and author the new loop against this harness.
 
 ## Step 0 — Should this even be a loop?
 
@@ -302,11 +327,13 @@ contract* and inherit the machinery:
   The authoring walkthrough (with the loop taxonomy and a frontmatter template)
   is `references/authoring.md`.
 
-Under the **orchestrator**, loops slot in at two levels: an inner loop per role
-(QE runs fix-until-green; performance runs profile-optimize-reprofile) and an
-outer loop over the shared task list (re-assign until every task passes its
-gate). That orchestrator wiring is a separate, later skill — this foundation is
-what it will build on.
+Under the **orchestrator**, loops slot in at two levels — and both are built:
+`orchestrator-task-loop` is the outer loop over the shared task list (re-assign
+until every task passes its gate), while the inner loops run per role —
+`fix-until-green` at the wave/QA gates, and `contract-conformance-loop` /
+`coverage-loop` / `perf-loop` / `migration-loop` dispatched when the mission
+calls for them (see the orchestrator's `references/phase-guide.md`, *Optional
+build loops*).
 
 ## Reference files
 

--- a/skills/meta/skill-explorer/SKILL.md
+++ b/skills/meta/skill-explorer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-explorer
-version: 1.1.1
+version: 1.2.0
 description: |
   Help the user discover, recall, understand, and pick the right skill from the available toolkit. Names the skill; does NOT invoke it. Use when the user is trying to find a skill ("I forgot the name of the one that does X", "what was that skill called"), asking what skills exist ("what skills do I have", "list all my skills", "show me the catalog"), asking what a specific skill does ("what does X do", "explain the X skill"), asking how skills relate ("how do these connect", "what does orchestrator spawn"), or asking for routing help ("which skill for this task", "what should I use to Y"). Also trigger when the user reaches for orchestrator on something that isn't a multi-agent build, or asks any meta-question about the skill ecosystem itself.
 requires_agent_teams: false

--- a/skills/meta/skill-explorer/references/routing-table.md
+++ b/skills/meta/skill-explorer/references/routing-table.md
@@ -118,6 +118,26 @@ Common user requests → recommended skill. Use this as a fallback when SKILL.md
 | "build a knowledge brain from past observations" | `claude-mem:knowledge-agent` |
 | "timeline report of this project's history" | `claude-mem:timeline-report` |
 
+### Autonomous loops
+
+All loop skills are `disable-model-invocation: true` — name them, then the user dispatches by slash command (or the orchestrator dispatches the build loops). `loop-controller` is the front door when no concrete loop fits.
+
+| User says... | Use |
+|---|---|
+| "make the tests/lint/typecheck pass", "run until green", red CI | `fix-until-green` |
+| "keep my PR green / rebased / address review comments while I'm away" | `babysit` |
+| "build until the contract/spec criteria hold" | `contract-conformance-loop` |
+| "raise coverage to N%" | `coverage-loop` |
+| "get this benchmark under budget / keep optimizing until X" | `perf-loop` |
+| "watch the logs/CI and fix what breaks" | `self-healing-loop` |
+| "migrate/transform every file matching X" | `migration-loop` |
+| "keep the docs and changelog fresh overnight" | `nightly-docs-and-changelog` |
+| "keep dependencies current / audited" | `dependency-health-loop` |
+| "explore/map this codebase until my questions are answered" | `codebase-exploration-loop` |
+| "clean up stale branches/PRs/worktrees weekly" | `repo-cleanup-loop` |
+| "drain the Agent-Teams task board until every task passes" | `orchestrator-task-loop` |
+| "loop until…" (nothing above fits), "author a new loop", "loop safely" | `loop-controller` |
+
 ### Settings / harness
 
 | User says... | Use |

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrator
-version: 1.15.0
+version: 1.16.0
 description: |
   Coordinate multi-agent Claude Code builds end-to-end: read the plan/mission, design integration contracts, dispatch role-agents in parallel, gate on QA, ship. Under ultracode (standing opt-in) or an explicit "workflow" ask, it drives the implement + verify phases with the Workflow tool — fanning out role-agents against the contracts and adversarially verifying instead of hand-spawning agents one message at a time. Use when the user mentions agent teams, parallel/swarm builds, multi-agent work, a MISSION.md file, a multi-phase mission, or splitting work across Claude sessions. Triggers on "agent team", "parallel build", "team build", "multi-agent", "swarm build", "build X with agents", "coordinate the build", "run the mission", "workflow", "dynamic workflows", "ultracode build", "orchestrate with workflows". Does NOT preempt brainstorming, planning, design-brief, or feature-dev — it picks up after those produce artifacts.
 requires_agent_teams: false
@@ -25,7 +25,8 @@ composes_with: [
   "claude-mem:mem-search", "claude-mem:timeline-report", "claude-mem:knowledge-agent",
   "skill-writer", "skill-review", "skill-update", "model-adaptation",
   "railway-deploy", "loop", "schedule",
-  "loop-controller", "fix-until-green", "orchestrator-task-loop"
+  "loop-controller", "fix-until-green", "orchestrator-task-loop",
+  "contract-conformance-loop", "coverage-loop", "perf-loop", "migration-loop"
 ]
 spawned_by: []
 ---
@@ -53,6 +54,7 @@ The orchestrator is the conductor — not the only player. It composes with thre
 - **DELEGATES diff/code review to the external `/code-review` CLI:** during a build, the Phase 4 diff review pass is the external `/code-review` CLI, NOT a spawned `code-review-agent`. The in-repo `code-review-agent` skill is not a default build phase — invoke it only deliberately for a standalone, repo-aware review. See `references/mission-interpretation.md`.
 - **DOES NOT preempt:** `brainstorming`, `plan-builder`, `writing-plans`, `claude-design-brief`, `ui-brief`, `feature-dev`, `claude-mem:*`. If any of these belong before the build starts, let them run first — orchestrator picks up from the artifacts they produce.
 - **RUNS the validation phases AS LOOPS (not one-shot checks):** the wave gate and the QA gate are convergence loops. `fix-until-green` is the contract for driving install/typecheck/test/QA red→green *without cheating the gate* — it is the QE inner loop and the wave-gate driver; `loop-controller` is the underlying harness (iterate → evaluate → guardrail → stop) whose no-progress/oscillation guardrail *is* the 3-failure circuit breaker and whose iteration/budget caps bound wave-gate retries. Both are `disable-model-invocation: true`: you **explicitly dispatch** them, they never auto-trigger because a test happened to fail. They shape *how* the validation phases iterate rather than being invoked at a single phase. Under native Agent Teams, `orchestrator-task-loop` drives the whole-task-list OUTER loop (drain the shared task list until every task is completed + passing its `TaskCompleted` gate, feeding idle workers via `TeammateIdle`), and each task's gate can be driven by a `fix-until-green` INNER loop (inner/outer composition). All three are `disable-model-invocation: true` — explicitly dispatched, never auto-triggered. See `skills/loops/`.
+- **DISPATCHES four more build loops when the mission calls for them:** `contract-conformance-loop` (a component must *converge on its authored contract* — build-until-spec, graded by a fresh-context evaluator — rather than one-shot it), `coverage-loop` (the mission sets a test-coverage target), `perf-loop` (the mission sets a performance budget), and `migration-loop` (the plan contains an enumerated wide-refactor / transform set). All four are `loop-controller` configs and `disable-model-invocation: true` — the **mission text** is their trigger, and you are their dispatcher; nothing fires on a failing check alone. The phase-by-phase dispatch table is in `references/phase-guide.md` (Phase 13's *Optional build loops*).
 
 <what-to-do>
 

--- a/skills/orchestrator/references/phase-guide.md
+++ b/skills/orchestrator/references/phase-guide.md
@@ -173,6 +173,19 @@ Gate rules:
 - Blocked when: any CRITICAL blocker, `contract_conformance.score < 3`, `security.score < 3`
 - The orchestrator does NOT override the QE gate
 
+### Optional build loops — dispatch when the mission calls for them
+
+All four are `loop-controller` configs and `disable-model-invocation: true`: they run only when you dispatch them, and the **mission text** is the trigger — never a failing check on its own.
+
+| Mission signal | Dispatch | When |
+|---|---|---|
+| A component must *converge on its authored contract* (build-until-spec) rather than one-shot it | `contract-conformance-loop` | Wraps that component's build (Phases 8–13); its fresh-context contract-auditor verdict feeds this QA gate |
+| A test-coverage target is set ("≥80% on the backend") | `coverage-loop` | After the QA gate passes — grow the suite to the target without gaming the metric |
+| A performance budget is set (p95 latency, bundle size, load time) | `perf-loop` | After the QA gate passes — profile → optimize → re-benchmark under repeatable conditions, no functional regression |
+| The plan contains an enumerated wide-refactor / transform set ("migrate all N call sites / files") | `migration-loop` | Plan it as its own work stream at Phases 2–3 — one file per iteration until the set is empty and the suite is green |
+
+`fix-until-green` (the wave/QA fix cycle) and `orchestrator-task-loop` (the Agent Teams outer loop) are already wired into the phases above; these four are the mission-conditional ones.
+
 ## Phase 14: Post-Build
 
 1. Spawn docs-agent to write README.md — provide full-system context (architecture summary, how to run, directory map). Docs-agent owns README.md.


### PR DESCRIPTION
## Summary

- Closes the two P1 dispatch gaps from the 2026-07-08 maxed-out-window review: four build loops claimed `spawned_by: ["orchestrator"]` but the orchestrator never mentioned them (MR-1), and the madness → loop-controller "picks the specific loop" promise had no routing table anywhere behind it (MR-2). Since all loops are `disable-model-invocation: true`, both gaps meant most of the library only triggered if the user already knew the slash name.

## Changes

- **orchestrator** (1.15.0 → 1.16.0): new Composition bullet — DISPATCHES `contract-conformance-loop` / `coverage-loop` / `perf-loop` / `migration-loop` when the mission calls for them; the four added to `composes_with`; new phase-guide "Optional build loops" dispatch table (mission text is the trigger, never a failing check alone).
- **loop-controller** (1.1.1 → 1.2.0): new "First — does a concrete loop already exist?" 12-row intent→loop table ahead of the authoring steps; the stale "orchestrator wiring is a separate, later skill" closer truthed to the shipped reality.
- **skill-explorer** (1.1.1 → 1.2.0): new "Autonomous loops" section in `references/routing-table.md` — 13 rows, so front-door intents like "keep my PR green" resolve to `babysit`.

## Test plan

- [ ] `scripts/lint-skills.sh` on the three skills — 0 errors (verified locally)
- [ ] `scripts/catalog.sh --check` — PASS @ 71 (verified locally)
- [ ] Grep `skills/orchestrator/` for each of the four loop names — now ≥1 hit each
- [ ] On merge (after intake PR #50): sweep MR-1 + MR-2 rows to `docs/COMPLETED-WORK.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)