### PR TITLE
fix: Read canonical allowed-tools in tooling + signing-safe fixture (MR-3, MR-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ The orchestrator and the multi-agent QA gate are Claude-Code-native — that's t
 | 🛰️  **Antigravity** | user | community-skill `SKILL.md` | generated |
 | 🌙 **Kimi Code** | user | YAML config + `system.md` | generated |
 
-**Lossy by design.** Claude-Code-specific orchestration fields (`allowed_tools`, `owns`, `composes_with`, `spawned_by`, `requires_agent_teams`) are stripped on conversion to the other ten hosts — those hosts don't run multi-agent dispatch with file-ownership exclusivity, so the metadata would be noise. You'll see one `[host] stripped allowed_tools/owns from <slug>` line per affected skill on stderr. Skills marked `requires_claude_code: true` are skipped entirely for non-Claude-Code targets.
+**Lossy by design.** Claude-Code-specific orchestration fields (`allowed-tools`, `owns`, `composes_with`, `spawned_by`, `requires_agent_teams`) are stripped on conversion to the other ten hosts — those hosts don't run multi-agent dispatch with file-ownership exclusivity, so the metadata would be noise. You'll see one `[host] stripped allowed-tools/owns from <slug>` line per affected skill on stderr. Skills marked `requires_claude_code: true` are skipped entirely for non-Claude-Code targets.
 
 > **Credit where it's due.** The eleven-host installer pattern, the `detect_<tool>()` probes, the interactive selection UI, the slug pipeline, and the OpenClaw soul/agents split are all adapted from [`msitarzewski/agency-agents`](https://github.com/msitarzewski/agency-agents) (MIT). Full attribution and the list of pieces that came across vs. were rewritten lives in [`ACKNOWLEDGMENTS.md`](ACKNOWLEDGMENTS.md). The orchestrator, role agents, contracts, QA gate, and the rest of the skill library are independent.
 
@@ -676,7 +676,7 @@ Expected. Skills with `requires_claude_code: true` — the `orchestrator`, all o
 </details>
 
 <details>
-<summary><b>"Stderr is full of <code>stripped allowed_tools/owns</code> lines"</b></summary>
+<summary><b>"Stderr is full of <code>stripped allowed-tools/owns</code> lines"</b></summary>
 
 That's by design — every Claude-Code-only frontmatter field that gets stripped on conversion to another host is announced. It's not an error; it's the installer being honest. Pipe stderr to a log file if it's noisy: `./scripts/convert.sh 2> convert.log`.
 </details>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -58,7 +58,7 @@ See `contracts/installer/per-tool-output-spec.md` for the full specification. Su
 
 - Deterministic: same input → identical output (except `antigravity` which includes `date_added` field)
 - Idempotent: re-running produces byte-identical output
-- Lossy: Claude-Code-only frontmatter fields (`owns`, `allowed_tools`, `composes_with`, `spawned_by`) are stripped with a stderr warning per skill
+- Lossy: Claude-Code-only frontmatter fields (`owns`, `allowed-tools`, `composes_with`, `spawned_by`) are stripped with a stderr warning per skill
 - Skills marked `requires_claude_code: true` are skipped for non-Claude-Code targets
 - Stderr summary at end: `[convert] processed 46 skills across 11 tools (0 errors, 0 warnings)`
 
@@ -328,7 +328,7 @@ scripts/lint-skills.sh [OPTIONS] [PATH ...]
 **Rule Categories:**
 
 - **Required Frontmatter:** `name` (kebab-case, matches directory), `version` (semver), `description` (non-empty)
-- **Recommended Frontmatter (agent roles only):** `owns.directories`, `allowed_tools`
+- **Recommended Frontmatter (agent roles only):** `owns.directories`, `allowed-tools`
 - **Body Quality:** present (≥1 line), ≥50 words (WARN if stub), ≤500 lines (WARN if too long)
 - **Description Quality:** starts with action verb, mentions trigger context. Heuristic-based (no hard rule for trigger detection).
 - **Cross-Skill Validation:** unique names, no overlapping `owns.directories`, valid `composes_with`/`spawned_by` references

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -241,8 +241,8 @@ convert_copilot() {
 
   # Emit per-skill stderr warning only when something was actually stripped
   # (avoids false-positive noise on minimal skills with neither field).
-  if fm_has_field "allowed_tools" "$file" || fm_has_field "owns" "$file"; then
-    printf '[copilot] stripped allowed_tools/owns from %s\n' "$slug" >&2
+  if fm_has_field "allowed-tools" "$file" || fm_has_field "owns" "$file"; then
+    printf '[copilot] stripped allowed-tools/owns from %s\n' "$slug" >&2
   fi
 
   # Copy references alongside
@@ -522,8 +522,9 @@ convert_qwen() {
 
   description="$(get_field_raw "description" "$file")"
   body="$(get_body "$file")"
-  # Map allowed_tools (comma-separated list from get_field) to qwen's tools field
-  allowed_tools_csv="$(get_field "allowed_tools" "$file")"
+  # Map allowed-tools (comma-separated list from get_field; the deprecated
+  # allowed_tools alias is honored by the parser) to qwen's tools field
+  allowed_tools_csv="$(get_field "allowed-tools" "$file")"
 
   {
     printf -- '---\n'

--- a/scripts/lib/frontmatter.sh
+++ b/scripts/lib/frontmatter.sh
@@ -31,7 +31,12 @@
 #   get_body <file>                 — everything after the closing ---
 #   fm_raw <file>                   — raw YAML between the two --- markers
 #   fm_check <file>                 — exit 1 if frontmatter malformed
-#   fm_has_field <field> <file>     — exit 0 if field present, 1 if absent
+#   fm_has_field <field> <file>     — exit 0 if field has a non-empty value
+#                                     (works for dict fields like owns too)
+#
+# Field-name aliasing: `allowed-tools` is the canonical spelling and
+# `allowed_tools` its deprecated alias (frontmatter-spec). The parser mirrors
+# whichever one a file declares, so every accessor answers under either name.
 #   fm_cache_clear                  — delete this process's parse cache
 #
 # Usage:
@@ -146,17 +151,28 @@ try:
 except ImportError:
     yaml = None
 
+def alias_allowed_tools(mapping):
+    # 'allowed-tools' is canonical, 'allowed_tools' the deprecated alias
+    # (frontmatter-spec). Mirror whichever is present so shell callers find
+    # the value under either spelling — all catalog skills use the hyphen,
+    # while some callers historically asked for the underscore.
+    if 'allowed-tools' in mapping and 'allowed_tools' not in mapping:
+        mapping['allowed_tools'] = mapping['allowed-tools']
+    elif 'allowed_tools' in mapping and 'allowed-tools' not in mapping:
+        mapping['allowed-tools'] = mapping['allowed_tools']
+
 if yaml is None:
     # Hand-rolled fallback for simple scalars only (mirrors the old
     # get_field fallback; raw/array/owns stay empty, as before).
-    seen = set()
+    consumed = set()
+    scalars = {}
     for line in fm_text.split('\n'):
         if line.startswith((' ', '\t')):
             continue
         m = re.match(r'^([^:]+):\s*(.*)$', line)
-        if not m or m.group(1) in seen:
+        if not m or m.group(1) in consumed:
             continue
-        seen.add(m.group(1))
+        consumed.add(m.group(1))
         val = m.group(2).strip()
         if val in ('|', '>', '>-', '|-'):
             continue  # multiline -- can't parse without yaml
@@ -166,10 +182,16 @@ if yaml is None:
             out = val.lower()
         else:
             out = val
-        emit('scalar', m.group(1), out + '\n')
+        scalars[m.group(1)] = out
+    alias_allowed_tools(scalars)
+    for key, out in scalars.items():
+        emit('scalar', key, out + '\n')
+        if out:
+            emit('has', key, '1\n')
     sys.exit(0)
 
 data = yaml.safe_load(fm_text) or {}
+alias_allowed_tools(data)
 
 for key, val in data.items():
     if not isinstance(key, str):
@@ -178,13 +200,19 @@ for key, val in data.items():
         continue  # every accessor printed nothing for null values
     # scalar.<key> — get_field
     if isinstance(val, bool):
-        emit('scalar', key, ('true' if val else 'false') + '\n')
+        s = 'true' if val else 'false'
     elif isinstance(val, list):
-        emit('scalar', key, ','.join(str(v) for v in val) + '\n')
+        s = ','.join(str(v) for v in val)
     elif isinstance(val, dict):
-        pass  # dicts not useful as scalar
+        s = None  # dicts not useful as scalar (no scalar file, as before)
     else:
-        emit('scalar', key, ' '.join(str(val).split()) + '\n')
+        s = ' '.join(str(val).split())
+    if s is not None:
+        emit('scalar', key, s + '\n')
+    # has.<key> — fm_has_field marker: any non-empty value, dicts included
+    # (dicts have no scalar file, which is why presence needs its own marker)
+    if (s or (isinstance(val, dict) and val)):
+        emit('has', key, '1\n')
     # raw.<key> — get_field_raw
     if isinstance(val, bool):
         emit('raw', key, 'true' if val else 'false')
@@ -314,13 +342,12 @@ fm_check() {
 
 # ---------------------------------------------------------------------------
 # fm_has_field <field> <file>
-# Return 0 if the field is present and non-empty in frontmatter, 1 otherwise.
+# Return 0 if the field is present with a non-empty value, 1 otherwise.
+# Backed by the parser's has.<key> markers rather than the scalar cache, so
+# it also answers for dict-valued fields (owns) that have no scalar form.
 # ---------------------------------------------------------------------------
 fm_has_field() {
-  local field="$1" file="$2" f v=""
+  local field="$1" file="$2"
   _fm_load "$file" || return 1
-  f="$_FM_ENTRY/scalar.${field//\//_}"
-  [[ -f "$f" ]] || return 1
-  IFS= read -r v < "$f" || true
-  [[ -n "$v" ]]
+  [[ -f "$_FM_ENTRY/has.${field//\//_}" ]]
 }

--- a/scripts/lint-skills.sh
+++ b/scripts/lint-skills.sh
@@ -458,9 +458,9 @@ lint_one() {
     fi
 
     local allowed_tools
-    allowed_tools="$(get_field "allowed_tools" "$file")"
+    allowed_tools="$(get_field "allowed-tools" "$file")"
     if [[ -z "$allowed_tools" ]]; then
-      emit_issue WARN "$file" "" "role skill missing recommended 'allowed_tools' (prevents agents reaching outside their domain)"
+      emit_issue WARN "$file" "" "role skill missing recommended 'allowed-tools' (prevents agents reaching outside their domain)"
     fi
   fi
 

--- a/tests/installer/bats/02-convert-per-tool.bats
+++ b/tests/installer/bats/02-convert-per-tool.bats
@@ -55,8 +55,8 @@ teardown_file() {
   grep -q "owns:" "$OUTDIR/claude-code/roles/full-agent/SKILL.md"
 }
 
-@test "claude-code: allowed_tools preserved in output" {
-  grep -q "allowed_tools:" "$OUTDIR/claude-code/roles/full-agent/SKILL.md"
+@test "claude-code: allowed-tools preserved in output" {
+  grep -q "allowed-tools:" "$OUTDIR/claude-code/roles/full-agent/SKILL.md"
 }
 
 @test "claude-code: with-references references/ copied alongside" {
@@ -87,8 +87,8 @@ teardown_file() {
   grep -q "description:" "$OUTDIR/copilot/full-agent.md"
 }
 
-@test "copilot: full-agent output does NOT contain allowed_tools" {
-  ! grep -q "allowed_tools:" "$OUTDIR/copilot/full-agent.md"
+@test "copilot: full-agent output does NOT contain allowed-tools (either spelling)" {
+  ! grep -qE "allowed[-_]tools:" "$OUTDIR/copilot/full-agent.md"
 }
 
 @test "copilot: full-agent output does NOT contain owns" {
@@ -96,7 +96,7 @@ teardown_file() {
 }
 
 @test "copilot: stderr warning emitted for stripped fields" {
-  grep -q "stripped allowed_tools/owns from full-agent" "$OUTDIR/.stderr.copilot"
+  grep -q "stripped allowed-tools/owns from full-agent" "$OUTDIR/.stderr.copilot"
 }
 
 @test "copilot: cc-only is skipped with stderr warning" {
@@ -276,6 +276,55 @@ teardown_file() {
 
 @test "qwen: with-references contains inline-bundled Reference: guide" {
   grep -q "## Reference: guide" "$OUTDIR/qwen/agents/with-references.md"
+}
+
+# ---------------------------------------------------------------------------
+# allowed-tools alias + dict-owns warning — regression for the
+# hyphen/underscore blind spot (MR-3): the canonical hyphen spelling must
+# reach every consumer, the deprecated underscore alias must keep working,
+# and a dict-valued `owns` alone must still trigger the copilot strip
+# warning (dicts have no scalar cache entry, so presence needs its own path).
+# ---------------------------------------------------------------------------
+
+@test "qwen/copilot: underscore alias still maps to tools; owns alone still warns" {
+  local mini out
+  mini="$(mktemp -d /tmp/ats-mini.XXXXXX)"
+  out="$(mktemp -d /tmp/ats-miniout.XXXXXX)"
+  mkdir -p "$mini/scripts/lib" "$mini/skills/roles/alias-agent" "$mini/skills/roles/owns-only-agent"
+  cp "$FAKEREPO/scripts/convert.sh" "$mini/scripts/convert.sh"
+  cp "$FAKEREPO/scripts/lib/"*.sh "$mini/scripts/lib/"
+  cat > "$mini/skills/roles/alias-agent/SKILL.md" <<'EOF'
+---
+name: alias-agent
+version: 1.0.0
+description: Apply alias-agent when testing that the deprecated allowed_tools underscore spelling still maps to the qwen tools field through the parser alias.
+allowed_tools:
+  - Read
+---
+
+## Overview
+
+Alias fixture body with enough words to stand on its own as a converted skill for the regression test.
+EOF
+  cat > "$mini/skills/roles/owns-only-agent/SKILL.md" <<'EOF'
+---
+name: owns-only-agent
+version: 1.0.0
+description: Apply owns-only-agent when testing that a dict-valued owns field with no allowed-tools still triggers the copilot strip warning.
+owns:
+  directories:
+    - somewhere/
+---
+
+## Overview
+
+Owns-only fixture body with enough words to stand on its own as a converted skill for the regression test.
+EOF
+  bash "$mini/scripts/convert.sh" --tool qwen --out "$out" 2>/dev/null
+  grep -q "^tools: Read" "$out/qwen/agents/alias-agent.md"
+  bash "$mini/scripts/convert.sh" --tool copilot --out "$out" 2>"$out/.stderr.copilot.mini"
+  grep -q "stripped allowed-tools/owns from owns-only-agent" "$out/.stderr.copilot.mini"
+  rm -rf "$mini" "$out"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/installer/bats/05-lint-rules.bats
+++ b/tests/installer/bats/05-lint-rules.bats
@@ -372,6 +372,10 @@ EOF
   git -C "$FIX" init -q
   git -C "$FIX" config user.email "t@example.com"
   git -C "$FIX" config user.name "t"
+  # Neutralize inherited signing config (1Password/gpg) — a global
+  # commit.gpgsign=true otherwise fails these commits non-interactively.
+  git -C "$FIX" config commit.gpgsign false
+  git -C "$FIX" config tag.gpgsign false
   git -C "$FIX" add -A
   git -C "$FIX" commit -qm base
   BASE="$(git -C "$FIX" rev-parse HEAD)"

--- a/tests/installer/fixtures/skills/roles/full-agent/SKILL.md
+++ b/tests/installer/fixtures/skills/roles/full-agent/SKILL.md
@@ -10,7 +10,7 @@ owns:
   shared_read:
     - contracts/
     - tests/
-allowed_tools:
+allowed-tools:
   - Read
   - Write
   - Bash
@@ -34,7 +34,7 @@ This fixture exercises the following fields in conversion tests:
 - `owns.directories` — must be stripped with warning for non-cc tools
 - `owns.patterns` — must be stripped with warning for non-cc tools
 - `owns.shared_read` — must be stripped with warning for non-cc tools
-- `allowed_tools` — must be stripped with warning for non-cc tools
+- `allowed-tools` — must be stripped with warning for non-cc tools (canonical hyphen spelling, matching every real catalog skill)
 - `composes_with` — must be stripped with warning for non-cc tools
 - `spawned_by` — must be stripped with warning for non-cc tools
 - `requires_agent_teams` — must be stripped for non-cc tools

--- a/tests/installer/golden/aider/CONVENTIONS.md
+++ b/tests/installer/golden/aider/CONVENTIONS.md
@@ -85,7 +85,7 @@ This fixture exercises the following fields in conversion tests:
 - `owns.directories` — must be stripped with warning for non-cc tools
 - `owns.patterns` — must be stripped with warning for non-cc tools
 - `owns.shared_read` — must be stripped with warning for non-cc tools
-- `allowed_tools` — must be stripped with warning for non-cc tools
+- `allowed-tools` — must be stripped with warning for non-cc tools (canonical hyphen spelling, matching every real catalog skill)
 - `composes_with` — must be stripped with warning for non-cc tools
 - `spawned_by` — must be stripped with warning for non-cc tools
 - `requires_agent_teams` — must be stripped for non-cc tools

--- a/tests/installer/golden/antigravity/full-agent/SKILL.md
+++ b/tests/installer/golden/antigravity/full-agent/SKILL.md
@@ -18,7 +18,7 @@ This fixture exercises the following fields in conversion tests:
 - `owns.directories` — must be stripped with warning for non-cc tools
 - `owns.patterns` — must be stripped with warning for non-cc tools
 - `owns.shared_read` — must be stripped with warning for non-cc tools
-- `allowed_tools` — must be stripped with warning for non-cc tools
+- `allowed-tools` — must be stripped with warning for non-cc tools (canonical hyphen spelling, matching every real catalog skill)
 - `composes_with` — must be stripped with warning for non-cc tools
 - `spawned_by` — must be stripped with warning for non-cc tools
 - `requires_agent_teams` — must be stripped for non-cc tools

--- a/tests/installer/golden/claude-code/roles/full-agent/SKILL.md
+++ b/tests/installer/golden/claude-code/roles/full-agent/SKILL.md
@@ -10,7 +10,7 @@ owns:
   shared_read:
     - contracts/
     - tests/
-allowed_tools:
+allowed-tools:
   - Read
   - Write
   - Bash
@@ -34,7 +34,7 @@ This fixture exercises the following fields in conversion tests:
 - `owns.directories` — must be stripped with warning for non-cc tools
 - `owns.patterns` — must be stripped with warning for non-cc tools
 - `owns.shared_read` — must be stripped with warning for non-cc tools
-- `allowed_tools` — must be stripped with warning for non-cc tools
+- `allowed-tools` — must be stripped with warning for non-cc tools (canonical hyphen spelling, matching every real catalog skill)
 - `composes_with` — must be stripped with warning for non-cc tools
 - `spawned_by` — must be stripped with warning for non-cc tools
 - `requires_agent_teams` — must be stripped for non-cc tools

--- a/tests/installer/golden/copilot/full-agent.md
+++ b/tests/installer/golden/copilot/full-agent.md
@@ -16,7 +16,7 @@ This fixture exercises the following fields in conversion tests:
 - `owns.directories` — must be stripped with warning for non-cc tools
 - `owns.patterns` — must be stripped with warning for non-cc tools
 - `owns.shared_read` — must be stripped with warning for non-cc tools
-- `allowed_tools` — must be stripped with warning for non-cc tools
+- `allowed-tools` — must be stripped with warning for non-cc tools (canonical hyphen spelling, matching every real catalog skill)
 - `composes_with` — must be stripped with warning for non-cc tools
 - `spawned_by` — must be stripped with warning for non-cc tools
 - `requires_agent_teams` — must be stripped for non-cc tools

--- a/tests/installer/golden/cursor/rules/full-agent.mdc
+++ b/tests/installer/golden/cursor/rules/full-agent.mdc
@@ -16,7 +16,7 @@ This fixture exercises the following fields in conversion tests:
 - `owns.directories` — must be stripped with warning for non-cc tools
 - `owns.patterns` — must be stripped with warning for non-cc tools
 - `owns.shared_read` — must be stripped with warning for non-cc tools
-- `allowed_tools` — must be stripped with warning for non-cc tools
+- `allowed-tools` — must be stripped with warning for non-cc tools (canonical hyphen spelling, matching every real catalog skill)
 - `composes_with` — must be stripped with warning for non-cc tools
 - `spawned_by` — must be stripped with warning for non-cc tools
 - `requires_agent_teams` — must be stripped for non-cc tools

--- a/tests/installer/golden/gemini-cli/skills/full-agent/SKILL.md
+++ b/tests/installer/golden/gemini-cli/skills/full-agent/SKILL.md
@@ -15,7 +15,7 @@ This fixture exercises the following fields in conversion tests:
 - `owns.directories` — must be stripped with warning for non-cc tools
 - `owns.patterns` — must be stripped with warning for non-cc tools
 - `owns.shared_read` — must be stripped with warning for non-cc tools
-- `allowed_tools` — must be stripped with warning for non-cc tools
+- `allowed-tools` — must be stripped with warning for non-cc tools (canonical hyphen spelling, matching every real catalog skill)
 - `composes_with` — must be stripped with warning for non-cc tools
 - `spawned_by` — must be stripped with warning for non-cc tools
 - `requires_agent_teams` — must be stripped for non-cc tools

--- a/tests/installer/golden/kimi/full-agent/system.md
+++ b/tests/installer/golden/kimi/full-agent/system.md
@@ -14,7 +14,7 @@ This fixture exercises the following fields in conversion tests:
 - `owns.directories` — must be stripped with warning for non-cc tools
 - `owns.patterns` — must be stripped with warning for non-cc tools
 - `owns.shared_read` — must be stripped with warning for non-cc tools
-- `allowed_tools` — must be stripped with warning for non-cc tools
+- `allowed-tools` — must be stripped with warning for non-cc tools (canonical hyphen spelling, matching every real catalog skill)
 - `composes_with` — must be stripped with warning for non-cc tools
 - `spawned_by` — must be stripped with warning for non-cc tools
 - `requires_agent_teams` — must be stripped for non-cc tools

--- a/tests/installer/golden/openclaw/full-agent/AGENTS.md
+++ b/tests/installer/golden/openclaw/full-agent/AGENTS.md
@@ -6,7 +6,7 @@ This fixture exercises the following fields in conversion tests:
 - `owns.directories` — must be stripped with warning for non-cc tools
 - `owns.patterns` — must be stripped with warning for non-cc tools
 - `owns.shared_read` — must be stripped with warning for non-cc tools
-- `allowed_tools` — must be stripped with warning for non-cc tools
+- `allowed-tools` — must be stripped with warning for non-cc tools (canonical hyphen spelling, matching every real catalog skill)
 - `composes_with` — must be stripped with warning for non-cc tools
 - `spawned_by` — must be stripped with warning for non-cc tools
 - `requires_agent_teams` — must be stripped for non-cc tools

--- a/tests/installer/golden/opencode/agents/full-agent.md
+++ b/tests/installer/golden/opencode/agents/full-agent.md
@@ -17,7 +17,7 @@ This fixture exercises the following fields in conversion tests:
 - `owns.directories` — must be stripped with warning for non-cc tools
 - `owns.patterns` — must be stripped with warning for non-cc tools
 - `owns.shared_read` — must be stripped with warning for non-cc tools
-- `allowed_tools` — must be stripped with warning for non-cc tools
+- `allowed-tools` — must be stripped with warning for non-cc tools (canonical hyphen spelling, matching every real catalog skill)
 - `composes_with` — must be stripped with warning for non-cc tools
 - `spawned_by` — must be stripped with warning for non-cc tools
 - `requires_agent_teams` — must be stripped for non-cc tools

--- a/tests/installer/golden/qwen/agents/full-agent.md
+++ b/tests/installer/golden/qwen/agents/full-agent.md
@@ -16,7 +16,7 @@ This fixture exercises the following fields in conversion tests:
 - `owns.directories` — must be stripped with warning for non-cc tools
 - `owns.patterns` — must be stripped with warning for non-cc tools
 - `owns.shared_read` — must be stripped with warning for non-cc tools
-- `allowed_tools` — must be stripped with warning for non-cc tools
+- `allowed-tools` — must be stripped with warning for non-cc tools (canonical hyphen spelling, matching every real catalog skill)
 - `composes_with` — must be stripped with warning for non-cc tools
 - `spawned_by` — must be stripped with warning for non-cc tools
 - `requires_agent_teams` — must be stripped for non-cc tools

--- a/tests/installer/golden/windsurf/.windsurfrules
+++ b/tests/installer/golden/windsurf/.windsurfrules
@@ -76,7 +76,7 @@ This fixture exercises the following fields in conversion tests:
 - `owns.directories` — must be stripped with warning for non-cc tools
 - `owns.patterns` — must be stripped with warning for non-cc tools
 - `owns.shared_read` — must be stripped with warning for non-cc tools
-- `allowed_tools` — must be stripped with warning for non-cc tools
+- `allowed-tools` — must be stripped with warning for non-cc tools (canonical hyphen spelling, matching every real catalog skill)
 - `composes_with` — must be stripped with warning for non-cc tools
 - `spawned_by` — must be stripped with warning for non-cc tools
 - `requires_agent_teams` — must be stripped for non-cc tools


### PR DESCRIPTION
## Summary

- Closes MR-3 from the 2026-07-08 maxed-out-window review: every catalog skill declares `allowed-tools` (hyphen, spec-canonical) but the shell tooling read only the deprecated `allowed_tools` alias — so the qwen converter's tool whitelist was dead code (0 of 34 converted files carried one), the copilot strip warning never fired, lint false-warned all 10 role skills on every run, and the README FAQ documented stderr that could not occur.
- Also closes MR-4: the `lint --changed` test fixture never neutralized commit signing, so a global 1Password config failed 5 tests on every local run.

## Changes

- `scripts/lib/frontmatter.sh`: parser-level alias mirroring (`allowed-tools` ↔ `allowed_tools`, PyYAML + fallback paths) so every consumer answers under either spelling; new `has.<key>` presence markers so `fm_has_field` works for dict-valued fields (`owns`) that have no scalar cache entry.
- `scripts/convert.sh` + `scripts/lint-skills.sh`: read the canonical hyphen spelling; warning text canonicalized to `stripped allowed-tools/owns`.
- Fixtures/tests: `full-agent` fixture flipped to the hyphen (mirroring reality — the old underscore fixture is why the suite greened over the blind spot); new regression test locks the underscore alias (qwen `tools:`) and the owns-only copilot warning; `_mk_changed_fixture` sets `commit.gpgsign false`.
- Docs: README lossy-conversion note + FAQ and `scripts/README.md` updated to the now-true canonical text.

## Test plan

- [x] Full suite `bash tests/run-all.sh`: **344/344** (with 1Password signing config present — previously 338/343)
- [x] Empirical: qwen conversion carries `tools:` in 32/34 files (was 0/34); copilot emits 34 strip warnings (was 0); lint warnings 123 → 113 (the 10 false role WARNs gone)
- [ ] On merge (after intake PR #50): sweep MR-3 + MR-4 rows to `docs/COMPLETED-WORK.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)