### PR TITLE
feat: Wire long-run hygiene into the scheduled loops + expand-contract mode (MR-5, CB-9)

### DIFF
--- a/skills/loops/babysit/SKILL.md
+++ b/skills/loops/babysit/SKILL.md
@@ -12,9 +12,9 @@ description: >-
   elsewhere, want review comments auto-handled on a cadence, or want a PR kept
   rebased and green. Trigger on "babysit my PR", "babysit prs", "watch this PR",
   "keep my PR green", "auto-address review comments on a schedule", "loop 5m
-  babysit", "keep the PR rebased", "poll the PR for new feedback", "tend this
-  pull request". Never auto-merges and never force-pushes a shared branch
-  unattended. A configuration of loop-controller.
+  babysit", "keep the PR rebased", "poll the PR for new feedback". Never
+  auto-merges and never force-pushes a shared branch unattended. A
+  configuration of loop-controller.
 requires_claude_code: true
 min_plan: starter
 disable-model-invocation: true

--- a/skills/loops/babysit/SKILL.md
+++ b/skills/loops/babysit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: babysit
-version: 1.0.0
+version: 1.1.0
 description: >-
   Keep one of your open PRs healthy on a schedule: poll for new review activity,
   auto-address bot/Copilot nits and routine rebases, re-run the project gate, and
@@ -140,6 +140,27 @@ clean, reversible change and re-checked the PR) is provable from `gh` output, so
 pass can run under auto mode unattended within the HITL boundary above. The loop
 as a whole has **no `/goal` finish line** — it watches until you stop it or a stop
 condition fires.
+
+## Long-run hygiene (wired per loop-controller Step 6)
+
+This loop runs unattended for days, so the Claude 5 long-run rules are part of
+its contract, not inherited ambience (drop-in text: `model-adaptation` →
+`references/long-run-hygiene.md`):
+
+- **Evidence-backed progress** — every per-pass report line (finding addressed,
+  rebase done, gate green) traces to a tool result from *that pass*: the `gh`
+  query output, the gate's exit code, the push result. Never narrate a fix the
+  re-fetch didn't confirm.
+- **Don't end a pass on a promise** — a pass ends with the change made and the
+  whole PR state re-checked, or at an explicit HITL stop; never with "I'll
+  rebase next pass" and no action. The autonomous-operation reminder applies
+  while the user is away — the HITL checkpoints above are the only sanctioned
+  pauses.
+- **Budget is a harness decision** — the cost ceiling reads from externalized
+  state (`.claude/profile.yaml`); don't surface a remaining-token countdown to
+  the working pass, and never summarize-and-quit on a phantom context worry.
+- **Effort per pass** — routine nit/rebase passes run at `medium`/`high`;
+  reserve `xhigh` for a genuinely hard finding (tiering: `model-adaptation`).
 
 ## Reference files
 

--- a/skills/loops/migration-loop/SKILL.md
+++ b/skills/loops/migration-loop/SKILL.md
@@ -10,8 +10,7 @@ description: >-
   target set whose proof is "no legacy pattern remains," not just "tests pass."
   Use for a codemod across a repo, a Jest-to-Vitest swap, an API version bump, a
   framework migration, an import/dependency rename, or any mechanical transform
-  applied to a finite list of files. Large sets may fan out via batch or a
-  dynamic workflow with worktree isolation. Trigger on "migrate everything from
+  applied to a finite list of files. Trigger on "migrate everything from
   X to Y", "run the codemod across the repo", "bump every call site", "swap the
   framework", "migrate all the tests", "finish the migration", "no old pattern
   left", "/migration-loop". A configuration of loop-controller.

--- a/skills/loops/migration-loop/SKILL.md
+++ b/skills/loops/migration-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migration-loop
-version: 1.0.0
+version: 1.1.0
 description: >-
   Migrate a known, enumerated set of targets one at a time until EVERY one is
   done — one iteration picks the next un-migrated target from a checklist,
@@ -166,6 +166,45 @@ after no-progress, that's a real migration blocker, not a number to paper over. 
 fully-migrated checklist informs the build; the `qe-agent`'s `qa-report.json`
 still decides the gate (`loop-controller`'s rule: the loop informs, the gate
 decides).
+
+## Expand–contract mode (when one change breaks everything at once)
+
+A single mechanical change whose blast radius breaks thousands of call sites in
+one motion — rename a column, retype a shared symbol, change a core signature —
+can't run as the normal migrate-and-verify loop: every batch is red until the
+last one lands. Sequence it **expand → migrate → contract** instead:
+
+1. **Expand** — add the new form *beside* the old (new column, overloaded
+   signature, aliased export). Nothing breaks; the suite stays green.
+2. **Migrate** — drive call sites over in blast-radius-sized batches with the
+   normal checklist loop; each batch stays green because the old form still
+   exists.
+3. **Contract** — when the legacy-pattern grep hits zero *call sites*, delete
+   the old form. The final proof adds a grep for the old *definition*.
+
+Wire the stages as three checklist phases — the contract stage is its own target
+whose transform is the deletion. When batches can't stay green alone (deeply
+entangled sites), fall back to a shared integration branch that merges only when
+the whole set is green. (Adapted from mattpocock `engineering/to-tickets`
+v1.1.0; CB-9.)
+
+## Long-run hygiene (wired per loop-controller Step 6)
+
+A long migration is exactly where the Claude 5 long-run rules earn their keep
+(drop-in text: `model-adaptation` → `references/long-run-hygiene.md`):
+
+- **Evidence-backed progress** — a checklist entry flips `true` only on the
+  observed pair (suite exit 0 + checkpoint commit hash) for *that* target; a
+  `PROGRESS.md` line without both is fabrication, not progress.
+- **Don't end an iteration on a promise** — each iteration ends with a target
+  migrated, committed, and flipped, or at a declared stop condition; never with
+  "next I'll migrate X" and no edit.
+- **Budget is a harness decision** — read caps from `.claude/profile.yaml`;
+  don't show the model a countdown, and don't let a long set trigger
+  summarize-and-quit — the checklist externalizes exactly where to resume.
+- **Effort per iteration** — mechanical transforms run at `medium`/`low`;
+  reserve `high`/`xhigh` for a transform that reds the suite (tiering:
+  `model-adaptation`).
 
 ## How this differs from its neighbors
 

--- a/skills/loops/self-healing-loop/SKILL.md
+++ b/skills/loops/self-healing-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: self-healing-loop
-version: 1.0.1
+version: 1.1.0
 description: >-
   Watch a production or CI error signal on a cadence and, when an ACTIONABLE
   error appears, trace its root cause, fix it in a branch, verify the failing
@@ -153,6 +153,24 @@ rather than pushing one task to a finish line:
 - **Inside a tick**, the *heal* step degenerates to a finish-line loop — that's
   where [`fix-until-green`] (a `/goal` or Stop-hook loop) drives the red build to
   green as this loop's verifier.
+
+## Long-run hygiene (wired per loop-controller Step 6)
+
+A watcher that ticks for days needs the Claude 5 long-run rules in its own
+contract (drop-in text: `model-adaptation` → `references/long-run-hygiene.md`):
+
+- **Evidence-backed progress** — "healed" is claimed only with the verifying
+  re-run's output in `heal_log.md`; a quiet tick is claimed only with the
+  timestamped clean-log query result. No entry, no claim.
+- **Don't end a tick on a promise** — a tick ends with a PR opened/updated, a
+  clean-log entry recorded, or a human paged at the HITL boundary; never with
+  "I'll diagnose this next tick" and no triage.
+- **Budget is a harness decision** — a poll loop that fires around the clock
+  adds up; enforce the ceiling from `.claude/profile.yaml` in the harness and
+  keep countdowns away from the working tick.
+- **Effort per tick** — quiet-tick polls run at `low`/`medium`; escalate to
+  `high`/`xhigh` only inside an actionable diagnose/fix cycle (tiering:
+  `model-adaptation`).
 
 ## How this differs from its neighbors
 

--- a/skills/orchestrator/references/phase-guide.md
+++ b/skills/orchestrator/references/phase-guide.md
@@ -186,6 +186,8 @@ All four are `loop-controller` configs and `disable-model-invocation: true`: the
 
 `fix-until-green` (the wave/QA fix cycle) and `orchestrator-task-loop` (the Agent Teams outer loop) are already wired into the phases above; these four are the mission-conditional ones.
 
+**Decomposing a wide-blast-radius refactor (expand–contract).** When one mechanical change would break thousands of call sites at once (rename a column, retype a shared symbol), don't plan it as a single vertical slice — decompose it into `migration-loop`'s **expand → migrate → contract** mode: land the new form beside the old (nothing breaks), migrate call sites in blast-radius-sized batches (each green because the old form still exists), then delete the old form once no caller remains. Plan the three stages as ordered tasks with the expand as a blocking dependency of every migrate batch; when batches can't stay green alone, fall back to a shared integration branch. See `migration-loop` § *Expand–contract mode*.
+
 ## Phase 14: Post-Build
 
 1. Spawn docs-agent to write README.md — provide full-system context (architecture summary, how to run, directory map). Docs-agent owns README.md.


### PR DESCRIPTION
## Summary

- Overnight-run batch D. Closes **MR-5** (multi-day scheduled loops inherited the Claude 5 long-run rules only transitively) and **CB-9** (expand–contract sequencing for wide-blast-radius refactors).

## Changes

- `babysit`, `self-healing-loop`, `migration-loop` (all → 1.1.0) each gain a "Long-run hygiene (wired per loop-controller Step 6)" section: evidence-backed progress, never ending a pass on a promise, budget as a harness decision, effort per pass — tailored to each loop's pass/tick/iteration shape.
- `migration-loop` gains **expand → migrate → contract** mode for changes that would break thousands of call sites at once, with the shared-integration-branch fallback; the orchestrator's phase-guide gains the matching task-decomposition note.
- Second commit: babysit + migration-loop descriptions trimmed for 1024-ceiling headroom (their share of MR-7e).

## Test plan

- [x] catalog --check clean, lint 0 errors
- [ ] CI green (no scripts touched)

Merge before tonight's final sweep PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6cZRG61LeTxJeHgs529xi