### PR TITLE
docs: Refresh use-freellmapi skill for freellmapi v0.6.9

### DIFF
--- a/skills/workflows/use-freellmapi/SKILL.md
+++ b/skills/workflows/use-freellmapi/SKILL.md
@@ -2,18 +2,15 @@
 name: use-freellmapi
 version: 1.4.0
 description: |
-  Wire any project or coding agent to FreeLLMAPI — a local proxy that aggregates ~30 free LLM provider
-  tiers (~4B tokens/month across 251 model families) behind one endpoint — so you can prototype without
-  paying for API calls. Use when a user wants to switch a project off paid OpenAI/Anthropic/etc. onto
-  free models, point an app or CLI agent at a local LLM proxy, cut their LLM bill for prototyping, or
-  stand up FreeLLMAPI itself. Speaks OpenAI, Anthropic Messages, native Gemini, and Ollama wire formats,
-  so it also covers pointing Claude Code, Codex CLI, Gemini CLI, Cline, Aider, Continue, Zed, or
-  JetBrains AI at free models. Detects the project's current LLM client (OpenAI or Anthropic SDK,
-  LangChain, LlamaIndex, Vercel AI SDK, Continue, raw HTTP), ensures the proxy is running (installs it
-  if missing), rewires base_url + api_key behind an env toggle so you can flip back, and verifies with a
-  live test call. Trigger on "use the free llm api", "use freellmapi", "switch this to free models",
-  "point this at freellmapi", "stop paying for openai here", "free llm proxy", "prototype without api
-  costs", "configure this for the free llm api", "run claude code on free models", "point claude
+  Wire any project or coding agent to FreeLLMAPI — a local proxy aggregating ~30 free LLM provider
+  tiers behind one endpoint — so you can prototype without paying for API calls. Use to switch a
+  project off paid OpenAI/Anthropic/etc. onto free models, point an app or CLI agent at a local LLM
+  proxy, or stand up FreeLLMAPI itself. Speaks OpenAI, Anthropic Messages, native Gemini, and Ollama
+  wire formats, covering Claude Code, Codex CLI, Gemini CLI, Cline, Aider, Continue, Zed, and
+  JetBrains AI. Detects the project's LLM client, ensures the proxy is running, rewires base_url +
+  api_key behind an env toggle, and verifies with a live test call. Trigger on "use freellmapi",
+  "switch this to free models", "point this at freellmapi", "stop paying for openai here", "free llm
+  proxy", "prototype without api costs", "run claude code on free models", "point claude
   code/codex/gemini cli at freellmapi", "free models for my coding agent".
 requires_agent_teams: false
 requires_claude_code: false

--- a/skills/workflows/use-freellmapi/SKILL.md
+++ b/skills/workflows/use-freellmapi/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: use-freellmapi
-version: 1.3.0
+version: 1.4.0
 description: |
-  Wire any project or coding agent to FreeLLMAPI — a local proxy that aggregates ~29 free LLM provider
+  Wire any project or coding agent to FreeLLMAPI — a local proxy that aggregates ~30 free LLM provider
   tiers (~4B tokens/month across 251 model families) behind one endpoint — so you can prototype without
   paying for API calls. Use when a user wants to switch a project off paid OpenAI/Anthropic/etc. onto
   free models, point an app or CLI agent at a local LLM proxy, cut their LLM bill for prototyping, or
@@ -29,7 +29,7 @@ spawned_by: []
 
 # use-freellmapi
 
-Point a project at **FreeLLMAPI** — a local proxy that aggregates the free tiers of ~29 LLM providers
+Point a project at **FreeLLMAPI** — a local proxy that aggregates the free tiers of ~30 LLM providers
 (Google, Groq, Cerebras, NVIDIA, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, Z.ai,
 ModelScope, Ollama, Kilo, OVH, AI Horde, and more) behind a single endpoint — roughly **4B tokens/month
 across 251 model families / 358 endpoints**. A router picks the best available model per request and
@@ -53,7 +53,7 @@ FreeLLMAPI is an **OpenAI-compatible** proxy. Wiring a project to it is almost a
 | What | Value |
 | --- | --- |
 | **base_url** | `http://localhost:3001/v1` (default; `PORT` may differ). **Anthropic, Gemini, and Ollama clients use the bare origin** — `http://localhost:3001`, no `/v1` |
-| **api_key** (bearer) | `freellmapi-…` — the proxy's single *unified key* |
+| **api_key** (bearer) | `freellmapi-…` — the install's *unified key* — or better, a **per-client key** (`sk-cp-…`) minted for this project |
 | **model** | `"auto"` — let the router pick and fail over. Steer it per request with `"auto:fast"` / `"auto:smart"` / `"auto:reliable"` / `"auto:<profile-name>"`; pin one like `"gemini-2.5-flash"`; or `"fusion"` to blend a panel of models into one answer |
 
 Because the surface is OpenAI-compatible, any OpenAI client library works unchanged — chat, streaming,
@@ -110,24 +110,31 @@ curl -fsSL https://freellmapi.co/install.sh | bash
 This sets up `~/freellmapi`, generates an at-rest `ENCRYPTION_KEY`, pulls
 `ghcr.io/tashfeenahmed/freellmapi:latest`, starts the container on `:3001`, and waits for `/api/ping`.
 Re-running is safe — it preserves the existing `.env`. When it finishes, probe `/api/ping` again to
-confirm. If Docker isn't available, fall back to a source install (`git clone` + `npm install` +
-`npm run dev`); see the *Local development* section of the [repo README](https://github.com/tashfeenahmed/freellmapi).
+confirm. If Docker isn't available, the project also ships a **desktop app** bundling the same server
+(macOS, Windows installer or zip, Linux AppImage/deb/tar.xz — the repo's Releases page), or fall back
+to a source install (`git clone` + `npm install` + `npm run dev`); see the *Local development* section
+of the [repo README](https://github.com/tashfeenahmed/freellmapi).
 
 If the user already runs it on a non-default port or another host, use that `base_url` everywhere below.
 
 ### Step 2 — Get the unified key and make sure a provider can serve requests
 
-**Unified key** (`freellmapi-…`): the single bearer token your app uses. Get it from:
+**Unified key** (`freellmapi-…`): the install-wide bearer token. Get it from:
 
 - the **Keys page header** at `http://localhost:3001` (the dashboard), or
 - the first-run container logs:
   `cd ~/freellmapi && docker compose logs 2>&1 | grep -i "unified api key"`
 
+Since v0.6.9 the Keys page can also mint **per-client keys** (`sk-cp-…`) — one per downstream app or
+tool, independently revocable, each with an optional system prompt the proxy enforces server-side.
+For wiring a single project, prefer minting one: analytics attribute traffic by key, and revoking it
+later doesn't touch any other client's credential. Everything below works the same with either key.
+
 **A fresh proxy has no provider keys, so chat requests fail until at least one provider is enabled.**
 This is the one part you can't do for the user — adding keys and toggling providers happens in the
 browser dashboard. Make it explicit and offer to wait. Two paths:
 
-- **Fastest, zero-key smoke test:** on the dashboard, enable a **keyless** provider — as of v0.6.5
+- **Fastest, zero-key smoke test:** on the dashboard, enable a **keyless** provider — as of v0.6.9
   that's **Kilo `:free`**, **OVH**, or **AI Horde**, which need no API key at all. Good enough to prove
   the pipe end to end in under a minute. (**Pollinations is no longer keyless** — it validates a key
   now, so don't offer it as the zero-key path. AI Horde is queue-based and can take tens of seconds.)
@@ -135,7 +142,9 @@ browser dashboard. Make it explicit and offer to wait. Two paths:
   etc. — each has a free signup), then reorder the **Fallback Chain** to taste.
 
 Hold here until the user confirms at least one provider is enabled — otherwise Step 5 will fail with a
-"no model available" error and look like a wiring bug when it isn't.
+"no model available" error and look like a wiring bug when it isn't. The Keys page's **provider
+checklist** (status icons per provider, flagging any that need a key but have none) is the quickest
+way to confirm, beating guesswork about which toggle actually took.
 
 ### Step 3 — Detect the target: coding agent, or application code?
 
@@ -249,11 +258,13 @@ Tell the user, briefly:
 - **How to flip back** — uncomment the original `.env` block (or re-run the agent's own config backup).
 - **Where the dashboard is** (`http://localhost:3001`) and what's on it: **Models** (Chat / Embeddings /
   Image / Audio / Fusion tabs, with editable intelligence-and-speed ranks and per-model rate limits),
-  **Playground** (now accepts image and text-file attachments), **Keys**, **Agents** (per-tool setup
-  blocks, Anthropic/Gemini family maps, Ollama emulation mode, URL tokens), **Analytics**, and
-  **Premium**. Named **routing profiles** auto-sort a chain by intelligence/speed/budget and are
-  selectable per request as `auto:<profile>`. Settings live in a sidebar dialog; the UI ships in 60
-  languages.
+  **Playground** (now accepts image and text-file attachments), **Keys** (provider checklist,
+  per-client `sk-cp-…` keys, per-key model scopes and proxy overrides, bulk key actions), **Agents**
+  (per-tool setup blocks, Anthropic/Gemini family maps, Ollama emulation mode, URL tokens),
+  **Analytics**, and **Premium**. Named **routing profiles** auto-sort a chain by
+  intelligence/speed/budget and are selectable per request as `auto:<profile>`. Settings live in a
+  sidebar dialog and include an automatic update check with release notes; a forgotten dashboard
+  password is recoverable with a code printed in the server logs. The UI ships in 60 languages.
 - **What the model values do** — `auto` routes and fails over, `auto:fast` / `auto:smart` /
   `auto:reliable` steer one request without touching the dashboard, `fusion` blends a panel of models
   for a quality bump on hard prompts.

--- a/skills/workflows/use-freellmapi/SKILL.md
+++ b/skills/workflows/use-freellmapi/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: use-freellmapi
-version: 1.2.2
+version: 1.3.0
 description: |
-  Wire any project to FreeLLMAPI — a local OpenAI-compatible proxy that aggregates ~20 free LLM provider
-  tiers (~1.7B+ tokens/month) behind one endpoint — so you can prototype without paying for API calls.
-  Use when a user wants to switch a project off paid OpenAI/Anthropic/etc. onto free models, point an app
-  at a local LLM proxy, cut their LLM bill for prototyping, or stand up FreeLLMAPI itself. Detects the
-  project's current LLM client (OpenAI or Anthropic SDK, LangChain, LlamaIndex, Vercel AI SDK, Continue,
-  raw HTTP), ensures the proxy is running (installs it if missing), rewires base_url + api_key behind an
-  env toggle so you can flip back, and verifies with a live test call. Trigger on "use the free llm api",
-  "use freellmapi", "switch this to free models", "point this at freellmapi", "stop paying for openai
-  here", "free llm proxy", "prototype without api costs", "configure this for the free llm api".
+  Wire any project or coding agent to FreeLLMAPI — a local proxy that aggregates ~29 free LLM provider
+  tiers (~4B tokens/month across 251 model families) behind one endpoint — so you can prototype without
+  paying for API calls. Use when a user wants to switch a project off paid OpenAI/Anthropic/etc. onto
+  free models, point an app or CLI agent at a local LLM proxy, cut their LLM bill for prototyping, or
+  stand up FreeLLMAPI itself. Speaks OpenAI, Anthropic Messages, native Gemini, and Ollama wire formats,
+  so it also covers pointing Claude Code, Codex CLI, Gemini CLI, Cline, Aider, Continue, Zed, or
+  JetBrains AI at free models. Detects the project's current LLM client (OpenAI or Anthropic SDK,
+  LangChain, LlamaIndex, Vercel AI SDK, Continue, raw HTTP), ensures the proxy is running (installs it
+  if missing), rewires base_url + api_key behind an env toggle so you can flip back, and verifies with a
+  live test call. Trigger on "use the free llm api", "use freellmapi", "switch this to free models",
+  "point this at freellmapi", "stop paying for openai here", "free llm proxy", "prototype without api
+  costs", "configure this for the free llm api", "run claude code on free models", "point claude
+  code/codex/gemini cli at freellmapi", "free models for my coding agent".
 requires_agent_teams: false
 requires_claude_code: false
 min_plan: starter
@@ -25,12 +29,16 @@ spawned_by: []
 
 # use-freellmapi
 
-Point a project at **FreeLLMAPI** — a local proxy that aggregates the free tiers of ~20 LLM providers
-(Google, Groq, Cerebras, NVIDIA, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, HuggingFace,
-Z.ai, Ollama, Kilo, Pollinations, LLM7, OVH, OpenCode Zen, AI Horde, and more — the exact roster shifts
-as providers come and go and the model catalog self-updates) behind a single OpenAI-compatible endpoint.
-A router picks the best available model per request and fails over when one is rate-limited. The payoff:
-prototype against real models for free, with zero code changes beyond a base URL and a key.
+Point a project at **FreeLLMAPI** — a local proxy that aggregates the free tiers of ~29 LLM providers
+(Google, Groq, Cerebras, NVIDIA, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, Z.ai,
+ModelScope, Ollama, Kilo, OVH, AI Horde, and more) behind a single endpoint — roughly **4B tokens/month
+across 251 model families / 358 endpoints**. A router picks the best available model per request and
+fails over when one is rate-limited. The payoff: prototype against real models for free, with zero code
+changes beyond a base URL and a key.
+
+> **Don't hardcode the roster or the numbers into advice.** Providers come and go, the catalog
+> self-updates from a signed feed, and free installs run on a 30-day catalog trail. Read the live
+> `/v1/models` and the dashboard rather than trusting any list — including this one.
 
 > **Tiering note:** a FreeLLMAPI project is the toolkit's one sanctioned multi-provider setup. The
 > model & effort tiering policy (`model-adaptation`, *Model & effort tiering*) is provider-relative —
@@ -44,20 +52,24 @@ FreeLLMAPI is an **OpenAI-compatible** proxy. Wiring a project to it is almost a
 
 | What | Value |
 | --- | --- |
-| **base_url** | `http://localhost:3001/v1` (default; `PORT` may differ) |
+| **base_url** | `http://localhost:3001/v1` (default; `PORT` may differ). **Anthropic, Gemini, and Ollama clients use the bare origin** — `http://localhost:3001`, no `/v1` |
 | **api_key** (bearer) | `freellmapi-…` — the proxy's single *unified key* |
-| **model** | `"auto"` — let the router pick and fail over; pin one like `"gemini-2.5-flash"`; or `"fusion"` to blend a panel of models into one answer |
+| **model** | `"auto"` — let the router pick and fail over. Steer it per request with `"auto:fast"` / `"auto:smart"` / `"auto:reliable"` / `"auto:<profile-name>"`; pin one like `"gemini-2.5-flash"`; or `"fusion"` to blend a panel of models into one answer |
 
 Because the surface is OpenAI-compatible, any OpenAI client library works unchanged — chat, streaming,
-tool calling, vision, and embeddings all route through the same endpoint. The proxy also accepts the
-**Anthropic-style `x-api-key` header**, so Anthropic SDK clients can point at it too (use the unified
-key as the `x-api-key`). Everything past this point is about doing the swap *cleanly, reversibly, and
-verified* — not about anything exotic.
+tool calling, vision, and embeddings all route through the same endpoint. But it is **not only**
+OpenAI-shaped: the proxy also speaks the **native Anthropic Messages API** (`/v1/messages` — Claude Code
+and the Anthropic SDKs), the **native Gemini API** (`/v1beta` — Gemini CLI), and an opt-in **Ollama**
+surface (`/api/*` — Zed, JetBrains AI). Point each client at the wire format it already speaks instead
+of forcing everything through chat completions. Everything past this point is about doing the swap
+*cleanly, reversibly, and verified* — not about anything exotic.
 
-> Read `references/capabilities.md` for the exact supported surface (endpoints, the two virtual models
-> `auto` and `fusion`, embeddings families, vision, tools, structured outputs, image generation + TTS,
-> the `/mcp` server, the opt-in response cache) and the short list of things it still does **not** do
-> (legacy `/v1/completions`, moderation, `n > 1`). Check it before promising a capability.
+> Read `references/capabilities.md` for the exact supported surface (all six wire formats, the virtual
+> models `auto`/`fusion` and `auto:*` steering, embeddings families, vision, tools, structured outputs,
+> media, the `/mcp` server, prompt compression, the response cache, analytics) and the short list of
+> things it still does **not** do (moderation, `n > 1`, multi-tenant auth). Check it before promising a
+> capability — and when it matters, confirm against `GET /v1/docs` on the user's own install, since
+> older pinned images lag the catalog.
 
 ## Workflow
 
@@ -71,13 +83,28 @@ Probe the unauthenticated liveness endpoint:
 
 ```bash
 curl -fsS http://localhost:3001/api/ping
-# {"status":"ok","timestamp":"..."}  → running, go to Step 2
+# {"status":"ok","timestamp":"..."}  → something is answering, but see the check below
 ```
+
+> **A 200 on `/api/ping` does not prove the *container* answered.** A stray host-side `npm run dev`
+> from a source checkout binds `*:3001` on the IPv6 wildcard, which the OS prefers over the container's
+> `127.0.0.1:3001` when resolving `localhost`. That dev server answers `/api/ping` happily but has no
+> built client (`ENOENT … client/dist/index.html`, with a **host** path in the error) and its own empty
+> database (a bogus "create an account" page) — which reads exactly like a wiped install after a
+> rebuild. If the dashboard looks freshly-installed or errors on refresh, check who owns the port
+> **before** touching any data:
+>
+> ```bash
+> lsof -nP -iTCP:3001 -sTCP:LISTEN   # a `node` row next to `com.docker` is the bug
+> ```
+>
+> Kill the `npm run dev` parent (not just the node child — `tsx watch` respawns it), then re-probe.
+> Never reach for `docker compose down -v` to "reset" this; that is what actually destroys keys.
 
 If nothing answers, install and start it with the official one-liner (needs Docker running):
 
 ```bash
-curl -fsSL https://tashfeenahmed.github.io/freellmapi/install.sh | bash
+curl -fsSL https://freellmapi.co/install.sh | bash
 ```
 
 This sets up `~/freellmapi`, generates an at-rest `ENCRYPTION_KEY`, pulls
@@ -100,18 +127,38 @@ If the user already runs it on a non-default port or another host, use that `bas
 This is the one part you can't do for the user — adding keys and toggling providers happens in the
 browser dashboard. Make it explicit and offer to wait. Two paths:
 
-- **Fastest, zero-key smoke test:** on the dashboard, enable a **keyless** provider — Pollinations
-  (GPT-OSS 20B), Kilo `:free`, or OVH work with no API key at all. Good enough to prove the pipe end to
-  end in under a minute.
+- **Fastest, zero-key smoke test:** on the dashboard, enable a **keyless** provider — as of v0.6.5
+  that's **Kilo `:free`**, **OVH**, or **AI Horde**, which need no API key at all. Good enough to prove
+  the pipe end to end in under a minute. (**Pollinations is no longer keyless** — it validates a key
+  now, so don't offer it as the zero-key path. AI Horde is queue-based and can take tens of seconds.)
 - **Real prototyping:** add free provider keys on the **Keys** page (Google AI Studio, Groq, Cerebras,
   etc. — each has a free signup), then reorder the **Fallback Chain** to taste.
 
 Hold here until the user confirms at least one provider is enabled — otherwise Step 5 will fail with a
 "no model available" error and look like a wiring bug when it isn't.
 
-### Step 3 — Detect the project's current LLM wiring
+### Step 3 — Detect the target: coding agent, or application code?
 
-Find how the project talks to an LLM today so you pick the right recipe and the smallest diff:
+**First ask which kind of target this is — the two paths diverge completely.**
+
+**If the target is a coding agent or CLI** (Claude Code, Codex, Gemini CLI, Cline, Aider, Continue,
+OpenCode, Goose, Qwen, Roo, Kilo, Crush, Cursor, Zed, JetBrains AI) — **do not hand-edit its config.**
+The proxy ships generators that read the live catalog, merge with existing config, and write a
+timestamped backup first:
+
+```bash
+npx freellmapi setup-claude --url http://localhost:3001 --dry-run   # show the diff
+npx freellmapi setup-claude --url http://localhost:3001             # apply, with backup
+```
+
+Read `references/agent-clients.md` for the full command table, the per-client base URLs, and the traps
+that waste the most time (Claude Code needs the **origin** not `/v1`, and `ANTHROPIC_AUTH_TOKEN` **not**
+`ANTHROPIC_API_KEY` or it refuses to start; Ollama emulation is off by default and `open-loopback`
+doesn't work in Docker). Then skip to Step 5 and verify — Step 4's env-toggle pattern is for
+application code, not agent config.
+
+**If the target is application code**, continue here. Find how the project talks to an LLM today so you
+pick the right recipe and the smallest diff:
 
 ```bash
 # language + client library + where the client is built
@@ -197,20 +244,43 @@ Map failures to causes instead of guessing:
 
 ### Step 6 — Hand off
 
-Tell the user, briefly: how to flip back (uncomment the original `.env` block), where the dashboard is
-(`http://localhost:3001` — manage keys, reorder the fallback chain or save named **routing profiles**
-that auto-sort by intelligence/speed/budget, watch analytics, use the playground), what `model:"auto"`
-does, that `model:"fusion"` blends a panel of models for a quality bump on hard prompts, and the
-relevant **not-supported** caveats from `references/capabilities.md` if their project uses legacy
-completions, moderation, or `n > 1` (those won't route — they'll need the real provider for those
-calls). Image generation and text-to-speech now *do* route on current releases (a media-capable
-provider must be enabled on the dashboard).
+Tell the user, briefly:
+
+- **How to flip back** — uncomment the original `.env` block (or re-run the agent's own config backup).
+- **Where the dashboard is** (`http://localhost:3001`) and what's on it: **Models** (Chat / Embeddings /
+  Image / Audio / Fusion tabs, with editable intelligence-and-speed ranks and per-model rate limits),
+  **Playground** (now accepts image and text-file attachments), **Keys**, **Agents** (per-tool setup
+  blocks, Anthropic/Gemini family maps, Ollama emulation mode, URL tokens), **Analytics**, and
+  **Premium**. Named **routing profiles** auto-sort a chain by intelligence/speed/budget and are
+  selectable per request as `auto:<profile>`. Settings live in a sidebar dialog; the UI ships in 60
+  languages.
+- **What the model values do** — `auto` routes and fails over, `auto:fast` / `auto:smart` /
+  `auto:reliable` steer one request without touching the dashboard, `fusion` blends a panel of models
+  for a quality bump on hard prompts.
+- **What analytics will tell them later** — p50/p95 latency, time-to-first-token, success rate,
+  estimated savings, and **pin-honor rate** (the number that answers "I asked for model X, why did I get
+  Y?"), plus per-request failover traces.
+- **The relevant not-supported caveats** from `references/capabilities.md` — moderation, `n > 1`, and
+  multi-tenant auth won't route, so those calls still need the real provider. Legacy
+  `/v1/completions`, image generation, text-to-speech, and fusion tool-calling **do** work on current
+  releases; only image *input* to `/v1/responses` and to `fusion` is still missing.
+- **If the catalog looks stale** — free installs run on a 30-day catalog trail (the live signed feed is
+  the paid tier), so a missing new model or a provider whose free tier changed is usually catalog lag,
+  not a wiring bug.
+- **Optionally, prompt compression** — off by default, but worth mentioning for long agent sessions:
+  it shrinks re-sent context before routing so more small-context models stay eligible.
 
 ## References
 
-- **`references/recipes.md`** — per-framework, copy-paste env-toggle wiring. Read the one section that
-  matches the detected stack; ignore the rest.
-- **`references/capabilities.md`** — exact supported surface (chat, streaming, tools, vision,
-  structured outputs, embeddings + their families, the Responses API shim, image/audio media, the
-  `/mcp` server, the opt-in response cache), plus the not-supported list and gotchas (sticky sessions,
-  fresh-install-has-no-keys, anonymous providers, the `X-Routed-Via` / `X-Fallback-Trail` headers).
+- **`references/recipes.md`** — per-framework, copy-paste env-toggle wiring for **application code**.
+  Read the one section that matches the detected stack; ignore the rest.
+- **`references/agent-clients.md`** — wiring for **coding agents and CLIs**: the `npx freellmapi
+  setup-*` generator table, Claude Code / Codex / Gemini CLI / Ollama-client / headerless setups, the
+  MCP server, and the per-client traps. Read this whenever the target is a tool rather than a codebase.
+- **`references/capabilities.md`** — exact supported surface across all six wire formats (chat,
+  streaming, tools, vision, structured outputs, embeddings + families, Responses, legacy completions,
+  media, transcription, Anthropic Messages, native Gemini, Ollama, `/mcp`, URL tokens, ops endpoints),
+  plus routing behavior and `auto:*` steering, prompt compression, the response cache, analytics, the
+  not-supported list, and the gotchas (sticky sessions, fresh-install-has-no-keys, which providers are
+  actually keyless, catalog lag, the `X-Routed-Via` / `X-Fallback-Trail` / `X-Request-ID` headers and
+  their percent-encoding trap).

--- a/skills/workflows/use-freellmapi/references/agent-clients.md
+++ b/skills/workflows/use-freellmapi/references/agent-clients.md
@@ -48,7 +48,7 @@ in a config file.
 
 ```bash
 export ANTHROPIC_BASE_URL=http://localhost:3001         # origin, NOT /v1
-export ANTHROPIC_AUTH_TOKEN=freellmapi-your-key         # NOT ANTHROPIC_API_KEY
+export ANTHROPIC_AUTH_TOKEN=freellmapi-xxxx         # NOT ANTHROPIC_API_KEY
 claude
 ```
 
@@ -67,7 +67,7 @@ Streaming, system prompts, tool use, image input, and document (PDF) content blo
 
 ```bash
 export GOOGLE_GEMINI_BASE_URL=http://localhost:3001
-export GEMINI_API_KEY=freellmapi-your-key
+export GEMINI_API_KEY=freellmapi-xxxx
 gemini
 ```
 
@@ -108,7 +108,7 @@ revocation is immediate.
 
 ```bash
 claude mcp add --transport http freellmapi http://localhost:3001/mcp \
-  --header "Authorization: Bearer freellmapi-your-key"
+  --header "Authorization: Bearer freellmapi-xxxx"  # scan-skills:ignore secret-generic
 ```
 
 Tools: `list_models`, `provider_health`, `usage_summary`, `routing_info`, `set_routing_strategy`,
@@ -124,7 +124,7 @@ models:
     provider: openai
     model: auto
     apiBase: http://localhost:3001/v1
-    apiKey: freellmapi-your-key
+    apiKey: freellmapi-xxxx
     useLegacyCompletionsEndpoint: true
     roles:
       - autocomplete

--- a/skills/workflows/use-freellmapi/references/agent-clients.md
+++ b/skills/workflows/use-freellmapi/references/agent-clients.md
@@ -61,7 +61,7 @@ claude
 Claude model names map to the free pool on the dashboard's **Agents** page: each family (`default`,
 `opus`, `sonnet`, `haiku`) routes to `auto` or a model you pin. `POST /v1/messages/count_tokens` and a
 content-negotiated `GET /v1/models` (Anthropic shape when `anthropic-version` is sent) are implemented.
-Streaming, system prompts, tool use, and image input all translate.
+Streaming, system prompts, tool use, image input, and document (PDF) content blocks all translate.
 
 ## Gemini CLI
 

--- a/skills/workflows/use-freellmapi/references/agent-clients.md
+++ b/skills/workflows/use-freellmapi/references/agent-clients.md
@@ -1,0 +1,144 @@
+# Coding agents & non-OpenAI wire formats
+
+FreeLLMAPI speaks **six** wire protocols over one router. Point a client at the surface it already
+speaks rather than forcing everything through OpenAI chat completions.
+
+| Client speaks | Surface | Base URL to configure |
+| --- | --- | --- |
+| OpenAI | `/v1/chat/completions`, `/v1/responses`, `/v1/completions` | `http://localhost:3001/v1` |
+| Anthropic Messages | `/v1/messages` | `http://localhost:3001` **(origin, no `/v1`)** |
+| Google Gemini | `/v1beta/models/{model}:generateContent` | `http://localhost:3001` |
+| Ollama | `/api/chat`, `/api/generate`, `/api/tags` | `http://localhost:3001` |
+| MCP | `/mcp` (Streamable HTTP) | `http://localhost:3001/mcp` |
+| Headerless | `/v1/t/{token}/…` | `http://localhost:3001/v1/t/<token>` |
+
+## Prefer the generator over hand-wiring
+
+For coding agents, **don't hand-edit config** — the proxy ships generators that read the live
+`/v1/models` catalog, merge with existing config, and write a timestamped backup first:
+
+```bash
+npx freellmapi setup-claude --url http://localhost:3001 --dry-run   # prints a diff
+npx freellmapi setup-claude --url http://localhost:3001             # writes, with backup
+```
+
+`--profile <name>` creates a named Claude/Codex profile instead of touching the default.
+
+| Agent | Command | Base URL | Wire |
+| --- | --- | --- | --- |
+| Claude Code | `setup-claude` / `launch` | `http://localhost:3001` | Anthropic Messages |
+| Codex CLI | `setup-codex` / `launch-codex` | `…/v1` | Responses (`wire_api = "responses"`) |
+| Cline | `setup-cline` | `…/v1` | OpenAI Chat |
+| Continue | `setup-continue` | `…/v1` | OpenAI Chat + legacy Completions |
+| Aider | `setup-aider` | `…/v1` | OpenAI Chat |
+| OpenCode | `setup-opencode` | `…/v1` | OpenAI Chat |
+| Goose | `setup-goose` | `…/v1` | OpenAI Chat |
+| Qwen Code | `setup-qwen` | `…/v1` | OpenAI Chat (native Gemini also works) |
+| Roo Code | `setup-roo` | `…/v1` | OpenAI Chat |
+| Kilo Code | `setup-kilo` | `…/v1` | OpenAI Chat |
+| Crush | `setup-crush` | `…/v1` | OpenAI Chat |
+| Cursor | `setup-cursor` (prints a guide) | public `https://…/v1` | OpenAI Chat |
+| Anything else | `setup-generic` (prints a block) | `…/v1` | OpenAI Chat |
+
+`freellmapi launch` / `launch-codex` are **zero-persistence launchers** — they inject credentials into
+the child process only, writing nothing to disk. Prefer them when the user doesn't want a key landing
+in a config file.
+
+## Claude Code — the two traps
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:3001         # origin, NOT /v1
+export ANTHROPIC_AUTH_TOKEN=freellmapi-your-key         # NOT ANTHROPIC_API_KEY
+claude
+```
+
+1. **Origin, not `/v1`.** Anthropic clients append `/v1/messages` themselves. Adding `/v1` yields
+   `/v1/v1/messages` and a 404.
+2. **`ANTHROPIC_AUTH_TOKEN`, never `ANTHROPIC_API_KEY`.** Claude Code treats a set `ANTHROPIC_API_KEY`
+   as a conflicting first-party credential and **refuses to start**. This is the single most common
+   failure and the error message doesn't point at it.
+
+Claude model names map to the free pool on the dashboard's **Agents** page: each family (`default`,
+`opus`, `sonnet`, `haiku`) routes to `auto` or a model you pin. `POST /v1/messages/count_tokens` and a
+content-negotiated `GET /v1/models` (Anthropic shape when `anthropic-version` is sent) are implemented.
+Streaming, system prompts, tool use, and image input all translate.
+
+## Gemini CLI
+
+```bash
+export GOOGLE_GEMINI_BASE_URL=http://localhost:3001
+export GEMINI_API_KEY=freellmapi-your-key
+gemini
+```
+
+Native surface: `GET /v1beta/models`, `GET /v1beta/models/{model}`, and
+`POST /v1beta/models/{model}:generateContent` / `:streamGenerateContent` (`?alt=sse` for the CLI) /
+`:countTokens`. Auth accepts `x-goog-api-key`, Bearer, or Gemini's `?key=` query fallback — **prefer a
+header**; query credentials leak into shell history and proxy logs. Gemini family names resolve through
+the Agents-page Gemini map; catalog ids work verbatim.
+
+## Ollama clients (Zed, JetBrains AI)
+
+Ollama emulation is **off by default**. Enable a mode on the dashboard's **Agents** page:
+
+- `open-loopback` — no key, but the socket peer must be `127.0.0.1`/`::1`.
+  **In Docker this refuses even host-local traffic** (the peer is the bridge IP), so a containerized
+  install — the default — needs `key-required`.
+- `key-required` — clients send `Authorization: Bearer <unified-key>`.
+
+Endpoints: `/api/tags`, `/api/chat`, `/api/generate`, `/api/show`, `/api/version`, `/api/embed`, and
+legacy `/api/embeddings`. Streaming is **NDJSON, not SSE**. Point the client at `http://localhost:3001`.
+
+## Headerless clients — revocable URL tokens
+
+For clients that can't set headers, mint a token on the **Agents** page:
+
+```text
+http://localhost:3001/v1/t/<token>/chat/completions
+http://localhost:3001/v1/t/<token>/responses
+http://localhost:3001/v1/t/<token>/models
+```
+
+The same prefix also exposes `/api/chat` and `/api/tags`. Tokens are random, stored only as hashes,
+and independently revocable. **Never put the unified key in a URL** — URLs leak into shell history,
+reverse-proxy logs, browser history, and telemetry. Treat tokens as sensitive for the same reason;
+revocation is immediate.
+
+## MCP server
+
+```bash
+claude mcp add --transport http freellmapi http://localhost:3001/mcp \
+  --header "Authorization: Bearer freellmapi-your-key"
+```
+
+Tools: `list_models`, `provider_health`, `usage_summary`, `routing_info`, `set_routing_strategy`,
+`cache_stats`, `compression_stats`. Any Streamable-HTTP MCP client works the same way.
+
+## VS Code ghost-text (Continue)
+
+`/v1/completions` exists specifically for legacy prompt/suffix autocomplete:
+
+```yaml
+models:
+  - name: FreeLLMAPI Autocomplete
+    provider: openai
+    model: auto
+    apiBase: http://localhost:3001/v1
+    apiKey: freellmapi-your-key
+    useLegacyCompletionsEndpoint: true
+    roles:
+      - autocomplete
+```
+
+## Context handoff
+
+When the router fails over mid-conversation, the new model doesn't know it inherited a task. Enable a
+compact handoff note in `.env`:
+
+```env
+FREELLMAPI_CONTEXT_HANDOFF=on_model_switch
+```
+
+Injected only when the model actually changes for a session key (`X-Session-Id`, else SHA-1 of the
+first user message). In-memory only, 3-hour TTL, nothing written to disk. It can't recover
+provider-internal hidden state — only what passed through the proxy.

--- a/skills/workflows/use-freellmapi/references/capabilities.md
+++ b/skills/workflows/use-freellmapi/references/capabilities.md
@@ -6,30 +6,73 @@ list, those specific calls won't route through the proxy and still need the real
 
 ## Supported endpoints
 
+The proxy speaks **six wire formats** over one router. For wiring a specific client to a non-OpenAI
+surface, see `agent-clients.md` — this table is the inventory.
+
+### OpenAI surface (`/v1`)
+
 | Endpoint | Notes |
 | --- | --- |
 | `POST /v1/chat/completions` | The main surface. Streaming + non-streaming. |
-| `POST /v1/responses` | OpenAI **Responses API** shim (the wire format current Codex CLI needs), translated over the same router. Image *input* not supported here yet — use chat completions for vision. |
+| `POST /v1/responses` | OpenAI **Responses API** shim (the wire format Codex CLI needs). Image *input* not supported here yet — use chat completions for vision. |
+| `POST /v1/completions` | **Legacy** prompt/suffix completions, routed through chat models while preserving the `text_completion` shape. Exists for editor ghost-text (Continue autocomplete). |
 | `POST /v1/embeddings` | Family-based routing (see below). |
-| `POST /v1/images/generations` | Image generation — routes to providers serving media models (see **Media** below). Enable one on the dashboard's **Models → Image** tab first. |
-| `POST /v1/audio/speech` | Text-to-speech — same routing, dashboard **Models → Audio** tab. |
-| `POST /mcp` | **Model Context Protocol** (Streamable HTTP). MCP-capable agents can ask the router which models are usable right now (with per-model `supported_parameters`), check provider/key health + cooldowns, read usage/cache stats, and switch routing strategy mid-session. |
-| `GET  /v1/models` | Lists available models. |
-| `GET  /api/ping` | Unauthenticated liveness — `{"status":"ok"}`. Use this to detect "is it running". |
+| `POST /v1/images/generations` | Image generation — dashboard **Models → Image** tab. |
+| `POST /v1/audio/speech` | Text-to-speech — dashboard **Models → Audio** tab. |
+| `POST /v1/audio/transcriptions` | Speech-to-text, catalog-driven. |
+| `GET  /v1/models` | Lists available models. Content-negotiated: returns the **Anthropic** shape when `anthropic-version` is sent. |
 
-**Auth:** every `/v1` call needs the unified key (`freellmapi-…`), accepted as either
-`Authorization: Bearer <key>` or `x-api-key: <key>`. The `/api/*` dashboard routes use a separate
-email+password session and are not what apps talk to.
+### Other wire formats
+
+| Endpoint | Notes |
+| --- | --- |
+| `POST /v1/messages` | **Anthropic Messages API** — native wire format, so Claude Code and the Anthropic SDKs run against the free pool. Clients must target the **origin**, not `/v1`. |
+| `POST /v1/messages/count_tokens` | Anthropic token counting. |
+| `/v1beta/models/{model}:generateContent` | **Native Gemini API** — plus `:streamGenerateContent` (`?alt=sse`), `:countTokens`, `GET /v1beta/models`, `GET /v1beta/models/{model}`. |
+| `/api/{tags,chat,generate,show,version,embed,embeddings}` | **Ollama emulation**, NDJSON streaming. **Off by default** — enable `open-loopback` or `key-required` on the Agents page. |
+| `/v1/t/{token}/…` | **Revocable URL tokens** for headerless clients — mirrors models, chat completions, Responses, and Ollama chat/tags. Separately revocable; not the unified key. |
+| `POST /mcp` | **Model Context Protocol** (Streamable HTTP). Tools: `list_models`, `provider_health`, `usage_summary`, `routing_info`, `set_routing_strategy`, `cache_stats`, `compression_stats`. |
+
+### Ops & discovery
+
+| Endpoint | Notes |
+| --- | --- |
+| `GET /api/ping` | Unauthenticated liveness — `{"status":"ok"}`. |
+| `GET /livez` · `GET /readyz` | Kubernetes-style liveness/readiness for meta-gateway interop. |
+| `GET /v1/providers` | Provider inventory (unified-key auth); `?ready=true` filters to ones that can serve now. |
+| `GET /v1/docs` · `GET /v1/openapi.json` | Dependency-free interactive OpenAPI viewer + the spec itself. Useful for confirming a capability on *this* install rather than trusting docs. |
+
+**Auth:** every `/v1` call needs the unified key (`freellmapi-…`), accepted as
+`Authorization: Bearer <key>` or `x-api-key: <key>` (Gemini's `x-goog-api-key` on `/v1beta`). The
+`/api/*` dashboard routes use a separate email+password session and are not what apps talk to.
 
 ## Routing behavior
 
 - **`model: "auto"`** (or omitting `model`) → the router scores enabled models and picks the best one
   that's under its rate caps, then **fails over** to the next in the fallback chain on a 429/5xx/timeout
-  (up to ~20 attempts). You can also pin a specific id like `gemini-2.5-flash`.
+  (up to ~20 attempts, bounded by a wall-clock retry budget). You can also pin a specific id like
+  `gemini-2.5-flash`.
+- **`auto:*` steering** — a suffix overrides the chain for one request, no dashboard change needed:
+  `auto:smart` (highest intelligence), `auto:fast` (measured throughput + TTFB), `auto:reliable`
+  (recent success rate), `auto:balanced` (the default blend), `auto:cheap` (currently the same blend as
+  balanced — everything in the pool is already free). These rank **every enabled model**, ignoring
+  chain order. Common synonyms resolve (`auto:fastest`, `auto:smartest`, `auto:budget`, …) and the
+  whole string is case-insensitive. **`auto:<profile-name>`** routes through a named profile's chain
+  instead, so different tools can use different chains through one key; an unknown profile is a clear
+  `400`, not a silent fallback.
+- **Six selectable strategies** rank the chain: `priority` (manual order), `balanced`, `smartest`,
+  `fastest`, `reliable`, or `custom` weights — scored from live per-model measurements with a
+  Thompson-sampling bandit. One-click sort presets reorder the chain from the dashboard.
+- **Unified models** — the same logical model on several providers collapses into one entry with
+  strict in-group failover, plus merge/split overrides when the grouping guesses wrong.
 - **`X-Routed-Via: <platform>/<model>`** response header tells you which provider actually served the
   call; `X-Fallback-Attempts: N` appears if it fell over between providers, and `X-Fallback-Trail`
   carries the ordered list of what was tried. Great for debugging "why is this answer weird" — check
   which model you actually got. On exhaustion, the error body carries the same full attempt trail.
+  **Gotcha:** HTTP headers only carry printable ASCII, so a model id with characters outside that range
+  (a Chinese name from a relay catalog) is **percent-encoded** — run the value through
+  `decodeURIComponent` / `urllib.parse.unquote` before displaying it. `X-Request-ID` correlates a call
+  with its row in dashboard analytics.
 - **Sticky sessions:** a multi-turn conversation keeps hitting the same model for 30 minutes (avoids
   the hallucination spike from mid-conversation model switches). Agent harnesses that manage their own
   conversation ids can pin affinity with an `X-Session-Id` header.
@@ -71,8 +114,11 @@ Two model ids aren't real models — they're router behaviors you select by name
   return the longest single panel answer — cheaper, no extra call). `expose_panel: true` attaches the
   per-model answers under `x_fusion`; a lightweight `_fusion` summary (which models + judge) is always
   included. Streaming works (it emits additive `_fusion` frames standard OpenAI clients ignore).
-  **Fusion does not support image input or tool calling yet** — those return a clear `422`
-  (`fusion_no_vision` / `fusion_no_tools`); use a vision/tool-capable model directly for those.
+  **Tool calling works** — when the request carries `tools`, the panel is filtered to tool-capable
+  models (models that can't are dropped with a reason) and the judge call runs without tools. Panel
+  selection is also size-aware, so a model whose context is too small can't claim a slot.
+  **Image input is still unsupported** — it returns a clear `422` (`fusion_no_vision`); pin a vision
+  model directly for that.
 
 ## Tool calling
 
@@ -125,9 +171,10 @@ vector store and stick with it.
 
 `model` accepts `auto` (the configured default family — `gemini-embedding-001` out of the box), a family
 name, or a provider-specific id (which resolves to its family). The default family and per-provider
-toggles live on the dashboard's **Models → Embeddings** page. Two things worth flagging to the user:
-**`embed-v4.0` (Cohere) ships disabled** — it shares Cohere's tight 1K-calls/month chat quota, so enable
-it deliberately. And `llama-nemotron-embed-vl-1b-v2` is a **vision-language** family that can embed
+toggles live on the dashboard's **Models → Embeddings** page. Worth flagging to the user: **`embed-v4.0`
+(Cohere)** shares Cohere's tight 1K-calls/month chat quota, so spending it on embeddings is a real
+trade-off — check whether it's enabled before recommending it. And `llama-nemotron-embed-vl-1b-v2` is a
+**vision-language** family that can embed
 images as well as text — the only multimodal embedder in the catalog. The proxy normalizes each
 provider's native embedding quirks (NVIDIA's `input_type`, Cohere's `/v2/embed`, Hugging Face's
 feature-extraction shape) behind the OpenAI request format, so the client just sends `{model, input}`.
@@ -142,24 +189,83 @@ so a container image pulled before that will `404` on those paths — if a media
 install, re-pull `:latest` (SKILL.md Step 1) and retry. Confirm the route exists before promising it to
 a project that pins an old image.
 
+## Prompt compression (opt-in)
+
+Long agent sessions re-send system prompts, file reads, tool output, and schemas. The proxy can shrink
+the request **before** cache lookup, token budgeting, and routing — so the router sees the reduced
+estimate and more small-context models stay eligible. Responses are never rewritten. **Off by default.**
+Runs on chat completions, Responses, Anthropic Messages, and Anthropic token counting.
+
+| Mode | What runs |
+| --- | --- |
+| `off` | No rewriting. Master switch — a request header cannot enable it. |
+| `lossless` | Repeated-block dedup, whitespace hygiene, reversible homogeneous-JSON table encoding. |
+| `standard` | Lossless + command-aware tool-output filtering + stale file-read supersession. |
+| `aggressive` | Standard + older-turn condensation, lexical relevance filtering, optional hard token target. |
+
+Set it on the dashboard (**Settings → Prompt compression**) or bootstrap with
+`FREELLMAPI_COMPRESSION=lossless`; once saved in the dashboard the stored value wins. Per request,
+`X-FreeLLM-Compress: off|on|lossless|standard|aggressive` can **lower or disable** the operator's mode
+but never raise it. The response reports what actually happened —
+`X-FreeLLM-Compress: standard; saved~=1840` (the `~=` is honest: savings use the same `chars / 4`
+estimate as routing).
+
+The pipeline is **fail-open**: each engine's output is discarded if it grows the request, throws, or
+fails a fidelity gate (all numeric literals and diff hunks survive, every explicit constraint / security
+instruction / error line survives, ≥90% of JSON keys, ≥95% of other protected spans, tool envelopes stay
+valid). Anthropic `cache_control` prefixes are capped at lossless. Compression config is part of the
+response-cache fingerprint, so differently-compressed requests can't share a stale entry. Extra filters
+load from `~/.freellmapi/filters/*.json`, and from `.freellmapi/filters.json` in-project **only** if
+"Trust project filter files" is on (off by default — repos may be untrusted).
+
+## Premium / catalog freshness
+
+The router self-updates its model catalog from a signed feed twice a day — new models, quota changes,
+and provider quirk fixes land without a `git pull`. **Free installs sit on a 30-day trail; the live
+feed is a paid tier** ($19/yr). This is the answer to "why doesn't my install have model X" or "why am
+I getting auth errors from a provider that changed its free tier" — it's catalog lag, not a wiring bug.
+There's a **Premium** page in the dashboard and a `/api/premium` route family.
+
 ## Not supported yet
 
 These have no route — calls to them fail, so the project still needs the real provider for them:
 
-- **Legacy completions** (`/v1/completions`) — only the *chat* endpoint exists
 - **Moderation** (`/v1/moderations`)
 - **`n > 1`** (multiple completions per request)
 - **Per-user billing / multi-tenant auth** — single-user by design
 
-*(Image generation and text-to-speech used to be on this list — they now route; see **Media** above.)*
+Narrower gaps, not whole-endpoint: **image input on `/v1/responses`** (use chat completions) and
+**image input to `fusion`** (pin a vision model).
+
+*(Three things have come **off** this list and the skill used to state them wrongly: image generation,
+text-to-speech, and **legacy `/v1/completions`** all route now, and **fusion supports tool calling**.
+Verify against `GET /v1/docs` on the user's own install before telling them something won't work.)*
+
+## Analytics & observability
+
+The dashboard's **Analytics** page reports over 24h–90d windows: request count, success rate, **p50/p95
+latency**, **time-to-first-token** for streams, token counts, **estimated cost savings** (priced against
+each model's paid equivalent), and **pin-honor rate** (how often a pinned model actually served, vs. the
+router falling over to something else — the number to check when someone says "I asked for model X and
+got Y"). Breakdowns exist per model, platform, client, and key, plus an error distribution and
+**per-request traces** (`GET /api/analytics/requests/:id`) showing the full failover ladder for one call.
+
+Headline totals come from a durable hourly aggregate so they survive raw-row pruning; latency
+percentiles, TTFT, and pin-honor need the raw rows and report **`null`** (rendered as a placeholder, not
+a misleading `0`) once a window ages past the prune horizon. Cache and compression aggregates are also
+readable over MCP (`usage_summary`, `cache_stats`, `compression_stats`) — useful for an agent that wants
+to check its own quota burn mid-session.
 
 ## Gotchas worth saying out loud
 
 - **A fresh proxy serves nothing until a provider is enabled.** No keys = every chat request 4xx's with
   "no model available." This looks exactly like a wiring bug but isn't. Add a provider first.
-- **Keyless providers** (Pollinations GPT-OSS 20B, Kilo `:free`, OVH) need no API key at all — the proxy
-  sends no auth header upstream. Enable one on the dashboard for an instant zero-config smoke test.
-  (LLM7 also has an anonymous free tier but isn't registered keyless — it may carry a shared key.)
+- **Keyless providers** — as of v0.6.5 the ones registered `keyless: true` are **Kilo `:free`**,
+  **OVH**, and **AI Horde** (plus local Ollama). The proxy sends no auth header upstream, so enabling
+  one is an instant zero-config smoke test. **Pollinations is no longer keyless** — it now validates a
+  key against `/account/key`, so don't offer it as the zero-key path. AI Horde is queue-based and can
+  take tens of seconds with no upstream streaming; fine for a smoke test, poor for interactive use.
+  This roster shifts — confirm against the dashboard rather than trusting this list.
 - **Free tiers are rate-limited and uneven.** Latency and quality vary by which provider served a call
   (`X-Routed-Via`). Add several provider keys so the router has headroom to fail over. This is a
   *prototyping* tool, not a production SLA.

--- a/skills/workflows/use-freellmapi/references/capabilities.md
+++ b/skills/workflows/use-freellmapi/references/capabilities.md
@@ -42,9 +42,14 @@ surface, see `agent-clients.md` — this table is the inventory.
 | `GET /v1/providers` | Provider inventory (unified-key auth); `?ready=true` filters to ones that can serve now. |
 | `GET /v1/docs` · `GET /v1/openapi.json` | Dependency-free interactive OpenAPI viewer + the spec itself. Useful for confirming a capability on *this* install rather than trusting docs. |
 
-**Auth:** every `/v1` call needs the unified key (`freellmapi-…`), accepted as
-`Authorization: Bearer <key>` or `x-api-key: <key>` (Gemini's `x-goog-api-key` on `/v1beta`). The
-`/api/*` dashboard routes use a separate email+password session and are not what apps talk to.
+**Auth:** three credential kinds unlock `/v1`, all accepted as `Authorization: Bearer <key>` or
+`x-api-key: <key>` (Gemini's `x-goog-api-key` on `/v1beta`): the install-wide **unified key**
+(`freellmapi-…`); **per-client keys** (`sk-cp-…`, minted on the Keys page since v0.6.9 — one per
+downstream app or tool, independently revocable, each with an optional **server-enforced system
+prompt** the proxy prepends to every request on that key); and revocable **URL tokens** for
+headerless clients (see the endpoints table). Prefer one per-client key per wired project —
+analytics attribute traffic by key, and revoking one doesn't rotate the others. The `/api/*`
+dashboard routes use a separate email+password session and are not what apps talk to.
 
 ## Routing behavior
 
@@ -62,12 +67,22 @@ surface, see `agent-clients.md` — this table is the inventory.
   `400`, not a silent fallback.
 - **Six selectable strategies** rank the chain: `priority` (manual order), `balanced`, `smartest`,
   `fastest`, `reliable`, or `custom` weights — scored from live per-model measurements with a
-  Thompson-sampling bandit. One-click sort presets reorder the chain from the dashboard.
+  Thompson-sampling bandit. Community reliability priors seed the posterior so fresh installs don't
+  start blind, and an **exploration toggle** controls whether unmeasured models get sampled.
+  One-click sort presets reorder the chain from the dashboard.
+- **Failing models cool down automatically.** Repeated failures put a model on a growing cooldown —
+  not just 429s; hard errors extend the penalty too — and a 5xx/timeout/transport error skips the
+  **whole provider** for that request instead of burning one attempt per key. A back-off stated in
+  an error *body* is honored like a `Retry-After` header.
+- **Output-token cap** — an optional server setting rescues requests whose client sends an excessive
+  `max_tokens` (agent harnesses love `max_tokens: 128000`) by capping it to what the routed model
+  accepts, instead of letting the provider reject the call.
 - **Unified models** — the same logical model on several providers collapses into one entry with
   strict in-group failover, plus merge/split overrides when the grouping guesses wrong.
 - **`X-Routed-Via: <platform>/<model>`** response header tells you which provider actually served the
   call; `X-Fallback-Attempts: N` appears if it fell over between providers, and `X-Fallback-Trail`
-  carries the ordered list of what was tried. Great for debugging "why is this answer weird" — check
+  carries the ordered list of what was tried. Opt in to **`X-Fallback-Detail`** for per-hop failover
+  timings on top of the trail. Great for debugging "why is this answer weird" — check
   which model you actually got. On exhaustion, the error body carries the same full attempt trail.
   **Gotcha:** HTTP headers only carry printable ASCII, so a model id with characters outside that range
   (a Chinese name from a relay catalog) is **percent-encoded** — run the value through
@@ -128,6 +143,11 @@ reaches. OpenAI-compatible providers get the request passed through; Gemini requ
 Google's `functionDeclarations` shape and back. Works with `stream: true`. A Gemini-only extra: pass a
 tool named `google_search` (aliases `googlesearch` / `google_search_retrieval`) and the proxy maps it to
 Gemini's native Google Search grounding, so a Gemini route can answer with fresh web results.
+
+Two argument-integrity behaviors ride along: the proxy **repairs double-encoded arguments** below the
+top level (a model returning a JSON string where an object belongs), and an **opt-in schema verdict**
+validates returned tool arguments against the tool's own JSON schema — an invalid set counts as a
+failed attempt and **fails over to the next model** instead of handing the app broken arguments.
 
 ## Structured outputs & sampling params
 
@@ -232,7 +252,8 @@ These have no route — calls to them fail, so the project still needs the real 
 
 - **Moderation** (`/v1/moderations`)
 - **`n > 1`** (multiple completions per request)
-- **Per-user billing / multi-tenant auth** — single-user by design
+- **Per-user billing** — one operator per install, by design. (Per-client *keys* do exist — see
+  Auth — but they attribute and constrain requests; there is no per-user quota or billing.)
 
 Narrower gaps, not whole-endpoint: **image input on `/v1/responses`** (use chat completions) and
 **image input to `fusion`** (pin a vision model).
@@ -260,7 +281,7 @@ to check its own quota burn mid-session.
 
 - **A fresh proxy serves nothing until a provider is enabled.** No keys = every chat request 4xx's with
   "no model available." This looks exactly like a wiring bug but isn't. Add a provider first.
-- **Keyless providers** — as of v0.6.5 the ones registered `keyless: true` are **Kilo `:free`**,
+- **Keyless providers** — as of v0.6.9 the ones registered `keyless: true` are **Kilo `:free`**,
   **OVH**, and **AI Horde** (plus local Ollama). The proxy sends no auth header upstream, so enabling
   one is an instant zero-config smoke test. **Pollinations is no longer keyless** — it now validates a
   key against `/account/key`, so don't offer it as the zero-key path. AI Horde is queue-based and can
@@ -271,6 +292,10 @@ to check its own quota burn mid-session.
   *prototyping* tool, not a production SLA.
 - **The unified key is per-install**, stored in the proxy's SQLite, shown on the dashboard Keys header.
   Regenerating it on the dashboard invalidates the old one — update the app's `.env` if you do.
+- **Provider keys are individually tunable.** A provider's keys can carry **model scopes** (different
+  keys serve different model groups), a **per-key proxy override** (each key exits through its own
+  proxy — geo-ban and risk isolation), and bulk enable/disable/delete within a group. Custom
+  endpoints have an immediate-probe action to validate a key on the spot.
 - **Opt-in response cache.** An exact-match in-memory LRU for identical *non-streaming* requests
   (canonical SHA-256 over the full request, with TTL + temperature gates). **Off by default**; flip it
   per-request with the `X-FreeLLM-Cache: on|off` header. Cache hits consume **zero provider quota** and

--- a/skills/workflows/use-freellmapi/skill-review-report.json
+++ b/skills/workflows/use-freellmapi/skill-review-report.json
@@ -1,0 +1,155 @@
+{
+  "schema": "skill-review/1.0",
+  "mode": "deep-dive",
+  "skill": "use-freellmapi",
+  "skill_path": "skills/workflows/use-freellmapi",
+  "skill_version_reviewed": "1.3.0",
+  "review_date": "2026-08-10",
+  "focus": "staleness vs freellmapi repo changes since 2026-07-29 (v0.6.6..v0.6.9 + unreleased main, 81 commits, verified at b9b6bf7)",
+  "verdict": "NEEDS_WORK",
+  "scores": {
+    "frontmatter_compliance": 4,
+    "description_quality": 5,
+    "progressive_disclosure": 4,
+    "instruction_clarity": 5,
+    "coordination": 4,
+    "completeness": 3,
+    "anti_patterns": 4
+  },
+  "telemetry": { "status": "no-data", "note": "unobserved, not evidence of a problem" },
+  "trigger_testing": { "status": "skipped", "reason": "review focus was content staleness; description embeds explicit trigger list" },
+  "issues": [
+    {
+      "id": "H1",
+      "severity": "high",
+      "file": "references/capabilities.md",
+      "section": "Not supported yet",
+      "claim": "Per-user billing / multi-tenant auth — single-user by design",
+      "reality": "v0.6.9 added per-client API keys (sk-cp-...) with optional server-enforced system prompts (#758/#411); billing remains single-user but multi-key client auth now exists",
+      "evidence": "server/src/db/migrations/20260805_000002_client_profiles.ts, server/src/lib/system-prompt.ts",
+      "suggestion": "Narrow the bullet to per-user billing only; add client-profile keys as a supported capability"
+    },
+    {
+      "id": "H2",
+      "severity": "high",
+      "file": "SKILL.md, references/capabilities.md",
+      "section": "Step 2 / Auth paragraph",
+      "claim": "single unified key is the auth story",
+      "reality": "three credential kinds now: unified key, sk-cp-... client-profile keys, revocable URL tokens; per-client key is arguably the better recommendation for wiring one project",
+      "evidence": "client_profiles migration + keys routes",
+      "suggestion": "Update Step 2 and Auth paragraph; consider recommending one client key per wired project for analytics attribution and revocability"
+    },
+    {
+      "id": "H3",
+      "severity": "high",
+      "file": "references/capabilities.md",
+      "section": "Tool calling",
+      "claim": "no mention of argument validation",
+      "reality": "opt-in schema verdict on tool arguments with failover when invalid (#802); double-encoded argument repair below top level (#794)",
+      "evidence": "server/src/lib/tool-validate.ts, server/src/lib/fallback-loop.ts",
+      "suggestion": "Add both behaviors, noting the verdict is opt-in"
+    },
+    {
+      "id": "H4",
+      "severity": "high",
+      "file": "references/capabilities.md",
+      "section": "Routing behavior",
+      "claim": "failover described without newer behaviors",
+      "reality": "auto-cooldown of repeatedly failing models beyond 429 (#806); whole-provider skip on 5xx/timeout (#817); back-off honored from error body (#798); unified output-token cap (#783); community reliability priors + exploration toggle (#744/#731)",
+      "evidence": "commits 398ed97, e1d1c5a, 6f13332, f3613ae, 1e675cc, 96da9ec",
+      "suggestion": "Fold into Routing behavior bullets; provider-skip and cooldown are user-observable"
+    },
+    {
+      "id": "H5",
+      "severity": "high",
+      "file": "references/capabilities.md",
+      "section": "Routing behavior / headers",
+      "claim": "X-Fallback-Trail is the failover debugging surface",
+      "reality": "opt-in X-Fallback-Detail header with per-hop failover timings also exists (#792)",
+      "evidence": "server/src/lib/fallback-loop.ts, server/src/__tests__/routes/fallback-detail-header.test.ts",
+      "suggestion": "Document alongside X-Fallback-Trail"
+    },
+    {
+      "id": "H6",
+      "severity": "high",
+      "file": "SKILL.md, references/capabilities.md",
+      "section": "Step 6 dashboard tour / Keys",
+      "claim": "no mention of per-key features",
+      "reality": "per-key model scopes (#757), per-key proxy override (#819), bulk key ops in a group (#816), immediate-probe for custom endpoints (#730)",
+      "evidence": "commits 19cdc53, 647683a, 21c3258, b20986c",
+      "suggestion": "One compact bullet in the dashboard tour plus a Keys paragraph in capabilities.md"
+    },
+    {
+      "id": "H7",
+      "severity": "high",
+      "file": "references/agent-clients.md",
+      "section": "Claude Code",
+      "claim": "streaming, system prompts, tool use, and image input all translate",
+      "reality": "document content blocks also translate since #793 (previously silently dropped)",
+      "evidence": "commit 35af82c, server/src/routes/anthropic.ts",
+      "suggestion": "Add documents to the translate list"
+    },
+    {
+      "id": "M1",
+      "severity": "medium",
+      "file": "SKILL.md",
+      "section": "Step 1",
+      "claim": "install paths are Docker or source only",
+      "reality": "maintained Electron desktop builds now ship: macOS, Windows installer + zip (#766/#773), Linux AppImage/deb/tar.xz (#739)",
+      "suggestion": "One sentence offering desktop app as the no-Docker fallback"
+    },
+    {
+      "id": "M2",
+      "severity": "medium",
+      "file": "SKILL.md, references/capabilities.md",
+      "section": "keyless providers",
+      "claim": "as of v0.6.5: Kilo :free, OVH, AI Horde",
+      "reality": "roster re-verified CORRECT at head (still exactly those three plus local Ollama); only the version stamp is stale",
+      "evidence": "server/src/providers/index.ts keyless: true entries, server/src/providers/aihorde.ts",
+      "suggestion": "Refresh stamp to v0.6.9+"
+    },
+    {
+      "id": "M3",
+      "severity": "medium",
+      "file": "SKILL.md",
+      "section": "Step 2",
+      "claim": "user must eyeball provider enablement",
+      "reality": "Keys page now has a provider checklist with status icons and flags providers missing keys (#596/#777/#822) plus searchable provider picker (#728)",
+      "suggestion": "Point the hold-here gate at the checklist"
+    },
+    {
+      "id": "M4",
+      "severity": "medium",
+      "file": "SKILL.md",
+      "section": "Step 6",
+      "claim": "dashboard tour omits newer surfaces",
+      "reality": "Settings auto update-check with release-notes dialog (#635/#782); password reset via server-log code (#560)",
+      "suggestion": "Add both to the handoff bullets"
+    },
+    {
+      "id": "M5",
+      "severity": "medium",
+      "file": "SKILL.md",
+      "section": "intro numbers",
+      "claim": "~29 provider tiers",
+      "reality": "AnyAPI added (#772); registry now has 32 register() calls; skill already hedges its numbers",
+      "suggestion": "Refresh the approximate count during the edit pass"
+    },
+    {
+      "id": "L1",
+      "severity": "low",
+      "file": "references/recipes.md",
+      "claim": "n/a",
+      "reality": "generic client recipes, no proxy-behavior claims; spot-check clean, not exhaustively re-verified",
+      "suggestion": "No action needed"
+    },
+    {
+      "id": "L2",
+      "severity": "low",
+      "file": "SKILL.md",
+      "section": "frontmatter",
+      "suggestion": "Bump version 1.3.0 -> 1.4.0 when content edits land"
+    }
+  ],
+  "edit_order": ["H1+H2", "H3", "H4", "H5", "H6", "H7", "M1-M5", "L2"]
+}

--- a/skills/workflows/use-freellmapi/skill-review-report.md
+++ b/skills/workflows/use-freellmapi/skill-review-report.md
@@ -1,0 +1,118 @@
+# Skill Review — use-freellmapi (deep dive, staleness focus)
+
+- **Date:** 2026-08-10
+- **Mode:** B (single-skill deep dive)
+- **Focus (why-now):** freellmapi repo has moved since the skill's last edit — is the content stale?
+- **Skill version reviewed:** 1.3.0 (SKILL.md + references last touched 2026-07-29)
+- **Repo drift:** 81 commits since 2026-07-29, spanning releases v0.6.6 → v0.6.9 plus unreleased main
+- **Telemetry:** `skill-health.sh report --json` has no rows for this skill (unobserved — not evidence of a problem)
+- **Verdict: NEEDS WORK (content staleness).** Structurally the skill is SHIP-quality; the workflow,
+  traps, and env-toggle pattern all still hold. But two claims are now wrong, one core framing
+  (single-key auth) is outdated, and several new proxy behaviors are missing from
+  `references/capabilities.md`.
+
+Every finding below was verified against the freellmapi working tree at `b9b6bf7`, not inferred from
+commit messages.
+
+## High-priority findings (claims now wrong or misleading)
+
+### H1. "Not supported: per-user billing / multi-tenant auth" is now half-wrong
+`references/capabilities.md` (Not supported list) still says multi-tenant auth has no route.
+v0.6.9 added **per-client API keys** (#758/#411): the Keys page can mint `sk-cp-…` client-profile
+keys, each independently enable/disable-able, each with an optional **server-enforced system prompt**
+prepended to every request authenticated with that key (verified in
+`server/src/db/migrations/20260805_000002_client_profiles.ts` and `server/src/lib/system-prompt.ts`).
+Billing is still single-user, but "multi-tenant auth — single-user by design" now over-claims.
+**Fix:** reword the not-supported bullet to "per-user billing" only, and document client-profile keys
+as a supported capability.
+
+### H2. The "single unified key" auth story is outdated
+SKILL.md ("the proxy's single *unified key*") and capabilities.md ("Auth: every /v1 call needs the
+unified key") predate client-profile keys. There are now three credential kinds: the unified key,
+`sk-cp-…` client keys, and revocable URL tokens. For the skill's own core use case — wiring one
+project/agent to the proxy — a per-client key is arguably the *better* recommendation (per-client
+analytics attribution, revocable without rotating everything, optional enforced system prompt).
+**Fix:** update Step 2 and the capabilities Auth paragraph; consider recommending a per-client key
+per wired project.
+
+### H3. Tool-calling section misses the schema verdict and the double-encoding repair
+capabilities.md "Tool calling" doesn't know about: (a) **opt-in schema verdict on tool arguments**
+(#802, `server/src/lib/tool-validate.ts`) — validates returned tool arguments against the tool's JSON
+schema and **fails over to the next model when invalid**; (b) **double-encoded argument repair below
+the top level** (#794). Both change what you can promise about tool-calling reliability.
+**Fix:** add both to the Tool calling section, noting the verdict is opt-in.
+
+### H4. Routing behavior section misses five shipped changes
+capabilities.md "Routing behavior" predates: **auto-cooldown of repeatedly failing models**, penalty
+beyond 429 (#806); **whole-provider skip on 5xx/timeout/transport errors** instead of key-by-key
+(#817); **back-off honored from the error body**, not just headers (#798); **unified output-token cap**
+rescuing excessive client `max_tokens` (#783); **community reliability priors folded into the Beta
+posterior** + an **exploration toggle for unmeasured models** (#744/#731).
+**Fix:** fold into the Routing behavior bullets — especially the provider-skip and cooldown, which
+change observable failover behavior users will ask about.
+
+### H5. `X-Fallback-Detail` header missing
+capabilities.md documents `X-Routed-Via` / `X-Fallback-Attempts` / `X-Fallback-Trail` but not the
+opt-in **`X-Fallback-Detail`** header with per-hop failover timings (#792, verified in
+`server/src/lib/fallback-loop.ts` + tests). It's exactly the debugging surface the skill's Step 5
+teaches. **Fix:** add alongside the trail header.
+
+### H6. Per-key features absent from the Keys story
+Since the last edit, provider API keys gained **per-key model scopes** (#757), **per-key proxy
+override** — each key can route through its own exit (#819), **bulk enable/disable/delete within a
+group** (#816), and **immediate-probe for custom endpoints** (#730). Neither capabilities.md nor the
+Step 6 dashboard tour mentions any of them. **Fix:** one compact bullet in the dashboard tour + a
+Keys paragraph in capabilities.md.
+
+### H7. Anthropic surface: document blocks now translate
+agent-clients.md (Claude Code section) lists "streaming, system prompts, tool use, and image input"
+as translating; #793 fixed silently-dropped **document content blocks**, so PDFs/documents now pass
+through too. **Fix:** add documents to that list.
+
+## Medium-priority findings
+
+- **M1. Desktop app is now a real install path.** Step 1 offers only Docker or source; the repo now
+  ships a maintained Electron desktop build — macOS, Windows installer + zip (#766/#773), Linux
+  AppImage/deb/tar.xz (#739). Worth one sentence as a fallback when Docker isn't available.
+- **M2. Keyless roster stamp is dated.** "as of v0.6.5 … Kilo `:free`, OVH, AI Horde" — roster
+  **re-verified correct** against `server/src/providers/` at head (still exactly those three plus
+  local Ollama), but the stamp should read v0.6.9+ so readers don't assume it's four releases stale.
+- **M3. Step 2 can lean on the new provider checklist.** The Keys page now has a provider checklist
+  with status icons and flags providers that need a key but have none (#596/#777/#822), plus a
+  searchable provider picker (#728). This is exactly the "hold here until a provider is enabled" gate
+  Step 2 walks the user through — pointing at it shortens the loop.
+- **M4. Dashboard tour drift (Step 6).** Settings now includes an automatic update check with a
+  release-notes dialog (#635/#782); a forgotten dashboard password is recoverable via a code from the
+  server logs (#560). Both are handoff-worthy.
+- **M5. Provider count drift.** AnyAPI landed as a new OpenAI-compatible provider (#772); the
+  registry now has 32 `register(…)` calls. The skill's "~29 provider tiers" is hedged (and the skill
+  explicitly says not to trust its own numbers), so this is cosmetic — refresh when editing anyway.
+
+## Low-priority notes
+
+- **L1.** `references/recipes.md` (untouched since June) contains generic client-wiring recipes with
+  no proxy-behavior claims; spot-check found nothing stale. Not exhaustively re-verified.
+- **L2.** Bump frontmatter `version` to 1.4.0 when the content edits land.
+
+## Rubric scores (references/deep-review-rubric.md)
+
+| Dimension | Score | Evidence |
+| --- | --- | --- |
+| Frontmatter compliance | 4 | All required fields, valid semver, no `<`/`>` in values — but the description is 1267 chars normalized, over the spec's 1024 ceiling (pre-existing; host doesn't enforce it, skill loads fine — trim in a future pass) |
+| Description quality | 5 | Action verbs, 10+ trigger phrasings, keyword variants, covers agent + app-code paths |
+| Progressive disclosure | 4 | 287-line body, three well-partitioned refs, clear read-only-what-matches pointers |
+| Instruction clarity | 5 | Imperative, ordered workflow, explains why (env-toggle rationale, verify-before-done) |
+| Coordination | 4 | `composes_with` targets exist (project-profiler, model-adaptation, use-pxpipe); no ownership overlaps |
+| Completeness / accuracy | 3 | H1–H7 above: two wrong claims, five missing shipped behaviors |
+| Anti-patterns | 4 | Strong self-defense against staleness ("don't hardcode the roster", "confirm against /v1/docs") — which is why only 2 of 81 commits produced outright wrong claims |
+
+## Trigger testing
+
+Skipped (Phase B2): the why-now for this review was content staleness, not triggering, and the
+description already embeds an explicit trigger-phrase list. No live eval run; noted per process.
+
+## Recommendation
+
+Run `/skill-update` against the JSON sidecar. Suggested edit order (one focused change at a time):
+H1+H2 together (one auth-story edit across SKILL.md + capabilities.md), then H3–H6 (capabilities.md),
+then H7 (agent-clients.md), then M1–M5 batch (SKILL.md steps 1/2/6), then L2 version bump.


### PR DESCRIPTION
## Summary

- The `use-freellmapi` skill's content lagged the freellmapi repo by 81 commits (v0.6.6–v0.6.9 plus unreleased main); a code-verified staleness review found two now-wrong claims and seven missing shipped behaviors.
- Carries the previously unmerged 1.3.0 commit (CLI coding-agent coverage) plus the new 1.4.0 refresh on top.
- Every changed claim was verified against the freellmapi working tree at `b9b6bf7`, not inferred from commit messages.

## Changes

- **Auth story modernized (the two wrong claims):** "multi-tenant auth" removed from the not-supported list (only per-user *billing* remains out of scope); per-client `sk-cp-…` keys with server-enforced system prompts documented in the Auth section, Step 2, and the three-facts table, recommended one-per-wired-project.
- **Capabilities caught up:** tool-argument schema verdict with failover + double-encoding repair; model auto-cooldown, whole-provider skip on 5xx, error-body back-off, output-token cap; reliability priors + exploration toggle; `X-Fallback-Detail` header; per-key model scopes / proxy overrides / bulk actions / endpoint probe.
- **Workflow touch-ups:** desktop app as the no-Docker install path, provider-checklist pointer on the Step 2 gate, keyless stamp refreshed to v0.6.9 (roster re-verified unchanged), dashboard tour covers the update checker and log-code password recovery, Claude Code translate list gains document (PDF) blocks.
- **Housekeeping:** provider count ~29 → ~30 (AnyAPI), version bump to 1.4.0, skill-review report (md + json sidecar) committed alongside the skill.

## Test plan

- [x] All claims traced to freellmapi source (provider registry, `client_profiles` migration, `tool-validate.ts`, `fallback-loop.ts`, CLI `setup-*` list)
- [x] Frontmatter parses; all three reference links resolve; body 297 lines / 2,853 words (within spec)
- [x] markdownlint: only pre-existing MD028 (blank line between intro blockquotes, present at HEAD)
- Known pre-existing issue, deliberately untouched: frontmatter description is 1267 chars normalized (over the spec's 1024 ceiling; host doesn't enforce it) — noted in the review report for a future trim

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yJseb2ofEyXiZeiJzK6ft