### PR TITLE
fix: Bound playwright screenshot capture against tall-page OOM

### DIFF
--- a/skills/workflows/playwright/SKILL.md
+++ b/skills/workflows/playwright/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playwright
-version: 1.4.1
+version: 1.5.0
 description: |
   Run browser-based E2E tests, capture screenshots, and validate user flows using Playwright with visible Chrome. Use this skill when testing a web UI end-to-end, capturing screenshots for visual review, checking responsive layouts, or auditing accessibility in a real browser. Trigger on: "e2e test", "screenshot the UI", "click through the app", "responsive layout check", "accessibility audit". Also invoke when qe-agent needs browser-level integration testing.
 requires_agent_teams: false
@@ -48,6 +48,24 @@ npm install -D @playwright/test
 npx playwright install chromium
 ```
 
+## Capture Bounds
+
+Screenshot cost scales with page *height*, not viewport size, and a long page will exhaust system memory before anything warns you. **Measure before you capture:**
+
+```js
+const h = await page.evaluate(() => document.documentElement.scrollHeight)
+```
+
+Then apply these rules:
+
+- **Under ~8,000px** — `fullPage: true` is fine.
+- **Over ~8,000px** — do **not** use `fullPage`. Scroll in viewport-sized tiles and capture each one. A list page can be 30,000–50,000px tall; at 1280px wide, 31,000px decodes to ~150 MB of raw RGBA per image.
+- **Reuse one page per viewport.** Never create a browser context per screenshot — contexts are spawned faster than they are reclaimed.
+- **Never hold more than one decoded image pair.** Pixel-diffing (`pixelmatch`, `odiff`) needs uncompressed RGBA: two inputs plus an output buffer is *three* copies. On a 31,000px page that is ~460 MB for a single comparison.
+- **Capture first, diff in a second pass**, freeing each buffer as you go.
+
+Sampling beats exhaustiveness on very long pages: comparing at 25%, 50%, 75%, and bottom catches real regressions at a fraction of the cost. Bound the run before launching it — the failure mode is a stalled machine and lost user work, not a clean error.
+
 ## Workflow
 
 1. **Determine what to test.** Translate inputs (plan excerpt, acceptance criteria, user request) into a list of user flows. See `references/selectors-guide.md` for how to structure each flow as navigate → interact → assert → screenshot.
@@ -72,6 +90,7 @@ Common issues and fixes are in `references/screenshot-workflow.md`; the full tro
 - "Navigation timeout" → service isn't running; verify the URL first
 - "No usable sandbox" (Linux) → `chromiumSandbox: false` (non-production only)
 - Blank screenshots → add `waitForLoadState('networkidle')` before capture
+- Machine stalls / swaps during a run → `fullPage` on a very tall page, a context per screenshot, or a pixel-diff holding several decoded images. See "Capture Bounds" above and tile instead.
 
 ## Reference Files
 


### PR DESCRIPTION
## Summary

- `fullPage` screenshots on very tall pages exhaust system memory before anything warns you — a 31,000px list page decodes to ~150 MB per image, and pixel-diffing triples that. This documents the safe bounds and the tiling workflow.

## Changes

- Add a "Capture Bounds" section: measure `scrollHeight` before capture, tile instead of `fullPage` over ~8,000px, reuse one page per viewport, and never hold more than one decoded image pair.
- Add a troubleshooting entry mapping "machine stalls / swaps" back to the new section.
- Bump version 1.4.1 -> 1.5.0.

## Test plan

- [ ] `./scripts/lint-skills.sh skills/workflows/playwright` passes (0 errors)
- [ ] Capture guidance covers tall-page tiling and pixel-diff memory limits