### PR TITLE
chore: Ignore freebuff tool state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ __pycache__/
 
 node_modules/
 audit/
+
+# Freebuff background-agent tool state (SQLite db, worktrees, project id)
+.freebuff/


### PR DESCRIPTION
## Summary

- `.freebuff/` is the freebuff background-agent's local state — a 5.8 MB SQLite database plus git worktrees — and was showing up as untracked. It risked being swept into a commit or PR by accident.

## Changes

- Add `.freebuff/` to `.gitignore`.

## Test plan

- [ ] `git status` no longer lists `.freebuff/` as untracked
