### PR TITLE
feat: Add DeepSeek cross-vendor adaptation to model-adaptation

### DIFF
--- a/skills/meta/model-adaptation/SKILL.md
+++ b/skills/meta/model-adaptation/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: model-adaptation
-version: 1.4.1
+version: 1.5.0
 description: |
-  Adapt prompts, skills, and agent scaffolding when the underlying Claude model changes — currently the Claude 5 family (Fable 5/Mythos 5) vs Opus 4.x. Stronger models need LESS scaffolding: this skill says what to PRUNE, what backfires (narrating reasoning trips a reasoning_extraction refusal), and what to add for long autonomous runs. Canonical home of the model & effort tiering policy (Anthropic ladder; never cross-vendor; FreeLLMAPI carve-out) and the capability-handoff technique — extract an operating manual from a stronger model to run on a cheaper one. Use when migrating a skill to a new model, a skill "worked before and got worse", agents get refused or fall back to Opus, or picking model/effort per role. Trigger on "migrate to Fable", "Fable 5", "Mythos 5", "model migration", "reasoning_extraction", "tune effort", "model tiering", "long-running agent hygiene", "extract operating manual", "pxpipe", "image proxy".
+  Adapt prompts, skills, and agent scaffolding when the underlying model changes — currently the Claude 5 family (Fable 5/Mythos 5) vs Opus 4.x, plus the cross-vendor DeepSeek landscape. Stronger models need LESS scaffolding: this skill says what to PRUNE, what backfires (narrating reasoning trips a reasoning_extraction refusal), and what to add for long autonomous runs. Canonical home of the model & effort tiering policy (declared-provider ladder — Anthropic or DeepSeek; FreeLLMAPI carve-out) and the capability-handoff technique — extract an operating manual from a stronger model to run on a cheaper one. Use when migrating a skill to a new model, agents get refused, or picking model/effort per role. Trigger on "migrate to Fable", "Fable 5", "Mythos 5", "deepseek", "model migration", "reasoning_extraction", "tune effort", "model tiering", "long-running agent hygiene", "extract operating manual", "pxpipe", "image proxy".
 requires_claude_code: false
 min_plan: starter
-compatibility: "Claude Code or Claude.ai; reference/advisory skill. No special tools required — WebFetch is optional, only to re-pull the live Anthropic guide."
+compatibility: "Claude Code, Claude.ai, or DeepSeek hosts (e.g. Freebuff); reference/advisory skill. No special tools required — WebFetch is optional, only to re-pull the live Anthropic or DeepSeek guide."
 allowed-tools: ["Read", "Grep", "Glob", "Edit", "WebFetch"]
 composes_with: ["skill-writer", "skill-review", "skill-update", "loop-controller", "orchestrator", "use-freellmapi", "use-pxpipe", "claude-api"]
 spawned_by: []
@@ -14,8 +14,9 @@ spawned_by: []
 # model-adaptation
 
 > The toolkit's home for **what changes about your prompts, skills, and scaffolding
-> when the underlying Claude model changes** — currently the Claude 5 family
-> (Fable 5 + Mythos 5) succeeding Opus 4.x. It advises and audits; it does not
+> when the underlying model changes** — currently the Claude 5 family
+> (Fable 5 + Mythos 5) succeeding Opus 4.x, plus the cross-vendor DeepSeek
+> landscape (V4 flash/pro). It advises and audits; it does not
 > build. `skill-writer`/`skill-review` enforce the authoring half, `loop-controller`
 > the long-run half, and `orchestrator` the multi-agent half — this skill is where
 > the *why* and the migration checklist live so those enforcement points stay in sync.
@@ -32,7 +33,9 @@ assumptions. Everything model-specific is quarantined in the *Current landscape*
 section below; the patterns are written to outlive it.
 
 Source of record: Anthropic's [Prompting Claude Fable 5](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5)
-and [Prompting best practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices).
+and [Prompting best practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices);
+for DeepSeek runs, the [DeepSeek API docs](https://api-docs.deepseek.com/quick_start/pricing/)
+and [Thinking Mode](https://api-docs.deepseek.com/guides/thinking_mode/).
 Re-fetch these when a new model generation ships — that's the trigger to update this skill.
 
 ## The core move: a capability jump means PRUNE, not ADD
@@ -76,8 +79,29 @@ This is the *only* part meant to age. The patterns below it are durable; these f
 | **Mythos 5** | Frontier sibling (Claude 5 family) | Same family, same prompting patterns and refusal behavior as Fable 5. Everything here that says "Fable 5" applies to Mythos 5 unless a future note says otherwise. |
 | **Opus 4.8** | Prior baseline **and the fallback target** | The model a refused Claude 5 request should reroute to. Prompts/skills tuned for it are the ones this skill helps you prune. |
 
-When "the next model" (a Mythos successor, an Opus 5) arrives: re-fetch the Anthropic
-prompting guide, update this table, and run the *migration audit* at the bottom.
+### DeepSeek landscape (cross-vendor entry)
+
+The toolkit also runs under DeepSeek models — the 2026-08-03 deep-dive vendor review
+(DV-1–DV-5) was a Freebuff/DeepSeek session, and this is the first vendor this skill
+covers besides Anthropic. The aging facts (pricing, model versions, effort mapping)
+live in `references/deepseek-adaptation.md`; the durable shape is here:
+
+| Model | Role today | What to know for adaptation |
+|---|---|---|
+| **deepseek-v4-flash** | Cheap tier | Non-thinking + thinking modes; tool calls, JSON output, Anthropic-format endpoint (`api.deepseek.com/anthropic`). Cache-hit input is ~30× cheaper than cache-miss — prompt-cache hits are the dominant cost lever. |
+| **deepseek-v4-pro** | Top tier | Same feature set, stronger reasoning; the reasoning-gate tier. 1M context / 384K max output across the family. |
+
+On DeepSeek the capability dial is **thinking mode + effort** (`none/low/high/max`;
+`xhigh` and `medium` both map to `high`), not a model switch — and the chain of
+thought arrives in `reasoning_content`, a separate channel from the answer. There is
+**no `reasoning_extraction` refusal classifier** and **no Opus fallback**: refusals
+retry inside the DeepSeek ladder (toggle thinking, switch flash↔pro). Body triggers
+that route here but stay out of the description (lint band): **"deepseek-reasoner"**,
+**"R1"**, **"V4"**, **"thinking mode"**, **"cross-vendor run"**.
+
+When "the next model" (a Mythos successor, an Opus 5, a DeepSeek V5) arrives:
+re-fetch the vendor's current docs, update this table **and**
+`references/deepseek-adaptation.md`, and run the *migration audit* at the bottom.
 
 ## The pattern catalog
 
@@ -141,12 +165,16 @@ routine passes, raise it only for the hardest reasoning). Output tokens cost
 ~5× input across the Anthropic family, so moving bulk work down a tier and
 trimming output dominate every other cost lever.
 
-**The provider-relativity rule (load-bearing).** Stay within one provider —
-never reach cross-vendor to save tokens:
+**The provider-relativity rule (load-bearing).** One project, one provider
+ladder — never mix vendors to save tokens. A project *declares* its provider
+and runs the whole toolkit on that one vendor's ladder:
 
 - **Default = Anthropic-native.** The ladder is Haiku → Sonnet → Opus → Fable,
   plus the effort dial. Read a project's declared provider from
   `.claude/profile.yaml`; absent that, assume Anthropic.
+- **DeepSeek-native.** The ladder is `deepseek-v4-flash` → `deepseek-v4-pro`,
+  with thinking mode + effort (`none/low/high/max`) as the dial within each.
+  Full facts in `references/deepseek-adaptation.md`.
 - **The doctrine is a shape** — cheapest-that-clears-the-bar for grunt work, top
   tier for the reasoning gate — instantiated with whatever single provider the
   project actually runs on, staying inside that provider's own ladder.
@@ -162,6 +190,11 @@ never reach cross-vendor to save tokens:
 | **Standard implementation** | feature code, test authoring, straightforward role-agent build work | Sonnet | medium/high |
 | **Load-bearing reasoning** | architecture & contract design, adversarial verification / fresh-context evaluator, final synthesis, hard debugging, ambiguity resolution | Opus or Fable | high/xhigh (max only when correctness ≫ cost) |
 
+On a DeepSeek project the same map instantiates as: `deepseek-v4-flash` with
+thinking off for mechanical work, flash/pro with thinking on for standard
+implementation, `deepseek-v4-pro` with thinking high/max for load-bearing
+reasoning — the two-model family *is* the ladder.
+
 **The optimizer/target split.** When one model *authors or optimizes* an
 artifact (a skill, a prompt, a config) that another model then *executes
 under*, tier by **role**, not just task difficulty: author/optimize/review on
@@ -175,6 +208,10 @@ everywhere." Detail in `references/model-effort-tiering.md`.
 
 - **No `effort` param on Haiku 4.5** — the API returns a 400. Tier down to
   Haiku *or* dial effort down, not both.
+- **DeepSeek effort semantics differ.** The API maps `xhigh`→`high` and
+  `medium`→`high`; emit `none/low/high/max` (`none` = thinking off), and don't
+  bother with `xhigh`. Thinking mode ignores `temperature`/`top_p`/penalties
+  (accepted, no effect).
 - **Don't reflexively `max`.** On the Claude 5 family `high`/`xhigh` is the
   sweet spot, and `low` effort often matches or beats prior-generation
   `xhigh`/`max` — so `low`/`medium` is the correct setting for routine work,
@@ -256,12 +293,22 @@ the full mechanics, the other classifier domains (offensive cyber, bio/life-scie
 frontier-LLM development), and the fallback configuration are in
 **`references/refusal-and-fallback.md`**.
 
+**On DeepSeek the classifier doesn't exist, but the instruction is still wrong.**
+Thinking mode already emits the chain of thought in `reasoning_content` (a separate
+channel), so asking the model to also narrate its reasoning into the response doubles
+output tokens and buries the answer — a cost/quality failure instead of a refusal.
+Read `reasoning_content` (or the harness's structured thinking) when you need the
+reasoning; and since there is no Opus fallback on DeepSeek, reroute refusals inside
+the DeepSeek ladder (toggle thinking, switch flash↔pro). See
+`references/deepseek-adaptation.md`.
+
 ## When a new model lands: the migration audit
 
 Run this checklist against an existing skill/harness (or the whole toolkit) on a model change:
 
-1. **Re-fetch the guide.** Pull Anthropic's current prompting guide for the new model and
-   update the *Current landscape* table above **and the priced ladder in
+1. **Re-fetch the guide.** Pull the vendor's current docs — Anthropic's prompting
+   guide, or the DeepSeek API docs for a DeepSeek project — and update the *Current
+   landscape* table above **and the priced ladder in
    `references/model-effort-tiering.md`** (models, pricing, effort support all age).
    New behaviors = new audit items.
 2. **Subtract first.** For each skill, ask per instruction: *does the new model already do
@@ -283,6 +330,12 @@ Run this checklist against an existing skill/harness (or the whole toolkit) on a
 
 ## Reference files
 
+- `references/deepseek-adaptation.md` — the cross-vendor DeepSeek landscape: the
+  V4 flash/pro family, thinking-mode mechanics (`reasoning_content`, the
+  Anthropic-format endpoint, tool-call pass-back), the effort mapping, the
+  provider-relative tiering instantiation, the image-proxy status, and the audit
+  additions for DeepSeek runs. Read when a project declares DeepSeek, or when
+  adapting any skill for DeepSeek execution.
 - `references/refusal-and-fallback.md` — the four Claude 5 classifier domains, the
   `reasoning_extraction` landmine in depth (what trips it, the symptom, the fix, how to
   audit for it), the `stop_reason: "refusal"` contract, and server-side vs client-side

--- a/skills/meta/model-adaptation/references/deepseek-adaptation.md
+++ b/skills/meta/model-adaptation/references/deepseek-adaptation.md
@@ -1,0 +1,143 @@
+# DeepSeek adaptation — the cross-vendor landscape
+
+Depth for the model-adaptation SKILL.md's DeepSeek coverage. Everything here is
+model- and pricing-specific and therefore **ages** — re-verify against the
+[DeepSeek API docs](https://api-docs.deepseek.com/) on every model release, the
+same cadence as the *Current landscape* table and the priced Anthropic ladder.
+
+Facts below verified **2026-08-16** against
+[Models & Pricing](https://api-docs.deepseek.com/quick_start/pricing/) and
+[Thinking Mode](https://api-docs.deepseek.com/guides/thinking_mode/).
+
+## Why DeepSeek is in scope
+
+The toolkit runs cross-vendor in practice: the 2026-08-03 deep-dive vendor
+review (DV-1–DV-5) was a **Freebuff/DeepSeek session** — the repo's own skills
+(plan-intake, living-plan, qa-gate, …) executed under a DeepSeek model. The
+tiering doctrine's "never cross-vendor" always meant *don't mix vendors to save
+tokens*, but it read as "don't run on DeepSeek at all." This file makes the
+declared-provider shape explicit for DeepSeek and records what actually differs
+from the Anthropic baseline.
+
+## Current DeepSeek landscape (2026-08)
+
+| Model | Model version | Role today | Off-peak $/1M (in miss / out) |
+|---|---|---|---|
+| `deepseek-v4-flash` | DeepSeek-V4-Flash-0731 | Cheap tier | $0.22 / $0.66 |
+| `deepseek-v4-pro` | DeepSeek-V4-Pro-0813 | Top tier | $0.66 / $1.98 |
+
+Shared facts:
+
+- **Context 1M, max output 384K** across the family — long-horizon runs have
+  more headroom than Claude 5, so long-run-hygiene's context-budget reassurance
+  is even less pressing here.
+- **Cache-hit input is ~30× cheaper than cache-miss** (flash: $0.007 vs $0.22
+  off-peak). The dominant cost lever on DeepSeek is **prompt-cache hits**, not
+  output trimming — keep the shared prefix (system prompt, skill bodies, tool
+  definitions) byte-stable across turns.
+- **Peak pricing**: 01:00–04:00 and 06:00–10:00 UTC are peak (2× off-peak);
+  all other hours are off-peak.
+- Both models support **JSON output, tool calls, the Responses API, and an
+  Anthropic-format endpoint** (`https://api.deepseek.com/anthropic`) — Claude-
+  shaped tool calls and effort params work directly, which is the mechanism that
+  lets Claude-shaped scaffolding run on DeepSeek with least friction.
+- Legacy aliases `deepseek-chat` / `deepseek-reasoner` (V3.1-era names) map to
+  non-thinking / thinking modes; the current family is exposed as
+  `deepseek-v4-flash` / `deepseek-v4-pro`.
+
+## Thinking mode — the capability dial
+
+On Anthropic, model + effort are two dials. On DeepSeek the primary capability
+dial is **thinking mode + effort**:
+
+- Thinking is **on by default**, default effort `high`.
+- Toggle/effort controls:
+  - OpenAI format: `extra_body={"thinking": {"type": "enabled|disabled"}}` +
+    `reasoning_effort: low|high|max`.
+  - Anthropic format: `{"reasoning": {"effort": "none|low|high|max"}}` —
+    **`none` disables thinking**.
+- **Effort mapping**: requested `low`→`low`, `medium`→`high`, `high`→`high`,
+  `xhigh`→`high`, `max`→`max`. There is no `medium` effort on the wire, and
+  `xhigh` is silently mapped to `high`.
+- The chain of thought arrives in **`reasoning_content`**, a sibling of
+  `content` at the same level — never in the answer text.
+- In thinking mode, `temperature`, `top_p`, `presence_penalty`, and
+  `frequency_penalty` are **accepted but ignored** (no error).
+- **Tool calls work in thinking mode** (multiple reasoning+tool turns per
+  request). When a turn includes tool calls, the assistant's `reasoning_content`
+  **must** be passed back on all subsequent requests in that turn chain — the
+  API returns a 400 if you drop it. Between user turns *without* tool calls,
+  prior `reasoning_content` is ignored and does not need to be persisted.
+  → Any harness (loop-controller Step 6, use-freellmapi, custom relay code)
+  that relays DeepSeek turns must carry the reasoning channel, not just
+  `content` + `tool_calls`.
+
+## How the tiering doctrine instantiates on DeepSeek
+
+The shape — cheapest-that-clears-the-bar for grunt, top tier for the reasoning
+gate — maps onto the two-model family + thinking toggle:
+
+| Task class | DeepSeek instantiation |
+|---|---|
+| Mechanical / high-volume | `deepseek-v4-flash`, thinking off (or low) |
+| Standard implementation | `deepseek-v4-flash` thinking on (high), or `deepseek-v4-pro` thinking low/high |
+| Load-bearing reasoning | `deepseek-v4-pro`, thinking high/max |
+
+Provider-relative: a project that declares `provider: deepseek` (`.claude/
+profile.yaml`) runs the **whole** toolkit on the DeepSeek ladder and never mixes
+in Anthropic models to save tokens — same rule as the Anthropic-native default,
+now explicit per vendor. FreeLLMAPI remains the only *aggregating* carve-out.
+
+## What's different vs Anthropic (the adaptation map)
+
+| Anthropic fact | DeepSeek fact | Toolkit move |
+|---|---|---|
+| `reasoning_extraction` refusal classifier | No such classifier; CoT is a separate `reasoning_content` channel | Keep the "never narrate reasoning into the response" rule for **cost + answer quality** (thinking mode already emits CoT; echoing doubles output and buries the answer), not for refusal avoidance. Read `reasoning_content` / structured thinking instead. |
+| Refused request reroutes to Opus 4.8 | No Opus fallback; DeepSeek has its own alignment filters | The orchestrator/loop "refusal reroute contract" is Claude-specific. On DeepSeek, retry **within the ladder**: toggle thinking, switch flash↔pro. Never cross vendors as a fallback. |
+| Effort dial `low–max` (+`xhigh`) | `low/high/max` (+`none` = thinking off); `medium`→`high`, `xhigh`→`high` | Don't emit `xhigh`/`medium` on DeepSeek (both map to `high`). The practical dial is `none/low/high/max`. |
+| Output tokens cost 5× input → trim output | Output ≈ 3× input (cache miss); cache-hit input ~30× cheaper | For DeepSeek projects the dominant lever is **prompt-cache hits**: keep the shared prefix byte-stable. Stable scaffolding beats output-trimming here. |
+| No thinking toggle in the API | Thinking toggle + effort **is** the capability dial | Use "thinking off" for cheap grunt instead of switching to a separate cheap model — the same model, cheaper. |
+| Extended-thinking budgets / summarized thinking | 1M context / 384K output, CoT fully returned via `reasoning_content` | Even more long-run headroom; harness must handle the reasoning channel on tool-call turns (400 otherwise). |
+| Image-proxy allowlist: Fable/Mythos pass the glyph sweep | DeepSeek V4 models **unlisted → not allowed** (fail-closed default) | Run the pxpipe ~20-call glyph sweep on V4 flash/pro before enabling the image proxy in a DeepSeek session. |
+
+## Image-proxy status
+
+`use-pxpipe` treats the allowlist in `model-effort-tiering.md` as its safety
+gate. DeepSeek V4 (flash and pro) are currently **not allowlisted** — they
+default to *not allowed* behind the image proxy until they pass the dense-glyph
+sweep. This matters because a DeepSeek session is a plausible proxy candidate:
+the model is cheap, so the pxpipe token-saver proxy's *session* economics look
+different — the proxy trades image tokens for input tokens, and DeepSeek's
+cache-hit input is already ~30× cheaper. Run the sweep and measure read
+fidelity before enabling; a model that misreads dense glyphs produces confident
+wrong answers from garbled input.
+
+## Audit additions for DeepSeek runs
+
+When reviewing a skill for DeepSeek execution (or a DeepSeek session is the
+consumer), check:
+
+1. **Model IDs.** No `claude-*` model IDs as required tiers; tier by role with
+   the DeepSeek ladder (flash/pro × thinking mode).
+2. **Narrated reasoning.** Same grep as the Anthropic landmine — hits that
+   route reasoning into the response are wrong on DeepSeek too (cost + answer
+   quality), they just won't trip a refusal. The canonical sweep lives in
+   `refusal-and-fallback.md`; the *why* differs by vendor but the instruction
+   is identical.
+3. **Effort.** Don't emit `xhigh`/`medium`; emit `none/low/high/max`.
+4. **Refusal fallback.** Any "reroute to Opus" language is Claude-specific; on
+   DeepSeek the retry is within-ladder.
+5. **Portable surface.** `requires_claude_code: false` skills are the DeepSeek
+   surface (the 2026-07-03 full-library review, SR1, counted ~14 portable vs
+   57 Claude-Code-only) — they must not *require* Claude-only tools (Task,
+   Artifact). Advisory mentions of Claude Code are fine.
+
+## Wiring into consumers
+
+- **loop-controller (Step 6) / orchestrator role dispatch** — already point at
+  the tiering doctrine; on a DeepSeek project they resolve models + effort via
+  this file's ladder instead of the Anthropic one.
+- **use-freellmapi** — unchanged (the only aggregating carve-out); a DeepSeek
+  *project* is not a FreeLLMAPI project and stays on the DeepSeek ladder.
+- **use-pxpipe** — checks the image-proxy allowlist in `model-effort-tiering.md`;
+  DeepSeek models are not allowed until they pass the glyph sweep.

--- a/skills/meta/model-adaptation/references/model-effort-tiering.md
+++ b/skills/meta/model-adaptation/references/model-effort-tiering.md
@@ -74,6 +74,11 @@ A project's provider should be discoverable, not guessed:
   `project-profiler` / `setup-project-skills` convention). Absent that,
   **default to Anthropic**.
 - **Anthropic** → the ladder above.
+- **DeepSeek** (a project that declares it — e.g. a Freebuff session) → the
+  two-model family *is* the ladder: `deepseek-v4-flash` (thinking off = grunt,
+  on = mid) → `deepseek-v4-pro` (thinking high/max = the reasoning gate). The
+  capability dial is thinking mode + effort (`none/low/high/max`; `xhigh` and
+  `medium` both map to `high`). Full facts: `deepseek-adaptation.md`.
 - **FreeLLMAPI** (the project uses `use-freellmapi`) → the aggregated free
   tiers are the ladder; optimize for rate/quota and capability, not dollars;
   multi-provider spanning is expected — and this is the *only* setup where it
@@ -117,6 +122,7 @@ table on every model release, the same cadence as the ladder above.
 
 | Model | Behind the image proxy? | Measured (pxpipe dive, 2026-07-21) |
 |---|---|---|
+| **DeepSeek V4 (flash/pro)** | **Not allowed** (unlisted default) | Not yet glyph-swept — earns a slot only by passing the sweep (see `deepseek-adaptation.md`) |
 | **Fable 5** | Allowed | 13–15/15 on the dense-hex glyph sweep |
 | **Mythos 5** | Allowed | Same family and read behavior as Fable 5 (dive groups them in the 13–15/15 band) |
 | **Opus 4.8** | **Not allowed** | 6/15 on dense hex — misreads surface as confident wrong answers, not errors |

--- a/skills/meta/skill-review/references/audit-checklist.md
+++ b/skills/meta/skill-review/references/audit-checklist.md
@@ -115,6 +115,12 @@ These check whether a skill is written for the model actually running it. See th
   / "do not truncate, produce it in full" block is a prior-model tactic; on the Claude 5
   family output laziness is far less common, so keep the block only where a *measured*
   truncation failure exists for this skill, not by default.
+- [ ] **Cross-vendor (DeepSeek) hygiene.** The skill targets a declared DeepSeek run but
+  emits Anthropic-only mechanics: `claude-*` model IDs as required tiers, `xhigh`/`medium`
+  effort (DeepSeek maps both to `high`), a "reroute to Opus" fallback, or an instruction
+  to narrate reasoning into the response (wrong on DeepSeek for cost/answer quality, not
+  refusal). See `model-adaptation/references/deepseek-adaptation.md` — its audit section
+  owns the sweep.
 
 ### Writing-craft checks (CB-2 — mattpocock `writing-great-skills` doctrine)
 


### PR DESCRIPTION
## Summary

- `model-adaptation` now covers the DeepSeek landscape alongside Anthropic, so skills can be adapted for cross-vendor runs instead of being assumed Claude-only. Reframes the provider rule from "never cross-vendor" (which read as "don't run on DeepSeek") to "one project, one declared provider ladder."

## Changes

- Add `references/deepseek-adaptation.md` — the V4 flash/pro family, thinking-mode mechanics (`reasoning_content`, the Anthropic-format endpoint, tool-call pass-back), the effort mapping (`none/low/high/max`; `xhigh`/`medium` both map to `high`), the provider-relative tiering instantiation, image-proxy status, and the audit additions for DeepSeek runs.
- Add a DeepSeek entry to the Current landscape table and to the provider-relativity rule in the SKILL.md body.
- Update `model-effort-tiering.md` with the DeepSeek ladder and image-proxy allowlist status.
- Add a cross-vendor (DeepSeek) hygiene check to `skill-review`'s audit checklist.
- Bump version 1.4.1 -> 1.5.0.

## Test plan

- [ ] `./scripts/lint-skills.sh skills/meta/model-adaptation` passes (0 errors)
- [ ] DeepSeek facts verified against api-docs.deepseek.com (dated 2026-08-16 in the reference)
