### PR TITLE
feat: Make front doors and skill-writer host-agnostic

### DIFF
--- a/skills/meta/madness/SKILL.md
+++ b/skills/meta/madness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: madness
-version: 1.3.1
+version: 1.4.0
 description: >-
   The front door to the whole toolkit — one reliable entry point that reads what
   you want, picks the RIGHT starting skill (orchestrator, plan-builder, a loop, a
@@ -89,17 +89,21 @@ See "madness vs skill-explorer" below for when to use which.
 ## The entry-point map
 
 Route intent -> front door. Each front door owns the deeper routing from there.
+Targets marked *Claude-Code-native* (`feature-dev:feature-dev`,
+`frontend-design:frontend-design`, `orchestrator`, the loops, the role agents)
+exist only on Claude Code; on any other host, route to the nearest portable
+skill in the same row instead.
 
 | When the intent is... | Front door | Cost |
 |---|---|---|
 | Multi-agent / parallel / "swarm" / "team" build, a `MISSION.md`, coordinate a build across components | `orchestrator` | expensive |
 | Turn research / a PRD / a goal into a build plan first | `plan-builder` (then `orchestrator`) | cheap |
 | Keep working until something is provably true — tests green, coverage target, contract met, queue drained, overnight/autonomous, "loop until" | `loop-controller` (it picks the specific loop + primitive) | expensive |
-| One concrete feature in an existing codebase (single-developer flow) | `feature-dev:feature-dev` | cheap->medium |
+| One concrete feature in an existing codebase (single-developer flow) | `feature-dev:feature-dev` (Claude-Code-native; else the matching role skill) | cheap->medium |
 | Build one component when you already know the role | the role skill (`backend-agent`, `frontend-agent`, `infrastructure-agent`, `db-migration-agent`, ...) | cheap->medium |
-| Design / rebuild / redesign a UI | `ui-brief` (then `frontend-design:frontend-design` or `frontend-agent`) | cheap |
+| Design / rebuild / redesign a UI | `ui-brief` (then `frontend-design:frontend-design` on Claude Code, else `frontend-agent`) | cheap |
 | Author or audit an integration contract | `contract-author` / `contract-auditor` | cheap |
-| Review code, security, or deploy-readiness | `code-review` / `security-review` / `deployment-checklist` | cheap |
+| Review code, security, or deploy-readiness | `code-review-agent` / `security-agent` / `deployment-checklist` | cheap |
 | Anything about the skills themselves — create, audit, update, sync | `skill-writer` / `skill-review` / `skill-update` / `sync-skills` | cheap |
 | Just browsing — "what do I have", "I forgot the name", "which skill for X" (no intent to launch yet) | `skill-explorer` | cheap |
 | Git: commit, PR, address feedback, cleanup | `git-commit` / `git-pr` / `git-pr-feedback` / `git-post-merge-cleanup` | cheap |
@@ -145,6 +149,10 @@ When unsure which side a route falls on, treat it as expensive and ask. The cost
 of one needless confirm is a sentence; the cost of an unwanted swarm is real.
 
 ### The token-saver question (rides the expensive confirm)
+
+This question only applies on Anthropic hosts (Claude Code / Claude API), where
+`use-pxpipe` can sit in front of the model. On any other host — DeepSeek,
+Hermes, any non-Anthropic model — skip it entirely and go straight to the route.
 
 The runs `madness` gates as expensive — swarms, autonomous loops, full builds —
 are exactly the long, token-heavy sessions where the pxpipe proxy pays (it cuts
@@ -212,16 +220,21 @@ If the user wants to *do* the thing ("set up the tests and run them till green")
   directly. `madness` is for *routing confusion and cold starts*, not for adding a
   hop in front of triggers that already work.
 
-## On non-Claude-Code hosts
+## Host awareness — this skill works on every host
 
-Converted copies of this skill ship to other AI coding tools, but only the
-*portable subset* of the library ships with them — the Claude-Code-bound skills
-(`orchestrator`, every `loops/*` skill, the role agents, and the workflows bound
-to the Artifact tool or `~/.claude` config) don't exist there. On those hosts,
-route only to skills actually present (the git conventions and the planning /
-docs / review / debugging / contract workflows); when the right front door would
-be a missing Claude-Code-only skill, say so and name it rather than routing into
-a dead end.
+madness runs on Claude Code, Hermes, DeepSeek, and any other harness that loads
+skills. The routing logic is host-agnostic; only the set of available target
+skills changes. **"Not Claude Code" is never a reason to skip routing.**
+
+The one host-specific step: **route to skills that actually exist here.** The
+skills available in this session are listed in your context — check that list
+before you name a target. Some front doors in the map below are
+Claude-Code-native (`orchestrator`'s Agent Teams, every `loops/*` skill, the
+role agents, and the workflows bound to the Artifact tool or `~/.claude`
+config). On a host where those aren't present or don't run, route to the closest
+portable skill — the git, planning, docs, review, debugging, and contract
+workflows work everywhere — and name the gap in one line. Never answer "this is
+Claude Code only"; pick the nearest live route.
 
 ## Anti-patterns
 

--- a/skills/meta/skill-explorer/SKILL.md
+++ b/skills/meta/skill-explorer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-explorer
-version: 1.3.1
+version: 1.4.0
 description: |
   Help the user discover, recall, understand, and pick the right skill from the available toolkit. Names the skill; does NOT invoke it. Use when the user is trying to find a skill ("I forgot the name of the one that does X", "what was that skill called"), asking what skills exist ("what skills do I have", "list all my skills", "show me the catalog"), asking what a specific skill does ("what does X do", "explain the X skill"), asking how skills relate ("how do these connect", "what does orchestrator spawn"), or asking for routing help ("which skill for this task", "what should I use to Y"). Also trigger when the user reaches for orchestrator on something that isn't a multi-agent build, or asks any meta-question about the skill ecosystem itself.
 requires_agent_teams: false
@@ -20,6 +20,8 @@ spawned_by: []
 The user has accumulated a large toolkit (40+ repo skills plus plugin skills loaded into every session). Names blur together, descriptions overlap, and reaching for the wrong entry point (typically `orchestrator`) wastes a turn before getting redirected. This skill is the deliberate entry point for "what do I have / which one is right for this".
 
 **skill-explorer vs its siblings.** Use `skill-explorer` (this skill) to *discover, recall, explain, and route* — it names the right skill and stops, leaving you to fire it. Use `madness` when you want that routing decision *acted on* — it picks the entry point and launches it (confirming first on anything expensive). Use `skill-catalog` when you want the authoritative generated inventory/counts of what is installed, not a recall or routing answer. (There is no `find-skills` skill in this repo; that name belongs to a separately-installed plugin.)
+
+**Host awareness.** This skill runs on any host that loads skills — Claude Code, Hermes, DeepSeek, and others. The routing table and rules below contain plugin-namespaced refs (`superpowers:*`, `claude-mem:*`, `claude-obsidian:*`, `feature-dev:*`, `frontend-design:*`) and Claude Code slash commands that exist only in a Claude Code setup. On any other host, treat those as placeholders: name the closest repo skill that is actually loaded in this session, and say so plainly if none covers it. Never report a plugin skill as available when it isn't.
 
 It answers four kinds of question:
 
@@ -51,7 +53,7 @@ skills/orchestrator/SKILL.md
 skills/{contracts,git,loops,meta,roles,workflows}/<skill-name>/SKILL.md
 ```
 
-Plugin skills come from `~/.claude/plugins/` and are visible in your session context but not in the repo tree.
+Plugin skills are host-specific and may be visible in your session context but not in this repo tree — on Claude Code they come from `~/.claude/plugins/`; other hosts have their own equivalents.
 
 ## Output format
 
@@ -118,13 +120,13 @@ These are common confusions. Lean toward the right answer rather than reflecting
 
 - **"I want to build X with multiple agents" / "swarm build" / "team build"** → `orchestrator`. This is its actual job.
 - **"I just want to write/fix one thing"** → name the role skill directly (`backend-agent`, `frontend-agent`, etc.), not orchestrator. Orchestrator is for *coordinating* a team, not for any task that touches code.
-- **"Design / rebuild / redesign a UI"** → `ui-brief` first to produce the brief, then `frontend-design` or `frontend-agent` to build from it.
+- **"Design / rebuild / redesign a UI"** → `ui-brief` first to produce the brief, then `frontend-agent` to build from it (or `frontend-design` if that Claude-Code plugin is present).
 - **"Make a plan from this research/PRD"** → `plan-builder`, then optionally `orchestrator` to execute the plan.
 - **"Audit / review my skills"** → `skill-review` (`--scope=all` for bulk, `--scope=<name>` for deep dive).
 - **"Create a new skill"** → `skill-writer`.
 - **"Sync skills globally" / "link them"** → `sync-skills`.
 - **"Commit / branch / PR"** → `git-commit`, `git-pr`, etc.
-- **Plugin skills** (`superpowers:*`, `claude-mem:*`, `claude-obsidian:*`, `feature-dev:*`, etc.) — name them with their full namespace so the user can invoke them.
+- **Plugin skills** (`superpowers:*`, `claude-mem:*`, `claude-obsidian:*`, `feature-dev:*`, etc.) — Claude-Code plugin namespaces; name them with their full namespace only if they're actually loaded in this session.
 
 When orchestrator would be wrong, **say so explicitly**: "This isn't a multi-agent build, so `orchestrator` would bounce you. Use `<actual-skill>` instead."
 

--- a/skills/meta/skill-writer/SKILL.md
+++ b/skills/meta/skill-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-writer
-version: 1.5.0
+version: 1.6.0
 description: |
   Generate new SKILL.md files conforming to the ecosystem's frontmatter spec and structure conventions. Use when creating a new agent role, meta skill, workflow skill, or contract skill — anything that needs a SKILL.md scaffold. Trigger on "create a skill", "new agent", "write a SKILL.md", "scaffold a skill", "add a role to the skill ecosystem".
 requires_agent_teams: false
@@ -69,6 +69,8 @@ Required fields:
 
 The description is the primary trigger mechanism. Write it "pushy" — enumerate contexts where the skill should activate. See `references/description-patterns.md` for templates and the 3-slot anatomy.
 
+**Declare portability explicitly.** Set `requires_claude_code: false` unless the skill genuinely needs Claude-Code machinery (Agent-Teams subagents, the Artifact tool, `~/.claude` config). Default to portable — a host-agnostic skill costs nothing extra, while one marked `true` is skipped entirely when converting for other tools. If the skill is host-specific, say which host in `compatibility` (e.g. `"Claude Code or any host with Bash"`).
+
 ### Step 3: Write the Body
 
 Structure the body around:
@@ -97,6 +99,12 @@ Structure the body around:
   ("burns the agent's entire context", "rework surfaces a wave later") gets
   weighed; an unpriced one reads as style advice and gets skipped under
   pressure. See *Cost-Tagged Anti-Patterns* in `references/patterns.md`.
+- **Describe capabilities, not tool names.** Write "read the file", "run the
+  command", "list the directory" — not "use the Read tool" or "use the Bash
+  tool". Capability language keeps the same body working on every host (Claude
+  Code, Hermes, DeepSeek, Copilot, Gemini CLI). Reserve tool names for genuinely
+  host-specific instructions, and scope them ("on Claude Code, use the Task
+  tool").
 
 For agent role skills, also include:
 
@@ -140,6 +148,9 @@ Work one focused change at a time — make a single edit, re-validate (lint + th
 - [ ] Reference files are linked from the body
 - [ ] No duplicate content between body and references
 - [ ] A triggering test is recorded (≥1 phrasing that must trigger; ideally one near-miss that must not)
+- [ ] `requires_claude_code` is `false` unless the skill genuinely needs Claude-Code machinery (subagents, Artifact, `~/.claude`)
+- [ ] Body uses capability language ("read the file"), not tool names ("use the Read tool")
+- [ ] No Claude-Code-only references (plugin namespaces, `~/.claude` paths, `ANTHROPIC_BASE_URL`) unless scoped as host-specific
 
 ### Step 7: Earn the Context Cost (optional, recommended for non-trivial skills)
 
@@ -153,6 +164,7 @@ Optionally compare behavior with vs without the skill — a quick baseline eval 
 - **Overlapping ownership** — Two agents can't own the same directory. Directory ownership takes precedence over pattern ownership (see `references/frontmatter-spec.md` §Ownership Resolution Rules).
 - **Ignoring resolved conflicts** — Check `references/frontmatter-spec.md` §Resolved Conflicts (v1.0 → v1.1) before declaring ownership of `contracts/`, `.claude/handoffs/`, `CLAUDE.md`, `README.md`, or `tests/performance/`.
 - **Hardcoded project details** — Global skills never change per project. Use profile.yaml.
+- **Claude-Code-only assumptions** — Writing "use the Bash tool", hardcoding `~/.claude` paths, or assuming Agent Teams / the Artifact tool exist makes the skill bail on non-Claude hosts. Write capability language, default `requires_claude_code` to `false`, and scope any genuinely host-specific step.
 
 ## Reference Files
 


### PR DESCRIPTION
## Summary

- Front-door skills (`madness`, `skill-explorer`) read as Claude-Code-only, so a non-Claude model (a DeepSeek session, Hermes) could conclude they don't apply and skip routing. This makes them host-aware and encodes portability rules in the skill-builder (`skill-writer`) so future skills are host-agnostic by default.

## Changes

- `madness` 1.3.1 -> 1.4.0: "On non-Claude-Code hosts" becomes "Host awareness" — leads with "works on every host", routes to skills that actually exist in session, and never bails with "Claude Code only". Scopes the pxpipe token-saver question to Anthropic hosts. Fixes dangling Claude-Code-native targets in the entry-point map (`feature-dev:feature-dev`, `frontend-design:frontend-design`, `code-review`/`security-review`).
- `skill-explorer` 1.3.1 -> 1.4.0: adds a host-awareness note (plugin-namespaced refs are Claude-Code placeholders on other hosts), and generalizes the `~/.claude/plugins/` wording.
- `skill-writer` 1.5.0 -> 1.6.0: adds portability rules — default `requires_claude_code: false`, write capability language ("read the file") instead of tool names ("use the Read tool"), keep bodies free of Claude-Code-only references. Wired into the validation checklist and Common Mistakes.

## Test plan

- [ ] `./scripts/lint-skills.sh skills/meta/madness skills/meta/skill-explorer skills/meta/skill-writer` passes (0 errors)
- [ ] A non-Claude model reading madness still routes (host-awareness section says so explicitly)
- [ ] Version bumps satisfy the `--changed` version-drift gate
